### PR TITLE
Allow HTTP01 challenge for ingresses

### DIFF
--- a/manifests/policies/allow-acme.yaml
+++ b/manifests/policies/allow-acme.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-acme
+spec:
+  ingress:
+  - from:
+    - namespaceSelector: {}
+    ports:
+      - protocol: TCP
+        port: 8089
+  podSelector:
+    matchLabels:
+      acme.cert-manager.io/http01-solver: 'true'
+  policyTypes:
+  - Ingress


### PR DESCRIPTION
I propose this NetworkPolicy to allow Acme HTTP01 challenge for those who wants to add an ingress in gotk namespace.