### PR TITLE
Minor fixes to core concepts doc

### DIFF
--- a/docs/core-concepts/index.md
+++ b/docs/core-concepts/index.md
@@ -32,7 +32,7 @@ For more information, take a look at [the source controller documentation](../co
 
 ## Reconciliation
 
-Reconciliation refers to ensuring that a given state(e.g application running in the cluster, infrasatructure) matches a desired state declaratively defined somewhere(e.g a git repository). There are various examples of these in flux e.g:
+Reconciliation refers to ensuring that a given state (e.g application running in the cluster, infrastructure) matches a desired state declaratively defined somewhere (e.g a git repository). There are various examples of these in flux e.g:
 
 - HelmRelease reconciliation: ensures the state of the Helm release matches what is defined in the resource, performs a release if this is not the case (including revision changes of a HelmChart resource).
 - Bucket reconciliation: downloads and archives the contents of the declared bucket on a given interval and stores this as an artifact, records the observed revision of the artifact and the artifact itself in the status of resource.
@@ -40,13 +40,13 @@ Reconciliation refers to ensuring that a given state(e.g application running in 
 
 ## Kustomization
 
-The kustomization represents an local set of Kubernetes resources that Flux is supposed to reconcile in the cluster. The reconciliation every one minute by default but this can be specified in the kustomization. If you make any changes to the cluster using `kubectl edit` or `kubectl patch`, it will be promptly reverted. You either suspend the reconciliation or push your changes to a Git repository.
+The kustomization represents a local set of Kubernetes resources that Flux is supposed to reconcile in the cluster. The reconciliation runs every one minute by default but this can be specified in the kustomization. If you make any changes to the cluster using `kubectl edit` or `kubectl patch`, it will be promptly reverted. You either suspend the reconciliation or push your changes to a Git repository.
 
 For more information, take a look at [this documentation](../components/kustomize/kustomization.md).
 
 ## Bootstrap
 
-The process of installing the Flux components in a complete GitOps way is called a bootstrap. The manifests are applied to the cluster, a `GitRepository` and `Kustomization` are created for the Flux components, and the manifests are pushed to an existing Git repository(or a new one is created). Flux can manage itself just as it manages other resources. 
+The process of installing the Flux components in a complete GitOps way is called a bootstrap. The manifests are applied to the cluster, a `GitRepository` and `Kustomization` are created for the Flux components, and the manifests are pushed to an existing Git repository (or a new one is created). Flux can manage itself just as it manages other resources. 
 The bootstrap is done using the `flux` CLI `flux bootstrap`.
 
 For more information, take a look at [the documentation for the bootstrap command](../cmd/flux_bootstrap.md).


### PR DESCRIPTION
Fix small typo, added verb to make the intent clear, added spaces before "(" to match the same pattern used in other parts of the docs