### PR TITLE
Improve installer list match for arm arches

### DIFF
--- a/install/flux.sh
+++ b/install/flux.sh
@@ -42,7 +42,10 @@ setup_verify_arch() {
         ARCH=$(uname -m)
     fi
     case ${ARCH} in
-        arm64)
+        arm|armv6l|armv7l)
+            ARCH=arm
+            ;;
+        arm64|aarch64|armv8l)
             ARCH=arm64
             ;;
         amd64)


### PR DESCRIPTION
`uname -m` will print out architecture codenames based on UTS_MACHINE
and COMPAT_UTS_MACHINE kernel defined constants. These extra values will
ensure the right version of the arm binary is installed on most Linux
systems running on ARM CPUs.

I was only able to test this on my RPiv3, `uname -m` reports `armv7l`. With the tweak, the installation is able to complete.