### PR TITLE
List component images in check cmd

### DIFF
--- a/cmd/flux/check.go
+++ b/cmd/flux/check.go
@@ -180,6 +180,10 @@ func componentsCheck() bool {
 		} else {
 			logger.Successf("%s is healthy", deployment)
 		}
+		kubectlArgs = []string{"-n", namespace, "get", "deployment", deployment, "-o", "jsonpath=\"{..image}\""}
+		if output, err := utils.ExecKubectlCommand(ctx, utils.ModeCapture, kubectlArgs...); err == nil {
+			logger.Actionf(strings.TrimPrefix(strings.TrimSuffix(output, "\""), "\""))
+		}
 	}
 	return ok
 }


### PR DESCRIPTION
Make it easy to view each component version with:

```console
$ flux check 
► checking prerequisites
✔ kubectl 1.19.3 >=1.18.0
✔ Kubernetes 1.18.10-gke.601 >=1.16.0
► checking controllers
✔ source-controller is healthy
► ghcr.io/fluxcd/source-controller:v0.2.1
✔ kustomize-controller is healthy
► ghcr.io/fluxcd/kustomize-controller:v0.2.1
✔ helm-controller is healthy
► ghcr.io/fluxcd/helm-controller:v0.2.0
✔ notification-controller is healthy
► ghcr.io/fluxcd/notification-controller:v0.2.0
✔ all checks passed
```
