### PR TITLE
Add service accounts to tenant command

### DIFF
--- a/cmd/flux/create_tenant.go
+++ b/cmd/flux/create_tenant.go
@@ -65,7 +65,6 @@ var (
 )
 
 func init() {
-	createTenantCmd.Hidden = true
 	createTenantCmd.Flags().StringSliceVar(&tenantNamespaces, "with-namespace", nil, "namespace belonging to this tenant")
 	createTenantCmd.Flags().StringVar(&tenantClusterRole, "cluster-role", "cluster-admin", "cluster role of the tenant role binding")
 	createCmd.AddCommand(createTenantCmd)

--- a/docs/cmd/flux_create.md
+++ b/docs/cmd/flux_create.md
@@ -34,4 +34,5 @@ The create sub-commands generate sources and resources.
 * [flux create kustomization](flux_create_kustomization.md)	 - Create or update a Kustomization resource
 * [flux create receiver](flux_create_receiver.md)	 - Create or update a Receiver resource
 * [flux create source](flux_create_source.md)	 - Create or update sources
+* [flux create tenant](flux_create_tenant.md)	 - Create or update a tenant
 

--- a/docs/cmd/flux_create_tenant.md
+++ b/docs/cmd/flux_create_tenant.md
@@ -1,0 +1,55 @@
+## flux create tenant
+
+Create or update a tenant
+
+### Synopsis
+
+
+The create tenant command generates namespaces, service accounts and role bindings to limit the
+reconcilers scope to the tenant namespaces.
+
+```
+flux create tenant [flags]
+```
+
+### Examples
+
+```
+  # Create a tenant with access to a namespace 
+  flux create tenant dev-team \
+    --with-namespace=frontend \
+    --label=environment=dev
+
+  # Generate tenant namespaces and role bindings in YAML format
+  flux create tenant dev-team \
+    --with-namespace=frontend \
+    --with-namespace=backend \
+	--export > dev-team.yaml
+
+```
+
+### Options
+
+```
+      --cluster-role string      cluster role of the tenant role binding (default "cluster-admin")
+  -h, --help                     help for tenant
+      --with-namespace strings   namespace belonging to this tenant
+```
+
+### Options inherited from parent commands
+
+```
+      --context string      kubernetes context to use
+      --export              export in YAML format to stdout
+      --interval duration   source sync interval (default 1m0s)
+      --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
+      --label strings       set labels on the resource (can specify multiple labels with commas: label1=value1,label2=value2)
+  -n, --namespace string    the namespace scope for this operation (default "flux-system")
+      --timeout duration    timeout for this operation (default 5m0s)
+      --verbose             print generated objects
+```
+
+### SEE ALSO
+
+* [flux create](flux_create.md)	 - Create or update sources and resources
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,7 +95,7 @@ nav:
     - Create alert provider: cmd/flux_create_alert-provider.md
     - Create alert: cmd/flux_create_alert.md
     - Create receiver: cmd/flux_create_receiver.md
-    #- Create tenant: cmd/flux_create_tenant.md
+    - Create tenant: cmd/flux_create_tenant.md
     - Delete: cmd/flux_delete.md
     - Delete kustomization: cmd/flux_delete_kustomization.md
     - Delete helmrelease: cmd/flux_delete_helmrelease.md


### PR DESCRIPTION
Generate a service account with limited access to its namespace, for each namespace owned by a tenant.

```
flux create tenant dev-team --with-namespace apps --export
```

```yaml
---
apiVersion: v1
kind: Namespace
metadata:
  labels:
    toolkit.fluxcd.io/tenant: dev-team
  name: apps
---
kind: ServiceAccount
metadata:
  labels:
    toolkit.fluxcd.io/tenant: dev-team
  name: dev-team
  namespace: apps
---
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  labels:
    toolkit.fluxcd.io/tenant: dev-team
  name: gotk-reconciler
  namespace: apps
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: cluster-admin
subjects:
- kind: User
  name: gotk:apps:reconciler
- kind: ServiceAccount
  name: dev-team
```