### PR TITLE
Add e2e test for flux2-kustomize-helm-example

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -146,6 +146,15 @@ jobs:
             --chart=podinfo \
             --chart-version="5.0.x" \
             --service-account=dev-team
+      - name: flux2-kustomize-helm-example
+        run: |
+          ./bin/flux create source git flux-system \
+          --url=https://github.com/fluxcd/flux2-kustomize-helm-example \
+          --branch=main
+          ./bin/flux create kustomization flux-system \
+          --source=flux-system \
+          --path=./clusters/staging
+          kubectl -n flux-system wait kustomization/apps --for=condition=ready --timeout=2m
       - name: flux check
         run: |
           ./bin/flux check


### PR DESCRIPTION
This PR adds the [flux2-kustomize-helm-example](https://github.com/fluxcd/flux2-kustomize-helm-example) setup to the end-to-end test suite, this covers:

- kustomize overlays mapped to Flux's Kustomizations
- dependsOn relationships between Flux's Kustomizations
- HelmReleases heath checks in Flux's Kustomizations
- HelmReleases with values from ConfigMaps generated with kustomize
- HelmReleases with fixed versions and semver ranges