### PR TITLE
Add note about deploy key linked to pat

### DIFF
--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -102,6 +102,12 @@ The bootstrap command creates a repository if one doesn't exist, and
 commits the manifests for the Flux components to the default branch at the specified path.
 Then it configures the target cluster to synchronize with the specified path inside the repository.
 
+!!! hint "Deploy Key"
+    The bootstrap command creates a ssh key which it stores as a secret in the
+    Kubernetes cluster. The key is also used to create a deploy key in the GitHub
+    repository. The new deploy key will be linked to the personal access token used
+    to authenticate. Removing the personal access token will remove the deploy key.
+
 If you wish to create the repository under a GitHub organization:
 
 ```sh

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -102,12 +102,6 @@ The bootstrap command creates a repository if one doesn't exist, and
 commits the manifests for the Flux components to the default branch at the specified path.
 Then it configures the target cluster to synchronize with the specified path inside the repository.
 
-!!! hint "Deploy Key"
-    The bootstrap command creates a ssh key which it stores as a secret in the
-    Kubernetes cluster. The key is also used to create a deploy key in the GitHub
-    repository. The new deploy key will be linked to the personal access token used
-    to authenticate. Removing the personal access token will remove the deploy key.
-
 If you wish to create the repository under a GitHub organization:
 
 ```sh

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -118,6 +118,12 @@ flux bootstrap github \
   --personal
 ```
 
+!!! hint "Deploy Key"
+    The bootstrap command creates a ssh key which it stores as a secret in the
+    Kubernetes cluster. The key is also used to create a deploy key in the GitHub
+    repository. The new deploy key will be linked to the personal access token used
+    to authenticate. Removing the personal access token will remove the deploy key.
+
 Run the bootstrap for a repository owned by a GitHub organization:
 
 ```sh


### PR DESCRIPTION
Adds a hint regarding the fact that the deploy key created by the bootstrap command is linked to the personal access token used to authenticate. This is important as users must be warned so that they do not just remove their personal access tokens.