### PR TITLE
Note the shared Flux v2 maintainers and team

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -2,6 +2,14 @@ The maintainers are generally available in Slack at
 https://cloud-native.slack.com in #flux (https://cloud-native.slack.com/messages/CLAJ40HV3)
 (obtain an invitation at https://slack.cncf.io/).
 
+These maintainers are shared with other Flux v2-related git
+repositories under https://github.com/fluxcd, as noted in their
+respective MAINTAINERS files.
+
+For convenience, they are reflected in the GitHub team
+@fluxcd/flux2-maintainers -- if the list here changes, that team also
+should.
+
 In alphabetical order:
 
 Aurel Canciu, Sortlist <aurel@sortlist.com> (github: @relu, slack: relu)


### PR DESCRIPTION
Many of the GitOps Toolkit controllers will share maintainers with
this repo, acting as the central Flux v2 repo. For convenience of
tracking membership and applying permissions, we can share maintainers
by:

 - referring to the MAINTAINERS file here, from elsewhere;
 - making a GitHub team that tracks those shared maintainers.

This commit makes a note of this in the MAINTAINERS file, to inform
people of the arrangement, and remind them to keep the team up to
date.

See https://github.com/fluxcd/flux2/discussions/515 for the original proposal. NB since this touches on governance, should be approved by @fluxcd/oversight-committee.