### PR TITLE
Use relative filepaths in generated kustomization and during build

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -323,7 +323,11 @@ func GenerateKustomizationYaml(dirPath string) error {
 
 		var resources []string
 		for _, file := range files {
-			resources = append(resources, strings.Replace(file, abs, ".", 1))
+			relP, err := filepath.Rel(abs, file)
+			if err != nil {
+				return err
+			}
+			resources = append(resources, relP)
 		}
 
 		kus.Resources = resources

--- a/pkg/manifestgen/install/manifests.go
+++ b/pkg/manifestgen/install/manifests.go
@@ -105,6 +105,22 @@ func build(base, output string) error {
 		return fmt.Errorf("%s not found", kfile)
 	}
 
+	// TODO(hidde): work around for a bug in kustomize causing it to
+	//  not properly handle absolute paths on Windows.
+	//  Convert the path to a relative path to the working directory
+	//  as a temporary fix:
+	//  https://github.com/kubernetes-sigs/kustomize/issues/2789
+	if filepath.IsAbs(base) {
+		wd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		base, err = filepath.Rel(wd, base)
+		if err != nil {
+			return err
+		}
+	}
+
 	opt := krusty.MakeDefaultOptions()
 	k := krusty.MakeKustomizer(fs, opt)
 	m, err := k.Run(base)


### PR DESCRIPTION
Work around for a bug in kustomize causing it to not properly
handle absolute paths on Windows.

- [x] `flux install` confirmed working on Windows 10
- [x] `flux bootstrap` confirmed working on Windows 10

Fixes #362 