### PR TITLE
docs: fixing command for expected output

### DIFF
--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -211,8 +211,9 @@ mkdir -p ./my-cluster/flux-system
 Generate the Flux manifests with:
 
 ```sh
+# on ARM64/AARCH64 clusters use --arch=arm64
 flux install --version=latest \
-  --arch=amd64 \ # on ARM64/AARCH64 clusters use --arch=arm64
+  --arch=amd64 \
   --export > ./my-cluster/flux-system/gotk-components.yaml
 ```
 


### PR DESCRIPTION
When following the guide for generic git server, I came across this problem which I solved, thought I'd do a PR to update the docs. 

The \ before the comment here means the subsequent lines end up getting commented out (and then not exported), see: https://stackoverflow.com/questions/9522631/how-to-put-a-line-comment-for-a-multi-line-command