### PR TITLE
Prevent AUR package publishing parallel execution

### DIFF
--- a/.github/aur/flux-bin/publish.sh
+++ b/.github/aur/flux-bin/publish.sh
@@ -6,6 +6,11 @@ WD=$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd)
 PKGNAME=$(basename $WD)
 ROOT=${WD%/.github/aur/$PKGNAME}
 
+LOCKFILE=/tmp/aur-$PKGNAME.lock
+exec 100>$LOCKFILE || exit 0
+flock -n 100 || exit 0
+trap "rm -f $LOCKFILE" EXIT
+
 export VERSION=$1
 echo "Publishing to AUR as version ${VERSION}"
 

--- a/.github/aur/flux-go/publish.sh
+++ b/.github/aur/flux-go/publish.sh
@@ -6,6 +6,11 @@ WD=$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd)
 PKGNAME=$(basename $WD)
 ROOT=${WD%/.github/aur/$PKGNAME}
 
+LOCKFILE=/tmp/aur-$PKGNAME.lock
+exec 100>$LOCKFILE || exit 0
+flock -n 100 || exit 0
+trap "rm -f $LOCKFILE" EXIT
+
 export VERSION=$1
 echo "Publishing to AUR as version ${VERSION}"
 

--- a/.github/aur/flux-scm/publish.sh
+++ b/.github/aur/flux-scm/publish.sh
@@ -6,6 +6,11 @@ WD=$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd)
 PKGNAME=$(basename $WD)
 ROOT=${WD%/.github/aur/$PKGNAME}
 
+LOCKFILE=/tmp/aur-$PKGNAME.lock
+exec 100>$LOCKFILE || exit 0
+flock -n 100 || exit 0
+trap "rm -f $LOCKFILE" EXIT
+
 export VERSION=$1
 echo "Publishing to AUR as version ${VERSION}"
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,15 +23,6 @@ builds:
     id: windows
     goos:
       - windows
-  - id: aurmock
-    binary: aurmock
-    main: ./cmd/flux
-    env:
-      - CGO_ENABLED=0
-    goos:
-      - linux
-    goarch:
-      - amd64
 archives:
   - name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     id: nix
@@ -45,9 +36,6 @@ archives:
     format: zip
     files:
       - none*
-  - name_template: "aur_{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-    id: aur
-    builds: [aurmock]
 brews:
   - name: flux
     tap:
@@ -64,30 +52,21 @@ brews:
       system "#{bin}/flux --version"
 publishers:
   - name: aur-pkg-bin
-    ids:
-      - aur
     env:
       - AUR_BOT_SSH_PRIVATE_KEY={{ .Env.AUR_BOT_SSH_PRIVATE_KEY }}
     cmd: |
       .github/aur/flux-bin/publish.sh {{ .Version }}
   - name: aur-pkg-scm
-    ids:
-      - aur
     env:
       - AUR_BOT_SSH_PRIVATE_KEY={{ .Env.AUR_BOT_SSH_PRIVATE_KEY }}
     cmd: |
       .github/aur/flux-scm/publish.sh {{ .Version }}
   - name: aur-pkg-go
-    ids:
-      - aur
     env:
       - AUR_BOT_SSH_PRIVATE_KEY={{ .Env.AUR_BOT_SSH_PRIVATE_KEY }}
     cmd: |
       .github/aur/flux-go/publish.sh {{ .Version }}
 release:
-  ids:
-    - nix
-    - windows
   extra_files:
     - glob: ./output/manifests.tar.gz
     - glob: ./output/install.yaml


### PR DESCRIPTION
Using a lock to prevent parallel executions in GoReleaser's custom
publishers. The custom publisher logic executes the tasks in parallel
for each available artifact.

https://goreleaser.com/customization/publishers/#how-it-works