### PR TITLE
Set e2e uninstall timeout to 10m

### DIFF
--- a/.github/workflows/bootstrap.yaml
+++ b/.github/workflows/bootstrap.yaml
@@ -49,8 +49,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITPROVIDER_BOT_TOKEN }}
       - name: uninstall
         run: |
-          ./bin/flux suspend kustomization flux-system
-          ./bin/flux uninstall --resources --crds -s
+          ./bin/flux uninstall --resources --crds -s --timeout=10m
       - name: bootstrap reinstall
         run: |
           ./bin/flux bootstrap github --manifests ./manifests/install/ \

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -160,7 +160,7 @@ jobs:
           ./bin/flux check
       - name: flux uninstall
         run: |
-          ./bin/flux uninstall --crds --silent
+          ./bin/flux uninstall --crds --silent --timeout=10m
       - name: Debug failure
         if: failure()
         run: |


### PR DESCRIPTION
Increase timeout for `flux uninstall` to work around GitHub Actions slow workers.