### PR TITLE
Fix Azure DevOps URL in docs

### DIFF
--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -320,7 +320,7 @@ If you don't specify the SSH algorithm, then `flux` will generate an RSA 2048 bi
     ```sh
     flux create source git flux-system \
       --git-implementation=libgit2 \
-      --url=git@ssh.dev.azure.com/v3/org/project/repository \
+      --url=ssh://git@ssh.dev.azure.com/v3/org/project/repository \
       --branch=master \
       --interval=1m
     ```


### PR DESCRIPTION
Fix: https://github.com/fluxcd/source-controller/issues/253