### PR TITLE
Fix create tenant command export

### DIFF
--- a/cmd/flux/create_tenant.go
+++ b/cmd/flux/create_tenant.go
@@ -135,7 +135,7 @@ func createTenantCmdRun(cmd *cobra.Command, args []string) error {
 
 	if export {
 		for i, _ := range tenantNamespaces {
-			if err := exportTenant(namespaces[i], roleBindings[1]); err != nil {
+			if err := exportTenant(namespaces[i], roleBindings[i]); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Fix multiple issues when running `flux create tenant --export` 

1. Panic when creating a tenant with a single namespace.
```
$ flux create tenant sample --with-namespace=sample --export
panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
main.createTenantCmdRun(0x36b0f20, 0xc0006a13b0, 0x1, 0x3, 0x0, 0x0)
	/home/runner/work/flux2/flux2/cmd/flux/create_tenant.go:138 +0x11b4
github.com/spf13/cobra.(*Command).execute(0x36b0f20, 0xc0006a1380, 0x3, 0x3, 0x36b0f20, 0xc0006a1380)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:842 +0x47c
github.com/spf13/cobra.(*Command).ExecuteC(0x36aea60, 0x0, 0xc000092058, 0x0)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887
main.main()
	/home/runner/work/flux2/flux2/cmd/flux/main.go:119 +0x55
```

2. Same role binding is duplicated for every namespace.
```
❯ flux create tenant sample --with-namespace=frontend --with-namespace=backend --export
---
apiVersion: v1
kind: Namespace
metadata:
  labels:
    toolkit.fluxcd.io/tenant: sample
  name: frontend

---
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  labels:
    toolkit.fluxcd.io/tenant: sample
  name: gotk-reconciler
  namespace: backend
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: cluster-admin
subjects:
- apiGroup: rbac.authorization.k8s.io
  kind: User
  name: gotk:backend:reconciler

---
apiVersion: v1
kind: Namespace
metadata:
  labels:
    toolkit.fluxcd.io/tenant: sample
  name: backend

---
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  labels:
    toolkit.fluxcd.io/tenant: sample
  name: gotk-reconciler
  namespace: backend
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: cluster-admin
subjects:
- apiGroup: rbac.authorization.k8s.io
  kind: User
  name: gotk:backend:reconcile
```