### PR TITLE
add a note not to apply encrypted secrets directly

### DIFF
--- a/docs/guides/mozilla-sops.md
+++ b/docs/guides/mozilla-sops.md
@@ -78,6 +78,9 @@ sops --encrypt \
 
 You can now commit the encrypted secret to your Git repository.
 
+!!! hint
+    Note that you shouldn't apply the encrypted secrets onto the cluster with kubectl. SOPS encrypted secrets are designed to be consumed by kustomize-controller.
+
 ## Configure secrets decryption
 
 Registry the Git repository on your cluster:


### PR DESCRIPTION
This PR adds a note to clarify a bit that encrypted secrets are not to be applied directly to the cluster.