### PR TITLE
Fix tenant and reconcile commands

### DIFF
--- a/cmd/flux/create_tenant.go
+++ b/cmd/flux/create_tenant.go
@@ -55,8 +55,7 @@ reconcilers scope to the tenant namespaces.`,
 }
 
 const (
-	tenantLabel       = "toolkit.fluxcd.io/tenant"
-	tenantRoleBinding = "gotk-reconciler"
+	tenantLabel = "toolkit.fluxcd.io/tenant"
 )
 
 var (
@@ -123,18 +122,20 @@ func createTenantCmdRun(cmd *cobra.Command, args []string) error {
 
 		roleBinding := rbacv1.RoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      tenantRoleBinding,
+				Name:      fmt.Sprintf("%s-reconciler", tenant),
 				Namespace: ns,
 				Labels:    objLabels,
 			},
 			Subjects: []rbacv1.Subject{
 				{
-					Kind: "User",
-					Name: fmt.Sprintf("gotk:%s:reconciler", ns),
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "User",
+					Name:     fmt.Sprintf("gotk:%s:reconciler", ns),
 				},
 				{
-					Kind: "ServiceAccount",
-					Name: tenant,
+					Kind:      "ServiceAccount",
+					Name:      tenant,
+					Namespace: ns,
 				},
 			},
 			RoleRef: rbacv1.RoleRef{
@@ -290,7 +291,7 @@ func exportTenant(namespace corev1.Namespace, account corev1.ServiceAccount, rol
 	fmt.Println(resourceToString(data))
 
 	account.TypeMeta = metav1.TypeMeta{
-		APIVersion: "",
+		APIVersion: "v1",
 		Kind:       "ServiceAccount",
 	}
 	data, err = yaml.Marshal(account)

--- a/cmd/flux/reconcile_helmrelease.go
+++ b/cmd/flux/reconcile_helmrelease.go
@@ -86,6 +86,10 @@ func reconcileHrCmdRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if helmRelease.Spec.Suspend {
+		return fmt.Errorf("resource is suspended")
+	}
+
 	if syncHrWithSource {
 		switch helmRelease.Spec.Chart.Spec.SourceRef.Kind {
 		case sourcev1.HelmRepositoryKind:

--- a/cmd/flux/reconcile_kustomization.go
+++ b/cmd/flux/reconcile_kustomization.go
@@ -84,6 +84,10 @@ func reconcileKsCmdRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if kustomization.Spec.Suspend {
+		return fmt.Errorf("resource is suspended")
+	}
+
 	if syncKsWithSource {
 		switch kustomization.Spec.SourceRef.Kind {
 		case sourcev1.GitRepositoryKind:

--- a/cmd/flux/reconcile_receiver.go
+++ b/cmd/flux/reconcile_receiver.go
@@ -64,13 +64,17 @@ func reconcileReceiverCmdRun(cmd *cobra.Command, args []string) error {
 		Name:      name,
 	}
 
-	logger.Actionf("annotating Receiver %s in %s namespace", name, namespace)
 	var receiver notificationv1.Receiver
 	err = kubeClient.Get(ctx, namespacedName, &receiver)
 	if err != nil {
 		return err
 	}
 
+	if receiver.Spec.Suspend {
+		return fmt.Errorf("resource is suspended")
+	}
+
+	logger.Actionf("annotating Receiver %s in %s namespace", name, namespace)
 	if receiver.Annotations == nil {
 		receiver.Annotations = map[string]string{
 			meta.ReconcileAtAnnotation: time.Now().Format(time.RFC3339Nano),

--- a/cmd/flux/reconcile_source_bucket.go
+++ b/cmd/flux/reconcile_source_bucket.go
@@ -74,6 +74,10 @@ func reconcileSourceBucketCmdRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if bucket.Spec.Suspend {
+		return fmt.Errorf("resource is suspended")
+	}
+
 	lastHandledReconcileAt := bucket.Status.LastHandledReconcileAt
 	logger.Actionf("annotating Bucket source %s in %s namespace", name, namespace)
 	if err := requestBucketReconciliation(ctx, kubeClient, namespacedName, &bucket); err != nil {

--- a/cmd/flux/reconcile_source_git.go
+++ b/cmd/flux/reconcile_source_git.go
@@ -72,6 +72,10 @@ func reconcileSourceGitCmdRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if repository.Spec.Suspend {
+		return fmt.Errorf("resource is suspended")
+	}
+
 	logger.Actionf("annotating GitRepository source %s in %s namespace", name, namespace)
 	if err := requestGitRepositoryReconciliation(ctx, kubeClient, namespacedName, &repository); err != nil {
 		return err

--- a/cmd/flux/reconcile_source_helm.go
+++ b/cmd/flux/reconcile_source_helm.go
@@ -73,6 +73,10 @@ func reconcileSourceHelmCmdRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if repository.Spec.Suspend {
+		return fmt.Errorf("resource is suspended")
+	}
+
 	logger.Actionf("annotating HelmRepository source %s in %s namespace", name, namespace)
 	if err := requestHelmRepositoryReconciliation(ctx, kubeClient, namespacedName, &repository); err != nil {
 		return err


### PR DESCRIPTION
Changes:
- Add service account namespace to tenant role binding
- Rename role binding to match the tenant name
- Do not try to reconcile a suspended object 