### PR TITLE
Log to stderr

### DIFF
--- a/cmd/flux/create_source_git.go
+++ b/cmd/flux/create_source_git.go
@@ -187,13 +187,13 @@ func createSourceGitCmdRun(cmd *cobra.Command, args []string) error {
 	if sourceGitSecretRef != "" {
 		withAuth = true
 	} else if u.Scheme == "ssh" {
-		logger.Actionf("generating deploy key pair")
+		logger.Generatef("generating deploy key pair")
 		pair, err := generateKeyPair(ctx)
 		if err != nil {
 			return err
 		}
 
-		fmt.Printf("%s", pair.PublicKey)
+		logger.Successf("deploy key: %s", pair.PublicKey)
 		prompt := promptui.Prompt{
 			Label:     "Have you added the deploy key to your repository",
 			IsConfirm: true,
@@ -207,8 +207,7 @@ func createSourceGitCmdRun(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		logger.Successf("collected public key from SSH server:")
-		fmt.Printf("%s", hostKey)
+		logger.Successf("collected public key from SSH server:\n%s", hostKey)
 
 		logger.Actionf("applying secret with keys")
 		secret := corev1.Secret{

--- a/cmd/flux/log.go
+++ b/cmd/flux/log.go
@@ -16,26 +16,31 @@ limitations under the License.
 
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"io"
+)
 
-type printLogger struct{}
-
-func (l printLogger) Actionf(format string, a ...interface{}) {
-	fmt.Println(`►`, fmt.Sprintf(format, a...))
+type stderrLogger struct {
+	stderr io.Writer
 }
 
-func (l printLogger) Generatef(format string, a ...interface{}) {
-	fmt.Println(`✚`, fmt.Sprintf(format, a...))
+func (l stderrLogger) Actionf(format string, a ...interface{}) {
+	fmt.Fprintln(l.stderr, `►`, fmt.Sprintf(format, a...))
 }
 
-func (l printLogger) Waitingf(format string, a ...interface{}) {
-	fmt.Println(`◎`, fmt.Sprintf(format, a...))
+func (l stderrLogger) Generatef(format string, a ...interface{}) {
+	fmt.Fprintln(l.stderr, `✚`, fmt.Sprintf(format, a...))
 }
 
-func (l printLogger) Successf(format string, a ...interface{}) {
-	fmt.Println(`✔`, fmt.Sprintf(format, a...))
+func (l stderrLogger) Waitingf(format string, a ...interface{}) {
+	fmt.Fprintln(l.stderr, `◎`, fmt.Sprintf(format, a...))
 }
 
-func (l printLogger) Failuref(format string, a ...interface{}) {
-	fmt.Println(`✗`, fmt.Sprintf(format, a...))
+func (l stderrLogger) Successf(format string, a ...interface{}) {
+	fmt.Fprintln(l.stderr, `✔`, fmt.Sprintf(format, a...))
+}
+
+func (l stderrLogger) Failuref(format string, a ...interface{}) {
+	fmt.Fprintln(l.stderr, `✗`, fmt.Sprintf(format, a...))
 }

--- a/cmd/flux/main.go
+++ b/cmd/flux/main.go
@@ -101,7 +101,7 @@ var (
 	timeout      time.Duration
 	verbose      bool
 	pollInterval                = 2 * time.Second
-	logger       fluxlog.Logger = printLogger{}
+	logger       fluxlog.Logger = stderrLogger{stderr: os.Stderr}
 	defaults                    = install.MakeDefaultOptions()
 )
 


### PR DESCRIPTION
This commit refactors the `printLogger` into a `stderrLogger` that
properly logs to `os.stderr` instead of `os.stdout`.

Fixes: #579 