### PR TITLE
Show the roadmap status more prominently and precisely

### DIFF
--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -55,12 +55,17 @@ Non-Goals
 
 Tasks
 
-- [x]  <span style="color:grey">[Design the image scanning and automation API](https://github.com/fluxcd/flux2/discussions/107)</span>
-- [ ]  Implement an image scanning controller
-- [x]  <span style="color:grey">Design the automation component</span>
-- [ ]  Implement the image scan/patch/push workflow
-- [ ]  Integrate the new components in the Flux CLI
-- [ ]  Create a migration guide from Flux annotations
+- [x] <span style="color:grey">[Design the image scanning and automation API](https://github.com/fluxcd/flux2/discussions/107)</span>
+- [x] <span style="color:grey">Implement an image scanning controller</span>
+- [x] <span style="color:grey">Public image repo support</span>
+- [ ] Credentials from Secret [fluxcd/image-reflector-controller#35](https://github.com/fluxcd/image-reflector-controller/pull/35)
+- [ ] ECR-specific support [fluxcd/image-reflector-controller#11](https://github.com/fluxcd/image-reflector-controller/issues/11)
+- [ ] GCR-specific support [fluxcd/image-reflector-controller#11](https://github.com/fluxcd/image-reflector-controller/issues/11)
+- [ ] Azure-specific support [fluxcd/image-reflector-controller#11](https://github.com/fluxcd/image-reflector-controller/issues/11)
+- [x] <span style="color:grey">Design the automation component</span>
+- [x] <span style="color:grey">Implement the image scan/patch/push workflow</span>
+- [ ] Integrate the new components in the Flux CLI
+- [ ] Write a migration guide from Flux annotations
 
 ## The road to Helm Operator v2
 

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -14,6 +14,11 @@ All of the above will constitute "Flux v2".
 
 [= 100% "100%"]
 
+Flux v2 read-only is ready to try. See the [Getting
+Started](https://toolkit.fluxcd.io/get-started/) how-to, and the
+[Migration
+guide](https://toolkit.fluxcd.io/guides/flux-v1-migration/).
+
 This would be the first stepping stone: we want Flux v2 to be on-par with today's Flux in
 [read-only mode](https://github.com/fluxcd/flux/blob/master/docs/faq.md#can-i-run-flux-with-readonly-git-access)
 and [FluxCloud](https://github.com/justinbarrick/fluxcloud) notifications.
@@ -45,6 +50,10 @@ Tasks
 
 [= 70% "70%"]
 
+Image automation is available as a prerelease. See [the
+README](https://github.com/fluxcd/image-automation-controller#readme)
+for instructions on installing it.
+
 Goals
 
 -  Offer components that can replace Flux v1 image update feature
@@ -72,6 +81,11 @@ Tasks
 ### Helm v3 feature parity
 
 [= 100% "100%"]
+
+Helm support in Flux v2 is ready to try. See the [Helm controller
+guide](https://toolkit.fluxcd.io/guides/helmreleases/), and the [Helm
+controller migration
+guide](https://toolkit.fluxcd.io/guides/helm-operator-migration/).
 
 Goals
 

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -43,7 +43,7 @@ Tasks
 
 ### Flux image update feature parity
 
-[= 30% "30%"]
+[= 70% "70%"]
 
 Goals
 
@@ -58,13 +58,13 @@ Tasks
 - [x] <span style="color:grey">[Design the image scanning and automation API](https://github.com/fluxcd/flux2/discussions/107)</span>
 - [x] <span style="color:grey">Implement an image scanning controller</span>
 - [x] <span style="color:grey">Public image repo support</span>
-- [ ] Credentials from Secret [fluxcd/image-reflector-controller#35](https://github.com/fluxcd/image-reflector-controller/pull/35)
+- [x] <span style="color:grey">Credentials from Secret [fluxcd/image-reflector-controller#35](https://github.com/fluxcd/image-reflector-controller/pull/35)</span>
 - [ ] ECR-specific support [fluxcd/image-reflector-controller#11](https://github.com/fluxcd/image-reflector-controller/issues/11)
 - [ ] GCR-specific support [fluxcd/image-reflector-controller#11](https://github.com/fluxcd/image-reflector-controller/issues/11)
 - [ ] Azure-specific support [fluxcd/image-reflector-controller#11](https://github.com/fluxcd/image-reflector-controller/issues/11)
 - [x] <span style="color:grey">Design the automation component</span>
 - [x] <span style="color:grey">Implement the image scan/patch/push workflow</span>
-- [ ] Integrate the new components in the Flux CLI
+- [ ] Integrate the new components in the Flux CLI [fluxcd/flux2#538](https://github.com/fluxcd/flux2/pull/538)
 - [ ] Write a migration guide from Flux annotations
 
 ## The road to Helm Operator v2


### PR DESCRIPTION
Alan [commented in a Flux dev meeting](https://docs.google.com/document/d/1l_M0om0qUEN_NNiGgpqJ2tvsF2iioHkaARDeh6b70B0/edit#heading=h.4w6ysomi4xa) that it is not easy to find out the status of the various components of Flux v2 (e.g., the image update automation).

TODO:
 - [x] Clarify the things left to do on image-automation, from a user point of view
 - [ ] Show a summary of the component readiness prominently

On that latter, the suggestion was 

> from the new home page, “Getting Started” and “Learn More” [...] -- at least one of them -- should give a quick summary of v2 feature parity status
