### PR TITLE
Configure `project_name` for GoReleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+project_name: flux
 builds:
   - <<: &build_defaults
       binary: flux


### PR DESCRIPTION
This causes the format of the checksum file generated during the release
to change from `flux2_*_checksums.txt` to `flux_*_checksums.txt`.

The configuration change is made through `project_name` and not via the
`checksum.name_template` setting, because a single checksum file is
generated during the release process.

The download and/or installation script in `install/flux.sh` has been
adapted to assume the new filename starting with MINOR version `0.6.0`.