### PR TITLE
Add create secret helm command

### DIFF
--- a/cmd/flux/create_secret_git.go
+++ b/cmd/flux/create_secret_git.go
@@ -55,7 +55,7 @@ For Git over HTTP/S, the provided basic authentication credentials are stored in
   # Create a Git SSH secret on disk and print the deploy key
   flux create secret git podinfo-auth \
     --url=ssh://git@github.com/stefanprodan/podinfo \
-	--export > podinfo-auth.yaml
+    --export > podinfo-auth.yaml
 
   yq read podinfo-auth.yaml 'data."identity.pub"' | base64 --decode
 
@@ -63,7 +63,7 @@ For Git over HTTP/S, the provided basic authentication credentials are stored in
   flux create secret git podinfo-auth \
     --namespace=apps \
     --url=ssh://git@github.com/stefanprodan/podinfo \
-	--export > podinfo-auth.yaml
+    --export > podinfo-auth.yaml
 
   sops --encrypt --encrypted-regex '^(data|stringData)$' \
     --in-place podinfo-auth.yaml

--- a/cmd/flux/create_secret_helm.go
+++ b/cmd/flux/create_secret_helm.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2021 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/fluxcd/flux2/internal/utils"
+)
+
+var createSecretHelmCmd = &cobra.Command{
+	Use:   "helm [name]",
+	Short: "Create or update a Kubernetes secret for Helm repository authentication",
+	Long: `
+The create secret helm command generates a Kubernetes secret with basic authentication credentials.`,
+	Example: `    # Create a Helm authentication secret on disk and encrypt it with Mozilla SOPS
+
+  flux create secret helm repo-auth \
+    --namespace=my-namespace \
+    --username=my-username \
+    --password=my-password \
+    --export > repo-auth.yaml
+
+  sops --encrypt --encrypted-regex '^(data|stringData)$' \
+    --in-place repo-auth.yaml
+
+  # Create an authentication secret using a custom TLS cert
+  flux create secret helm repo-auth \
+    --username=username \
+    --password=password \
+    --cert-file=./cert.crt \
+    --key-file=./key.crt \
+    --ca-file=./ca.crt
+`,
+	RunE: createSecretHelmCmdRun,
+}
+
+var (
+	secretHelmUsername string
+	secretHelmPassword string
+	secretHelmCertFile string
+	secretHelmKeyFile  string
+	secretHelmCAFile   string
+)
+
+func init() {
+	createSecretHelmCmd.Flags().StringVarP(&secretHelmUsername, "username", "u", "", "basic authentication username")
+	createSecretHelmCmd.Flags().StringVarP(&secretHelmPassword, "password", "p", "", "basic authentication password")
+	createSecretHelmCmd.Flags().StringVar(&secretHelmCertFile, "cert-file", "", "TLS authentication cert file path")
+	createSecretHelmCmd.Flags().StringVar(&secretHelmKeyFile, "key-file", "", "TLS authentication key file path")
+	createSecretHelmCmd.Flags().StringVar(&secretHelmCAFile, "ca-file", "", "TLS authentication CA file path")
+
+	createSecretCmd.AddCommand(createSecretHelmCmd)
+}
+
+func createSecretHelmCmdRun(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("secret name is required")
+	}
+	name := args[0]
+
+	secretLabels, err := parseLabels()
+	if err != nil {
+		return err
+	}
+
+	secret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    secretLabels,
+		},
+		StringData: map[string]string{},
+	}
+
+	if secretHelmUsername != "" && secretHelmPassword != "" {
+		secret.StringData["username"] = secretHelmUsername
+		secret.StringData["password"] = secretHelmPassword
+	}
+
+	if secretHelmCertFile != "" && secretHelmKeyFile != "" {
+		cert, err := ioutil.ReadFile(secretHelmCertFile)
+		if err != nil {
+			return fmt.Errorf("failed to read repository cert file '%s': %w", secretHelmCertFile, err)
+		}
+		secret.StringData["certFile"] = string(cert)
+
+		key, err := ioutil.ReadFile(secretHelmKeyFile)
+		if err != nil {
+			return fmt.Errorf("failed to read repository key file '%s': %w", secretHelmKeyFile, err)
+		}
+		secret.StringData["keyFile"] = string(key)
+	}
+
+	if secretHelmCAFile != "" {
+		ca, err := ioutil.ReadFile(secretHelmCAFile)
+		if err != nil {
+			return fmt.Errorf("failed to read repository CA file '%s': %w", secretHelmCAFile, err)
+		}
+		secret.StringData["caFile"] = string(ca)
+	}
+
+	if export {
+		return exportSecret(secret)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	kubeClient, err := utils.KubeClient(kubeconfig, kubecontext)
+	if err != nil {
+		return err
+	}
+
+	if err := upsertSecret(ctx, kubeClient, secret); err != nil {
+		return err
+	}
+	logger.Actionf("secret '%s' created in '%s' namespace", name, namespace)
+
+	return nil
+}

--- a/docs/cmd/flux_create_secret.md
+++ b/docs/cmd/flux_create_secret.md
@@ -29,4 +29,5 @@ The create source sub-commands generate Kubernetes secrets specific to Flux.
 
 * [flux create](flux_create.md)	 - Create or update sources and resources
 * [flux create secret git](flux_create_secret_git.md)	 - Create or update a Kubernetes secret for Git authentication
+* [flux create secret helm](flux_create_secret_helm.md)	 - Create or update a Kubernetes secret for Helm repository authentication
 

--- a/docs/cmd/flux_create_secret_git.md
+++ b/docs/cmd/flux_create_secret_git.md
@@ -32,7 +32,7 @@ flux create secret git [name] [flags]
   # Create a Git SSH secret on disk and print the deploy key
   flux create secret git podinfo-auth \
     --url=ssh://git@github.com/stefanprodan/podinfo \
-	--export > podinfo-auth.yaml
+    --export > podinfo-auth.yaml
 
   yq read podinfo-auth.yaml 'data."identity.pub"' | base64 --decode
 
@@ -40,7 +40,7 @@ flux create secret git [name] [flags]
   flux create secret git podinfo-auth \
     --namespace=apps \
     --url=ssh://git@github.com/stefanprodan/podinfo \
-	--export > podinfo-auth.yaml
+    --export > podinfo-auth.yaml
 
   sops --encrypt --encrypted-regex '^(data|stringData)$' \
     --in-place podinfo-auth.yaml

--- a/docs/cmd/flux_create_secret_helm.md
+++ b/docs/cmd/flux_create_secret_helm.md
@@ -1,0 +1,65 @@
+## flux create secret helm
+
+Create or update a Kubernetes secret for Helm repository authentication
+
+### Synopsis
+
+
+The create secret helm command generates a Kubernetes secret with basic authentication credentials.
+
+```
+flux create secret helm [name] [flags]
+```
+
+### Examples
+
+```
+    # Create a Helm authentication secret on disk and encrypt it with Mozilla SOPS
+
+  flux create secret helm repo-auth \
+    --namespace=my-namespace \
+    --username=my-username \
+    --password=my-password \
+    --export > repo-auth.yaml
+
+  sops --encrypt --encrypted-regex '^(data|stringData)$' \
+    --in-place repo-auth.yaml
+
+  # Create an authentication secret using a custom TLS cert
+  flux create secret helm repo-auth \
+    --username=username \
+    --password=password \
+    --cert-file=./cert.crt \
+    --key-file=./key.crt \
+    --ca-file=./ca.crt
+
+```
+
+### Options
+
+```
+      --ca-file string     TLS authentication CA file path
+      --cert-file string   TLS authentication cert file path
+  -h, --help               help for helm
+      --key-file string    TLS authentication key file path
+  -p, --password string    basic authentication password
+  -u, --username string    basic authentication username
+```
+
+### Options inherited from parent commands
+
+```
+      --context string      kubernetes context to use
+      --export              export in YAML format to stdout
+      --interval duration   source sync interval (default 1m0s)
+      --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
+      --label strings       set labels on the resource (can specify multiple labels with commas: label1=value1,label2=value2)
+  -n, --namespace string    the namespace scope for this operation (default "flux-system")
+      --timeout duration    timeout for this operation (default 5m0s)
+      --verbose             print generated objects
+```
+
+### SEE ALSO
+
+* [flux create secret](flux_create_secret.md)	 - Create or update Kubernetes secrets
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
     - Create tenant: cmd/flux_create_tenant.md
     - Create secret: cmd/flux_create_secret.md
     - Create secret git: cmd/flux_create_secret_git.md
+    - Create secret helm: cmd/flux_create_secret_helm.md
     - Delete: cmd/flux_delete.md
     - Delete kustomization: cmd/flux_delete_kustomization.md
     - Delete helmrelease: cmd/flux_delete_helmrelease.md


### PR DESCRIPTION
This PRs adds a new command that can be used to generate Helm repository auth secrets.

Example of creating a Helm authentication secret on disk and encrypting it with Mozilla SOPS:

```sh
  flux create secret helm repo-auth \
    --namespace=my-namespace \
    --username=my-username \
    --password=my-password \
    --cert-file=./cert.crt \
    --key-file=./key.crt \
    --ca-file=./ca.crt \
    --export > repo-auth.yaml

  sops --encrypt --encrypted-regex '^(data|stringData)$' \
    --in-place repo-auth.yaml

  flux create source helm my-repo \
    --namespace=my-namespace \
    --interval=10m \
    --url=https://my-repo \
    --secret-ref=repo-auth
```