### PR TITLE
Make resource selector args case insensitive

### DIFF
--- a/internal/flags/helm_chart_source.go
+++ b/internal/flags/helm_chart_source.go
@@ -20,8 +20,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/fluxcd/flux2/internal/utils"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
+
+	"github.com/fluxcd/flux2/internal/utils"
 )
 
 var supportedHelmChartSourceKinds = []string{sourcev1.HelmRepositoryKind, sourcev1.GitRepositoryKind, sourcev1.BucketKind}
@@ -48,13 +49,14 @@ func (s *HelmChartSource) Set(str string) error {
 	if sourceKind == "" || sourceName == "" {
 		return fmt.Errorf("invalid helm chart source '%s', must be in format <kind>/<name>", str)
 	}
-	if !utils.ContainsItemString(supportedHelmChartSourceKinds, sourceKind) {
+	cleanSourceKind, ok := utils.ContainsEqualFoldItemString(supportedHelmChartSourceKinds, sourceKind)
+	if !ok {
 		return fmt.Errorf("source kind '%s' is not supported, must be one of: %s",
 			sourceKind, strings.Join(supportedHelmChartSourceKinds, ", "))
 	}
 
 	s.Name = sourceName
-	s.Kind = sourceKind
+	s.Kind = cleanSourceKind
 
 	return nil
 }

--- a/internal/flags/helm_chart_source_test.go
+++ b/internal/flags/helm_chart_source_test.go
@@ -31,6 +31,7 @@ func TestHelmChartSource_Set(t *testing.T) {
 		expectErr bool
 	}{
 		{"supported", fmt.Sprintf("%s/foo", sourcev1.HelmRepositoryKind), fmt.Sprintf("%s/foo", sourcev1.HelmRepositoryKind), false},
+		{"lower case kind", "helmrepository/foo", fmt.Sprintf("%s/foo", sourcev1.HelmRepositoryKind), false},
 		{"unsupported", "Unsupported/kind", "", true},
 		{"invalid format", sourcev1.HelmRepositoryKind, "", true},
 		{"missing name", fmt.Sprintf("%s/", sourcev1.HelmRepositoryKind), "", true},

--- a/internal/flags/helm_release_values.go
+++ b/internal/flags/helm_release_values.go
@@ -47,13 +47,14 @@ func (v *HelmReleaseValuesFrom) Set(str string) error {
 	if sourceKind == "" {
 		return fmt.Errorf("invalid Kubernetes object reference '%s', must be in format <kind>/<name>", str)
 	}
-	if !utils.ContainsItemString(supportedHelmReleaseValuesFromKinds, sourceKind) {
+	cleanSourceKind, ok := utils.ContainsEqualFoldItemString(supportedHelmReleaseValuesFromKinds, sourceKind)
+	if !ok {
 		return fmt.Errorf("reference kind '%s' is not supported, must be one of: %s",
 			sourceKind, strings.Join(supportedHelmReleaseValuesFromKinds, ", "))
 	}
 
 	v.Name = sourceName
-	v.Kind = sourceKind
+	v.Kind = cleanSourceKind
 
 	return nil
 }

--- a/internal/flags/helm_release_values_test.go
+++ b/internal/flags/helm_release_values_test.go
@@ -28,6 +28,7 @@ func TestHelmReleaseValuesFrom_Set(t *testing.T) {
 		expectErr bool
 	}{
 		{"supported", "Secret/foo", "Secret/foo", false},
+		{"lower case kind", "secret/foo", "Secret/foo", false},
 		{"unsupported", "Unsupported/kind", "", true},
 		{"invalid format", "Secret", "", true},
 		{"empty", "", "", true},

--- a/internal/flags/kustomization_source.go
+++ b/internal/flags/kustomization_source.go
@@ -20,8 +20,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/fluxcd/flux2/internal/utils"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
+
+	"github.com/fluxcd/flux2/internal/utils"
 )
 
 var supportedKustomizationSourceKinds = []string{sourcev1.GitRepositoryKind, sourcev1.BucketKind}
@@ -54,13 +55,14 @@ func (s *KustomizationSource) Set(str string) error {
 		}
 		sourceKind = sourcev1.GitRepositoryKind
 	}
-	if !utils.ContainsItemString(supportedKustomizationSourceKinds, sourceKind) {
+	cleanSourceKind, ok := utils.ContainsEqualFoldItemString(supportedKustomizationSourceKinds, sourceKind)
+	if !ok {
 		return fmt.Errorf("source kind '%s' is not supported, must be one of: %s",
 			sourceKind, strings.Join(supportedKustomizationSourceKinds, ", "))
 	}
 
 	s.Name = sourceName
-	s.Kind = sourceKind
+	s.Kind = cleanSourceKind
 
 	return nil
 }

--- a/internal/flags/kustomization_source_test.go
+++ b/internal/flags/kustomization_source_test.go
@@ -32,6 +32,7 @@ func TestKustomizationSource_Set(t *testing.T) {
 	}{
 		{"supported", fmt.Sprintf("%s/foo", sourcev1.GitRepositoryKind), fmt.Sprintf("%s/foo", sourcev1.GitRepositoryKind), false},
 		{"default kind", "foo", fmt.Sprintf("%s/foo", sourcev1.GitRepositoryKind), false},
+		{"lower case kind", "gitrepository/foo", fmt.Sprintf("%s/foo", sourcev1.GitRepositoryKind), false},
 		{"unsupported", "Unsupported/kind", "", true},
 		{"missing name", fmt.Sprintf("%s/", sourcev1.GitRepositoryKind), "", true},
 		{"empty", "", "", true},

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -230,6 +230,15 @@ func ContainsItemString(s []string, e string) bool {
 	return false
 }
 
+func ContainsEqualFoldItemString(s []string, e string) (string, bool) {
+	for _, a := range s {
+		if strings.EqualFold(a, e) {
+			return a, true
+		}
+	}
+	return "", false
+}
+
 func ParseObjectKindName(input string) (string, string) {
 	kind := ""
 	name := input


### PR DESCRIPTION
So that `<kind>/<name>` flags can be supplied as:

* `secret/foo`
* `Secret/foo`
* `SeCrEt/foo`

But result in: `Secret/foo`.