### PR TITLE
Add cluster-domain option for bootstrap command

### DIFF
--- a/cmd/flux/bootstrap.go
+++ b/cmd/flux/bootstrap.go
@@ -59,6 +59,7 @@ var (
 	bootstrapLogLevel           = flags.LogLevel(defaults.LogLevel)
 	bootstrapRequiredComponents = []string{"source-controller", "kustomize-controller"}
 	bootstrapTokenAuth          bool
+	bootstrapClusterDomain      string
 )
 
 const (
@@ -87,6 +88,7 @@ func init() {
 		"when enabled, the personal access token will be used instead of SSH deploy key")
 	bootstrapCmd.PersistentFlags().Var(&bootstrapLogLevel, "log-level", bootstrapLogLevel.Description())
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapManifestsPath, "manifests", "", "path to the manifest directory")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapClusterDomain, "cluster-domain", "cluster.local", "internal cluster domain")
 	bootstrapCmd.PersistentFlags().MarkHidden("manifests")
 	rootCmd.AddCommand(bootstrapCmd)
 }
@@ -121,6 +123,7 @@ func generateInstallManifests(targetPath, namespace, tmpDir string, localManifes
 		ManifestFile:           defaults.ManifestFile,
 		Timeout:                timeout,
 		TargetPath:             targetPath,
+		ClusterDomain:          bootstrapClusterDomain,
 	}
 
 	if localManifests == "" {

--- a/cmd/flux/install.go
+++ b/cmd/flux/install.go
@@ -64,6 +64,7 @@ var (
 	installNetworkPolicy      bool
 	installArch               = flags.Arch(defaults.Arch)
 	installLogLevel           = flags.LogLevel(defaults.LogLevel)
+	installClusterDomain      string
 )
 
 func init() {
@@ -89,6 +90,7 @@ func init() {
 	installCmd.Flags().Var(&installLogLevel, "log-level", installLogLevel.Description())
 	installCmd.Flags().BoolVar(&installNetworkPolicy, "network-policy", defaults.NetworkPolicy,
 		"deny ingress access to the toolkit controllers from other namespaces using network policies")
+	installCmd.Flags().StringVar(&installClusterDomain, "cluster-domain", defaults.ClusterDomain, "internal cluster domain")
 	rootCmd.AddCommand(installCmd)
 }
 

--- a/docs/cmd/flux_bootstrap.md
+++ b/docs/cmd/flux_bootstrap.md
@@ -11,6 +11,7 @@ The bootstrap sub-commands bootstrap the toolkit components on the targeted Git 
 ```
       --arch arch                  cluster architecture, available options are: (amd64, arm, arm64) (default amd64)
       --branch string              default branch (for GitHub this must match the default branch setting for the organization) (default "main")
+      --cluster-domain string      internal cluster domain (default "cluster.local")
       --components strings         list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
       --components-extra strings   list of components in addition to those supplied or defaulted, accepts comma-separated values
   -h, --help                       help for bootstrap

--- a/docs/cmd/flux_bootstrap_github.md
+++ b/docs/cmd/flux_bootstrap_github.md
@@ -63,6 +63,7 @@ flux bootstrap github [flags]
 ```
       --arch arch                  cluster architecture, available options are: (amd64, arm, arm64) (default amd64)
       --branch string              default branch (for GitHub this must match the default branch setting for the organization) (default "main")
+      --cluster-domain string      internal cluster domain (default "cluster.local")
       --components strings         list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
       --components-extra strings   list of components in addition to those supplied or defaulted, accepts comma-separated values
       --context string             kubernetes context to use

--- a/docs/cmd/flux_bootstrap_gitlab.md
+++ b/docs/cmd/flux_bootstrap_gitlab.md
@@ -59,6 +59,7 @@ flux bootstrap gitlab [flags]
 ```
       --arch arch                  cluster architecture, available options are: (amd64, arm, arm64) (default amd64)
       --branch string              default branch (for GitHub this must match the default branch setting for the organization) (default "main")
+      --cluster-domain string      internal cluster domain (default "cluster.local")
       --components strings         list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
       --components-extra strings   list of components in addition to those supplied or defaulted, accepts comma-separated values
       --context string             kubernetes context to use

--- a/docs/cmd/flux_install.md
+++ b/docs/cmd/flux_install.md
@@ -32,6 +32,7 @@ flux install [flags]
 
 ```
       --arch arch                  cluster architecture, available options are: (amd64, arm, arm64) (default amd64)
+      --cluster-domain string      internal cluster domain (default "cluster.local")
       --components strings         list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
       --components-extra strings   list of components in addition to those supplied or defaulted, accepts comma-separated values
       --dry-run                    only print the object that would be applied

--- a/pkg/manifestgen/install/options.go
+++ b/pkg/manifestgen/install/options.go
@@ -34,6 +34,7 @@ type Options struct {
 	ManifestFile           string
 	Timeout                time.Duration
 	TargetPath             string
+	ClusterDomain          string
 }
 
 func MakeDefaultOptions() Options {
@@ -53,6 +54,7 @@ func MakeDefaultOptions() Options {
 		ManifestFile:           "gotk-components.yaml",
 		Timeout:                time.Minute,
 		TargetPath:             "",
+		ClusterDomain:          "cluster.local",
 	}
 }
 

--- a/pkg/manifestgen/install/templates.go
+++ b/pkg/manifestgen/install/templates.go
@@ -30,6 +30,7 @@ var kustomizationTmpl = `---
 {{- $registry := .Registry }}
 {{- $arch := .Arch }}
 {{- $logLevel := .LogLevel }}
+{{- $clusterDomain := .ClusterDomain }}
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: {{.Namespace}}
@@ -67,6 +68,25 @@ patchesJson6902:
     - op: replace
       path: /spec/template/spec/containers/0/args/1
       value: --log-level={{$logLevel}}
+{{- else if eq $component "source-controller" }}
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: {{$component}}
+  patch: |-
+    - op: replace
+      path: /spec/template/spec/containers/0/args/0
+      value: --events-addr={{$eventsAddr}}
+    - op: replace
+      path: /spec/template/spec/containers/0/args/1
+      value: --watch-all-namespaces={{$watchAllNamespaces}}
+    - op: replace
+      path: /spec/template/spec/containers/0/args/2
+      value: --log-level={{$logLevel}}
+    - op: replace
+      path: /spec/template/spec/containers/0/args/6
+      value: --storage-adv-addr=source-controller.$(RUNTIME_NAMESPACE).svc.{{$clusterDomain}}.
 {{- else }}
 - target:
     group: apps


### PR DESCRIPTION
Since https://github.com/fluxcd/source-controller/pull/233 the bootstrap command will use `--storage-adv-addr=source-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.` as default option for the source controller.

But for some users, the cluster domain is not `cluster.local` and this will result in breaking their source controller each time they run the `bootstrap` command (for upgrading their flux instance for example).