### PR TITLE
Typo fix in image-update documentation 

### DIFF
--- a/docs/guides/image-update.md
+++ b/docs/guides/image-update.md
@@ -217,7 +217,7 @@ podinfo	True 	Latest image tag for 'ghcr.io/stefanprodan/podinfo' resolved to: 5
 
 ## Configure image updates
 
-Edit the `podinfo-deploy.yaml` and add a maker to tell Flux which policy to use when updating the container image:
+Edit the `podinfo-deploy.yaml` and add a marker to tell Flux which policy to use when updating the container image:
 
 ```yaml
 spec:


### PR DESCRIPTION
This is a simple typo fix (maker => marker) in the image update documentation. 

I've stumbled over this and was not sure what a "maker" should be and if its really just the comment in the yaml. Maybe it could also be just simply be named comment? The reader adds a comment which acts as a marker for flux. 