### PR TITLE
Delete generated docs before regenerating them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ install:
 
 .PHONY: docs
 docs:
+	rm docs/cmd/*
 	mkdir -p ./docs/cmd && go run ./cmd/flux/ docgen
 
 install-dev:


### PR DESCRIPTION
This ensures no stray files are kept when for example a command name
changes.
