### PR TITLE
docs: add a missing git pull command

### DIFF
--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -88,6 +88,12 @@ flux bootstrap github \
   --personal
 ```
 
+Pull the changes locally:
+
+```sh
+git pull
+```
+
 !!! hint "ARM"
     When deploying to a Kubernetes cluster with ARM architecture,
     you can use `--arch=arm` for ARMv7 32-bit container images


### PR DESCRIPTION
After automatically committed (via `flux <GITHUB_USER@users.noreply.github.com>`) to remote repository through bootstrap command, it is necessary to be synchronized locally.