### PR TITLE
Add service account arg to create commands

### DIFF
--- a/cmd/flux/create_helmrelease.go
+++ b/cmd/flux/create_helmrelease.go
@@ -107,6 +107,7 @@ var (
 	hrTargetNamespace string
 	hrValuesFile      string
 	hrValuesFrom      flags.HelmReleaseValuesFrom
+	hrSAName          string
 )
 
 func init() {
@@ -116,6 +117,7 @@ func init() {
 	createHelmReleaseCmd.Flags().StringVar(&hrChartVersion, "chart-version", "", "Helm chart version, accepts a semver range (ignored for charts from GitRepository sources)")
 	createHelmReleaseCmd.Flags().StringArrayVar(&hrDependsOn, "depends-on", nil, "HelmReleases that must be ready before this release can be installed, supported formats '<name>' and '<namespace>/<name>'")
 	createHelmReleaseCmd.Flags().StringVar(&hrTargetNamespace, "target-namespace", "", "namespace to install this release, defaults to the HelmRelease namespace")
+	createHelmReleaseCmd.Flags().StringVar(&hrSAName, "service-account", "", "the name of the service account to impersonate when reconciling this HelmRelease")
 	createHelmReleaseCmd.Flags().StringVar(&hrValuesFile, "values", "", "local path to the values.yaml file")
 	createHelmReleaseCmd.Flags().Var(&hrValuesFrom, "values-from", hrValuesFrom.Description())
 	createCmd.AddCommand(createHelmReleaseCmd)
@@ -165,6 +167,10 @@ func createHelmReleaseCmdRun(cmd *cobra.Command, args []string) error {
 			},
 			Suspend: false,
 		},
+	}
+
+	if hrSAName != "" {
+		helmRelease.Spec.ServiceAccountName = hrSAName
 	}
 
 	if hrValuesFile != "" {

--- a/cmd/flux/create_kustomization.go
+++ b/cmd/flux/create_kustomization.go
@@ -88,13 +88,13 @@ var (
 
 func init() {
 	createKsCmd.Flags().Var(&ksSource, "source", ksSource.Description())
-	createKsCmd.Flags().StringVar(&ksPath, "path", "./", "path to the directory containing the Kustomization file")
+	createKsCmd.Flags().StringVar(&ksPath, "path", "./", "path to the directory containing a kustomization.yaml file")
 	createKsCmd.Flags().BoolVar(&ksPrune, "prune", false, "enable garbage collection")
 	createKsCmd.Flags().StringArrayVar(&ksHealthCheck, "health-check", nil, "workload to be included in the health assessment, in the format '<kind>/<name>.<namespace>'")
 	createKsCmd.Flags().DurationVar(&ksHealthTimeout, "health-check-timeout", 2*time.Minute, "timeout of health checking operations")
 	createKsCmd.Flags().StringVar(&ksValidation, "validation", "", "validate the manifests before applying them on the cluster, can be 'client' or 'server'")
 	createKsCmd.Flags().StringArrayVar(&ksDependsOn, "depends-on", nil, "Kustomization that must be ready before this Kustomization can be applied, supported formats '<name>' and '<namespace>/<name>'")
-	createKsCmd.Flags().StringVar(&ksSAName, "sa-name", "", "service account name")
+	createKsCmd.Flags().StringVar(&ksSAName, "service-account", "", "the name of the service account to impersonate when reconciling this Kustomization")
 	createKsCmd.Flags().Var(&ksDecryptionProvider, "decryption-provider", ksDecryptionProvider.Description())
 	createKsCmd.Flags().StringVar(&ksDecryptionSecret, "decryption-secret", "", "set the Kubernetes secret name that contains the OpenPGP private keys used for sops decryption")
 	createKsCmd.Flags().StringVar(&ksTargetNamespace, "target-namespace", "", "overrides the namespace of all Kustomization objects reconciled by this Kustomization")

--- a/docs/cmd/flux_create_helmrelease.md
+++ b/docs/cmd/flux_create_helmrelease.md
@@ -75,6 +75,7 @@ flux create helmrelease [name] [flags]
       --depends-on stringArray              HelmReleases that must be ready before this release can be installed, supported formats '<name>' and '<namespace>/<name>'
   -h, --help                                help for helmrelease
       --release-name string                 name used for the Helm release, defaults to a composition of '[<target-namespace>-]<HelmRelease-name>'
+      --service-account string              the name of the service account to impersonate when reconciling this HelmRelease
       --source helmChartSource              source that contains the chart in the format '<kind>/<name>',where kind can be one of: (HelmRepository, GitRepository, Bucket)
       --target-namespace string             namespace to install this release, defaults to the HelmRelease namespace
       --values string                       local path to the values.yaml file

--- a/docs/cmd/flux_create_kustomization.md
+++ b/docs/cmd/flux_create_kustomization.md
@@ -50,9 +50,9 @@ flux create kustomization [name] [flags]
       --health-check stringArray                 workload to be included in the health assessment, in the format '<kind>/<name>.<namespace>'
       --health-check-timeout duration            timeout of health checking operations (default 2m0s)
   -h, --help                                     help for kustomization
-      --path string                              path to the directory containing the Kustomization file (default "./")
+      --path string                              path to the directory containing a kustomization.yaml file (default "./")
       --prune                                    enable garbage collection
-      --sa-name string                           service account name
+      --service-account string                   the name of the service account to impersonate when reconciling this Kustomization
       --source kustomizationSource               source that contains the Kubernetes manifests in the format '[<kind>/]<name>',where kind can be one of: (GitRepository, Bucket), if kind is not specified it defaults to GitRepository
       --target-namespace string                  overrides the namespace of all Kustomization objects reconciled by this Kustomization
       --validation string                        validate the manifests before applying them on the cluster, can be 'client' or 'server'


### PR DESCRIPTION
This PR adds a `--service-account` arg to `create helmrelease` command and renames the `--sa-name` arg to `--service-account` in the `create kustomization` command.

This allows users to specify the name of the service account to impersonate when reconciling a Kustomization or HelmRelease.

Example:

```sh
flux create tenant dev-team --with-namespace=apps

flux create kustomization --namespace=apps --service-account=dev-team

flux create helmrelease --namespace=apps --service-account=dev-team
```
