### PR TITLE
Add labels to generated secrets

### DIFF
--- a/cmd/flux/create_source_bucket.go
+++ b/cmd/flux/create_source_bucket.go
@@ -154,6 +154,7 @@ func createSourceBucketCmdRun(cmd *cobra.Command, args []string) error {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      secretName,
 				Namespace: namespace,
+				Labels:    sourceLabels,
 			},
 			StringData: map[string]string{},
 		}

--- a/cmd/flux/create_source_git.go
+++ b/cmd/flux/create_source_git.go
@@ -215,6 +215,7 @@ func createSourceGitCmdRun(cmd *cobra.Command, args []string) error {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: namespace,
+				Labels:    sourceLabels,
 			},
 			StringData: map[string]string{
 				"identity":     string(pair.PrivateKey),
@@ -232,6 +233,7 @@ func createSourceGitCmdRun(cmd *cobra.Command, args []string) error {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: namespace,
+				Labels:    sourceLabels,
 			},
 			StringData: map[string]string{
 				"username": sourceGitUsername,

--- a/cmd/flux/create_source_helm.go
+++ b/cmd/flux/create_source_helm.go
@@ -151,6 +151,7 @@ func createSourceHelmCmdRun(cmd *cobra.Command, args []string) error {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      secretName,
 				Namespace: namespace,
+				Labels:    sourceLabels,
 			},
 			StringData: map[string]string{},
 		}


### PR DESCRIPTION
Label secrets generated by the create commands:

```sh 
flux create source <TYPE> <NAME> \
--label=environment=dev \
--label=region=eu-west-2
```

Fix: #545