### PR TITLE
Add token authentication option to bootstrap

### DIFF
--- a/cmd/flux/bootstrap.go
+++ b/cmd/flux/bootstrap.go
@@ -57,6 +57,7 @@ var (
 	bootstrapArch               = flags.Arch(defaults.Arch)
 	bootstrapLogLevel           = flags.LogLevel(defaults.LogLevel)
 	bootstrapRequiredComponents = []string{"source-controller", "kustomize-controller"}
+	bootstrapTokenAuth          bool
 )
 
 const (
@@ -75,14 +76,16 @@ func init() {
 	bootstrapCmd.PersistentFlags().Var(&bootstrapArch, "arch", bootstrapArch.Description())
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapBranch, "branch", bootstrapDefaultBranch,
 		"default branch (for GitHub this must match the default branch setting for the organization)")
-	rootCmd.AddCommand(bootstrapCmd)
 	bootstrapCmd.PersistentFlags().BoolVar(&bootstrapWatchAllNamespaces, "watch-all-namespaces", true,
 		"watch for custom resources in all namespaces, if set to false it will only watch the namespace where the toolkit is installed")
 	bootstrapCmd.PersistentFlags().BoolVar(&bootstrapNetworkPolicy, "network-policy", true,
 		"deny ingress access to the toolkit controllers from other namespaces using network policies")
+	bootstrapCmd.PersistentFlags().BoolVar(&bootstrapTokenAuth, "token-auth", false,
+		"when enabled, the personal access token will be used instead of SSH deploy key")
 	bootstrapCmd.PersistentFlags().Var(&bootstrapLogLevel, "log-level", bootstrapLogLevel.Description())
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapManifestsPath, "manifests", "", "path to the manifest directory")
 	bootstrapCmd.PersistentFlags().MarkHidden("manifests")
+	rootCmd.AddCommand(bootstrapCmd)
 }
 
 func bootstrapValidate() error {

--- a/docs/cmd/flux_bootstrap.md
+++ b/docs/cmd/flux_bootstrap.md
@@ -17,6 +17,7 @@ The bootstrap sub-commands bootstrap the toolkit components on the targeted Git 
       --log-level logLevel         log level, available options are: (debug, info, error) (default info)
       --network-policy             deny ingress access to the toolkit controllers from other namespaces using network policies (default true)
       --registry string            container registry where the toolkit images are published (default "ghcr.io/fluxcd")
+      --token-auth                 when enabled, the personal access token will be used instead of SSH deploy key
   -v, --version string             toolkit version (default "latest")
       --watch-all-namespaces       watch for custom resources in all namespaces, if set to false it will only watch the namespace where the toolkit is installed (default true)
 ```

--- a/docs/cmd/flux_bootstrap_github.md
+++ b/docs/cmd/flux_bootstrap_github.md
@@ -5,7 +5,7 @@ Bootstrap toolkit components in a GitHub repository
 ### Synopsis
 
 The bootstrap github command creates the GitHub repository if it doesn't exists and
-commits the toolkit components manifests to the master branch.
+commits the toolkit components manifests to the main branch.
 Then it configures the target cluster to synchronize with the repository.
 If the toolkit components are present on the cluster,
 the bootstrap command will perform an upgrade if needed.
@@ -32,8 +32,11 @@ flux bootstrap github [flags]
   # Run bootstrap for a public repository on a personal account
   flux bootstrap github --owner=<user> --repository=<repo name> --private=false --personal=true 
 
-  # Run bootstrap for a private repo hosted on GitHub Enterprise
-  flux bootstrap github --owner=<organization> --repository=<repo name> --hostname=<domain>
+  # Run bootstrap for a private repo hosted on GitHub Enterprise using SSH auth
+  flux bootstrap github --owner=<organization> --repository=<repo name> --hostname=<domain> --ssh-hostname=<domain>
+
+  # Run bootstrap for a private repo hosted on GitHub Enterprise using HTTPS auth
+  flux bootstrap github --owner=<organization> --repository=<repo name> --hostname=<domain> --token-auth
 
   # Run bootstrap for a an existing repository with a branch named main
   flux bootstrap github --owner=<organization> --repository=<repo name> --branch=main
@@ -43,15 +46,16 @@ flux bootstrap github [flags]
 ### Options
 
 ```
-  -h, --help                help for github
-      --hostname string     GitHub hostname (default "github.com")
-      --interval duration   sync interval (default 1m0s)
-      --owner string        GitHub user or organization name
-      --path string         repository path, when specified the cluster sync will be scoped to this path
-      --personal            is personal repository
-      --private             is private repository (default true)
-      --repository string   GitHub repository name
-      --team stringArray    GitHub team to be given maintainer access
+  -h, --help                  help for github
+      --hostname string       GitHub hostname (default "github.com")
+      --interval duration     sync interval (default 1m0s)
+      --owner string          GitHub user or organization name
+      --path string           repository path, when specified the cluster sync will be scoped to this path
+      --personal              is personal repository
+      --private               is private repository (default true)
+      --repository string     GitHub repository name
+      --ssh-hostname string   GitHub SSH hostname, to be used when the SSH host differs from the HTTPS one
+      --team stringArray      GitHub team to be given maintainer access
 ```
 
 ### Options inherited from parent commands
@@ -68,6 +72,7 @@ flux bootstrap github [flags]
       --network-policy             deny ingress access to the toolkit controllers from other namespaces using network policies (default true)
       --registry string            container registry where the toolkit images are published (default "ghcr.io/fluxcd")
       --timeout duration           timeout for this operation (default 5m0s)
+      --token-auth                 when enabled, the personal access token will be used instead of SSH deploy key
       --verbose                    print generated objects
   -v, --version string             toolkit version (default "latest")
       --watch-all-namespaces       watch for custom resources in all namespaces, if set to false it will only watch the namespace where the toolkit is installed (default true)

--- a/docs/cmd/flux_bootstrap_gitlab.md
+++ b/docs/cmd/flux_bootstrap_gitlab.md
@@ -21,22 +21,22 @@ flux bootstrap gitlab [flags]
   export GITLAB_TOKEN=<my-token>
 
   # Run bootstrap for a private repo using HTTPS token authentication 
-  flux bootstrap gitlab --owner=<group> --repository=<repo name>
+  flux bootstrap gitlab --owner=<group> --repository=<repo name> --token-auth
 
   # Run bootstrap for a private repo using SSH authentication
-  flux bootstrap gitlab --owner=<group> --repository=<repo name> --ssh-hostname=gitlab.com
+  flux bootstrap gitlab --owner=<group> --repository=<repo name>
 
   # Run bootstrap for a repository path
   flux bootstrap gitlab --owner=<group> --repository=<repo name> --path=dev-cluster
 
   # Run bootstrap for a public repository on a personal account
-  flux bootstrap gitlab --owner=<user> --repository=<repo name> --private=false --personal=true
+  flux bootstrap gitlab --owner=<user> --repository=<repo name> --private=false --personal --token-auth
 
   # Run bootstrap for a private repo hosted on a GitLab server 
-  flux bootstrap gitlab --owner=<group> --repository=<repo name> --hostname=<domain>
+  flux bootstrap gitlab --owner=<group> --repository=<repo name> --hostname=<domain> --token-auth
 
   # Run bootstrap for a an existing repository with a branch named main
-  flux bootstrap gitlab --owner=<organization> --repository=<repo name> --branch=main
+  flux bootstrap gitlab --owner=<organization> --repository=<repo name> --branch=main --token-auth
 
 ```
 
@@ -51,7 +51,7 @@ flux bootstrap gitlab [flags]
       --personal              is personal repository
       --private               is private repository (default true)
       --repository string     GitLab repository name
-      --ssh-hostname string   GitLab SSH hostname, when specified a deploy key will be added to the repository
+      --ssh-hostname string   GitLab SSH hostname, to be used when the SSH host differs from the HTTPS one
 ```
 
 ### Options inherited from parent commands
@@ -68,6 +68,7 @@ flux bootstrap gitlab [flags]
       --network-policy             deny ingress access to the toolkit controllers from other namespaces using network policies (default true)
       --registry string            container registry where the toolkit images are published (default "ghcr.io/fluxcd")
       --timeout duration           timeout for this operation (default 5m0s)
+      --token-auth                 when enabled, the personal access token will be used instead of SSH deploy key
       --verbose                    print generated objects
   -v, --version string             toolkit version (default "latest")
       --watch-all-namespaces       watch for custom resources in all namespaces, if set to false it will only watch the namespace where the toolkit is installed (default true)

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -130,6 +130,19 @@ To run the bootstrap for a repository hosted on GitHub Enterprise, you have to s
 ```sh
 flux bootstrap github \
   --hostname=my-github-enterprise.com \
+  --ssh-hostname=my-github-enterprise.com \
+  --owner=my-github-organization \
+  --repository=my-repository \
+  --branch=main \
+  --path=clusters/my-cluster
+```
+
+If your GitHub Enterprise has SSH access disabled, you can use HTTPS and token authentication with:
+
+```sh
+flux bootstrap github \
+  --token-auth \
+  --hostname=my-github-enterprise.com \
   --owner=my-github-organization \
   --repository=my-repository \
   --branch=main \
@@ -155,6 +168,7 @@ flux bootstrap gitlab \
   --repository=my-repository \
   --branch=master \
   --path=clusters/my-cluster \
+  --token-auth \
   --personal
 ```
 
@@ -189,6 +203,7 @@ To run the bootstrap for a repository hosted on GitLab on-prem or enterprise, yo
 ```sh
 flux bootstrap gitlab \
   --hostname=my-gitlab.com \
+  --token-auth \
   --owner=my-gitlab-group \
   --repository=my-repository \
   --branch=master \


### PR DESCRIPTION
This PR adds the `--token-auth` flag to the bootstrap command, when enabled, a SSH deploy key will no longer be generated, Flux will connect to Git using HTTPS token authentication. 

Fix: #449 