### PR TITLE
Publish install manifest to GitHub releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,24 +59,9 @@ jobs:
 
           # create tarball
           cd ./output && tar -cvzf manifests.tar.gz $files
-      - name: Create release
-        id: create_release
-        uses: actions/create-release@latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-      - name: Upload artifacts
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./output/manifests.tar.gz
-          asset_name: manifests.tar.gz
-          asset_content_type: application/gzip
+      - name: Generate install manifest
+        run: |
+          kustomize build ./manifests/install > ./output/install.yaml
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -68,3 +68,7 @@ publishers:
       eval $(ssh-agent -s)
       ssh-add <(echo "{{ .Env.AUR_BOT_SSH_PRIVATE_KEY }}")
       .github/aur/flux-go/publish.sh {{ .Version }}
+release:
+  extra_files:
+    - glob: ./output/manifests.tar.gz
+    - glob: ./output/install.yaml

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -444,10 +444,10 @@ For testing purposes you can install Flux without storing its manifests in a Git
 flux install --arch=amd64
 ```
 
-Or using kustomize and kubectl:
+Or using kubectl:
 
 ```sh
-kustomize build https://github.com/fluxcd/flux2/manifests/install?ref=main | kubectl apply -f-
+kubectl apply -f https://github.com/fluxcd/flux2/releases/latest/download/install.yaml
 ```
 
 Then you can register Git repositories and reconcile them on your cluster:


### PR DESCRIPTION
Build and publish Flux `install.yaml` to GitHub release for those that don't want to use `flux bootstrap`.

After the next release, Flux can be installed with kubectl:

```
kubectl apply -f https://github.com/fluxcd/flux2/releases/latest/download/install.yaml
```