### PR TITLE
Add AUR_BOT_SSH_PRIVATE_KEY env var for goreleaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -85,3 +85,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          AUR_BOT_SSH_PRIVATE_KEY: ${{ secret.AUR_BOT_SSH_PRIVATE_KEY }}


### PR DESCRIPTION
The AUR_BOT_SSH_PRIVATE_KEY environment variable needs to be set in
goreleaser so publishing the packages to AUR can work.