### PR TITLE
Rename migration menu items

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,9 +52,9 @@ nav:
       - Monitoring with Prometheus: guides/monitoring.md
       - Sealed Secrets: guides/sealed-secrets.md
       - Mozilla SOPS: guides/mozilla-sops.md
-      - Migrate:
-        - From Flux v1: guides/flux-v1-migration.md
-        - From the Helm Operator: guides/helm-operator-migration.md
+      - Migration:
+        - Migrate from Flux v1: guides/flux-v1-migration.md
+        - Migrate from the Helm Operator: guides/helm-operator-migration.md
   - Toolkit Components:
     - Overview: components/index.md
     - Source Controller:


### PR DESCRIPTION
As they are used in the metadata, instead of the title from the
document.