### PR TITLE
Include image controller config in `flux install`

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -40,6 +40,8 @@ jobs:
             bump_version kustomize-controller
             bump_version source-controller
             bump_version notification-controller
+            bump_version image-reflector-controller
+            bump_version image-automation-controller
 
             # add missing and remove unused modules
             go mod tidy

--- a/cmd/flux/bootstrap_github.go
+++ b/cmd/flux/bootstrap_github.go
@@ -206,7 +206,7 @@ func bootstrapGitHubCmdRun(cmd *cobra.Command, args []string) error {
 	if isInstall {
 		// apply install manifests
 		logger.Actionf("installing components in %s namespace", namespace)
-		if err := applyInstallManifests(ctx, manifest, bootstrapComponents); err != nil {
+		if err := applyInstallManifests(ctx, manifest, bootstrapComponents()); err != nil {
 			return err
 		}
 		logger.Successf("install completed")

--- a/cmd/flux/bootstrap_gitlab.go
+++ b/cmd/flux/bootstrap_gitlab.go
@@ -172,7 +172,7 @@ func bootstrapGitLabCmdRun(cmd *cobra.Command, args []string) error {
 	if isInstall {
 		// apply install manifests
 		logger.Actionf("installing components in %s namespace", namespace)
-		if err := applyInstallManifests(ctx, manifest, bootstrapComponents); err != nil {
+		if err := applyInstallManifests(ctx, manifest, bootstrapComponents()); err != nil {
 			return err
 		}
 		logger.Successf("install completed")

--- a/cmd/flux/install.go
+++ b/cmd/flux/install.go
@@ -56,7 +56,7 @@ var (
 	installDryRun             bool
 	installManifestsPath      string
 	installVersion            string
-	installComponents         []string
+	installDefaultComponents  []string
 	installExtraComponents    []string
 	installRegistry           string
 	installImagePullSecret    string
@@ -73,9 +73,9 @@ func init() {
 		"only print the object that would be applied")
 	installCmd.Flags().StringVarP(&installVersion, "version", "v", defaults.Version,
 		"toolkit version")
-	installCmd.Flags().StringSliceVar(&installComponents, "components", defaults.Components,
+	installCmd.Flags().StringSliceVar(&installDefaultComponents, "components", defaults.Components,
 		"list of components, accepts comma-separated values")
-	installCmd.Flags().StringSliceVar(&installExtraComponents, "extra-components", nil,
+	installCmd.Flags().StringSliceVar(&installExtraComponents, "components-extra", nil,
 		"list of components in addition to those supplied or defaulted, accepts comma-separated values")
 	installCmd.Flags().StringVar(&installManifestsPath, "manifests", "", "path to the manifest directory")
 	installCmd.Flags().MarkHidden("manifests")
@@ -106,7 +106,7 @@ func installCmdRun(cmd *cobra.Command, args []string) error {
 		logger.Generatef("generating manifests")
 	}
 
-	components := append(installComponents, installExtraComponents...)
+	components := append(installDefaultComponents, installExtraComponents...)
 
 	opts := install.Options{
 		BaseURL:                installManifestsPath,

--- a/docs/cmd/flux_bootstrap.md
+++ b/docs/cmd/flux_bootstrap.md
@@ -12,6 +12,7 @@ The bootstrap sub-commands bootstrap the toolkit components on the targeted Git 
       --arch arch                  cluster architecture, available options are: (amd64, arm, arm64) (default amd64)
       --branch string              default branch (for GitHub this must match the default branch setting for the organization) (default "main")
       --components strings         list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
+      --components-extra strings   list of components in addition to those supplied or defaulted, accepts comma-separated values
   -h, --help                       help for bootstrap
       --image-pull-secret string   Kubernetes secret name used for pulling the toolkit images from a private registry
       --log-level logLevel         log level, available options are: (debug, info, error) (default info)

--- a/docs/cmd/flux_bootstrap_github.md
+++ b/docs/cmd/flux_bootstrap_github.md
@@ -64,6 +64,7 @@ flux bootstrap github [flags]
       --arch arch                  cluster architecture, available options are: (amd64, arm, arm64) (default amd64)
       --branch string              default branch (for GitHub this must match the default branch setting for the organization) (default "main")
       --components strings         list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
+      --components-extra strings   list of components in addition to those supplied or defaulted, accepts comma-separated values
       --context string             kubernetes context to use
       --image-pull-secret string   Kubernetes secret name used for pulling the toolkit images from a private registry
       --kubeconfig string          path to the kubeconfig file (default "~/.kube/config")

--- a/docs/cmd/flux_bootstrap_gitlab.md
+++ b/docs/cmd/flux_bootstrap_gitlab.md
@@ -60,6 +60,7 @@ flux bootstrap gitlab [flags]
       --arch arch                  cluster architecture, available options are: (amd64, arm, arm64) (default amd64)
       --branch string              default branch (for GitHub this must match the default branch setting for the organization) (default "main")
       --components strings         list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
+      --components-extra strings   list of components in addition to those supplied or defaulted, accepts comma-separated values
       --context string             kubernetes context to use
       --image-pull-secret string   Kubernetes secret name used for pulling the toolkit images from a private registry
       --kubeconfig string          path to the kubeconfig file (default "~/.kube/config")

--- a/docs/cmd/flux_install.md
+++ b/docs/cmd/flux_install.md
@@ -33,9 +33,9 @@ flux install [flags]
 ```
       --arch arch                  cluster architecture, available options are: (amd64, arm, arm64) (default amd64)
       --components strings         list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
+      --components-extra strings   list of components in addition to those supplied or defaulted, accepts comma-separated values
       --dry-run                    only print the object that would be applied
       --export                     write the install manifests to stdout and exit
-      --extra-components strings   list of components in addition to those supplied or defaulted, accepts comma-separated values
   -h, --help                       help for install
       --image-pull-secret string   Kubernetes secret name used for pulling the toolkit images from a private registry
       --log-level logLevel         log level, available options are: (debug, info, error) (default info)

--- a/docs/cmd/flux_install.md
+++ b/docs/cmd/flux_install.md
@@ -35,6 +35,7 @@ flux install [flags]
       --components strings         list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
       --dry-run                    only print the object that would be applied
       --export                     write the install manifests to stdout and exit
+      --extra-components strings   list of components in addition to those supplied or defaulted, accepts comma-separated values
   -h, --help                       help for install
       --image-pull-secret string   Kubernetes secret name used for pulling the toolkit images from a private registry
       --log-level logLevel         log level, available options are: (debug, info, error) (default info)

--- a/manifests/bases/image-automation-controller/kustomization.yaml
+++ b/manifests/bases/image-automation-controller/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- https://github.com/fluxcd/image-automation-controller/archive/v0.1.0.zip//image-automation-controller-0.1.0/config/crd
+- https://github.com/fluxcd/image-automation-controller/archive/v0.1.0.zip//image-automation-controller-0.1.0/config/manager
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: image-automation-controller
+  path: patch.yaml

--- a/manifests/bases/image-automation-controller/patch.yaml
+++ b/manifests/bases/image-automation-controller/patch.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/0
+  value: --events-addr=http://notification-controller/

--- a/manifests/bases/image-reflector-controller/kustomization.yaml
+++ b/manifests/bases/image-reflector-controller/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- https://github.com/fluxcd/image-reflector-controller/archive/v0.1.0.zip//image-reflector-controller-0.1.0/config/crd
+- https://github.com/fluxcd/image-reflector-controller/archive/v0.1.0.zip//image-reflector-controller-0.1.0/config/manager
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: image-reflector-controller
+  path: patch.yaml

--- a/manifests/bases/image-reflector-controller/patch.yaml
+++ b/manifests/bases/image-reflector-controller/patch.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/0
+  value: --events-addr=http://notification-controller/

--- a/manifests/install/kustomization.yaml
+++ b/manifests/install/kustomization.yaml
@@ -7,6 +7,8 @@ resources:
   - ../bases/kustomize-controller
   - ../bases/notification-controller
   - ../bases/helm-controller
+  - ../bases/image-reflector-controller
+  - ../bases/image-automation-controller
   - ../rbac
   - ../policies
 transformers:


### PR DESCRIPTION
This adds kustomizations for `image-{reflector,automation}-controller`, which will get bundled into the file fetched by `flux install`.

It also adds the corresponding APIs into the update workflow, so they don't get left out.

Lastly, this introduces an argument `--extra-components`, which can be used to add components to the defaults. E.g., you can do

    flux install --extra-components image-reflector-controller,image-automation-controller

rather than having to use `--components` and name all of them including the defaults.