### PR TITLE
Deprecate arch flags in favor of multi-arch images

### DIFF
--- a/cmd/flux/bootstrap.go
+++ b/cmd/flux/bootstrap.go
@@ -55,7 +55,7 @@ var (
 	bootstrapWatchAllNamespaces bool
 	bootstrapNetworkPolicy      bool
 	bootstrapManifestsPath      string
-	bootstrapArch               = flags.Arch(defaults.Arch)
+	bootstrapArch               flags.Arch
 	bootstrapLogLevel           = flags.LogLevel(defaults.LogLevel)
 	bootstrapRequiredComponents = []string{"source-controller", "kustomize-controller"}
 	bootstrapTokenAuth          bool
@@ -90,6 +90,7 @@ func init() {
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapManifestsPath, "manifests", "", "path to the manifest directory")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapClusterDomain, "cluster-domain", defaults.ClusterDomain, "internal cluster domain")
 	bootstrapCmd.PersistentFlags().MarkHidden("manifests")
+	bootstrapCmd.PersistentFlags().MarkDeprecated("arch", "multi-arch container image is now available for AMD64, ARMv7 and ARM64")
 	rootCmd.AddCommand(bootstrapCmd)
 }
 
@@ -120,7 +121,6 @@ func generateInstallManifests(targetPath, namespace, tmpDir string, localManifes
 		Components:             bootstrapComponents(),
 		Registry:               bootstrapRegistry,
 		ImagePullSecret:        bootstrapImagePullSecret,
-		Arch:                   bootstrapArch.String(),
 		WatchAllNamespaces:     bootstrapWatchAllNamespaces,
 		NetworkPolicy:          bootstrapNetworkPolicy,
 		LogLevel:               bootstrapLogLevel.String(),

--- a/cmd/flux/install.go
+++ b/cmd/flux/install.go
@@ -62,7 +62,7 @@ var (
 	installImagePullSecret    string
 	installWatchAllNamespaces bool
 	installNetworkPolicy      bool
-	installArch               = flags.Arch(defaults.Arch)
+	installArch               flags.Arch
 	installLogLevel           = flags.LogLevel(defaults.LogLevel)
 	installClusterDomain      string
 )
@@ -79,7 +79,6 @@ func init() {
 	installCmd.Flags().StringSliceVar(&installExtraComponents, "components-extra", nil,
 		"list of components in addition to those supplied or defaulted, accepts comma-separated values")
 	installCmd.Flags().StringVar(&installManifestsPath, "manifests", "", "path to the manifest directory")
-	installCmd.Flags().MarkHidden("manifests")
 	installCmd.Flags().StringVar(&installRegistry, "registry", defaults.Registry,
 		"container registry where the toolkit images are published")
 	installCmd.Flags().StringVar(&installImagePullSecret, "image-pull-secret", "",
@@ -91,6 +90,8 @@ func init() {
 	installCmd.Flags().BoolVar(&installNetworkPolicy, "network-policy", defaults.NetworkPolicy,
 		"deny ingress access to the toolkit controllers from other namespaces using network policies")
 	installCmd.Flags().StringVar(&installClusterDomain, "cluster-domain", defaults.ClusterDomain, "internal cluster domain")
+	installCmd.Flags().MarkHidden("manifests")
+	installCmd.Flags().MarkDeprecated("arch", "multi-arch container image is now available for AMD64, ARMv7 and ARM64")
 	rootCmd.AddCommand(installCmd)
 }
 
@@ -121,7 +122,6 @@ func installCmdRun(cmd *cobra.Command, args []string) error {
 		Components:             components,
 		Registry:               installRegistry,
 		ImagePullSecret:        installImagePullSecret,
-		Arch:                   installArch.String(),
 		WatchAllNamespaces:     installWatchAllNamespaces,
 		NetworkPolicy:          installNetworkPolicy,
 		LogLevel:               installLogLevel.String(),

--- a/docs/cmd/flux_bootstrap.md
+++ b/docs/cmd/flux_bootstrap.md
@@ -9,7 +9,6 @@ The bootstrap sub-commands bootstrap the toolkit components on the targeted Git 
 ### Options
 
 ```
-      --arch arch                  cluster architecture, available options are: (amd64, arm, arm64) (default amd64)
       --branch string              default branch (for GitHub this must match the default branch setting for the organization) (default "main")
       --cluster-domain string      internal cluster domain (default "cluster.local")
       --components strings         list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])

--- a/docs/cmd/flux_bootstrap_github.md
+++ b/docs/cmd/flux_bootstrap_github.md
@@ -61,7 +61,6 @@ flux bootstrap github [flags]
 ### Options inherited from parent commands
 
 ```
-      --arch arch                  cluster architecture, available options are: (amd64, arm, arm64) (default amd64)
       --branch string              default branch (for GitHub this must match the default branch setting for the organization) (default "main")
       --cluster-domain string      internal cluster domain (default "cluster.local")
       --components strings         list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])

--- a/docs/cmd/flux_bootstrap_gitlab.md
+++ b/docs/cmd/flux_bootstrap_gitlab.md
@@ -57,7 +57,6 @@ flux bootstrap gitlab [flags]
 ### Options inherited from parent commands
 
 ```
-      --arch arch                  cluster architecture, available options are: (amd64, arm, arm64) (default amd64)
       --branch string              default branch (for GitHub this must match the default branch setting for the organization) (default "main")
       --cluster-domain string      internal cluster domain (default "cluster.local")
       --components strings         list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])

--- a/docs/cmd/flux_install.md
+++ b/docs/cmd/flux_install.md
@@ -31,7 +31,6 @@ flux install [flags]
 ### Options
 
 ```
-      --arch arch                  cluster architecture, available options are: (amd64, arm, arm64) (default amd64)
       --cluster-domain string      internal cluster domain (default "cluster.local")
       --components strings         list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
       --components-extra strings   list of components in addition to those supplied or defaulted, accepts comma-separated values

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -92,10 +92,10 @@ flux bootstrap github \
   --personal
 ```
 
-!!! hint "ARM"
-    When deploying to a Kubernetes cluster with ARM architecture,
-    you can use `--arch=arm` for ARMv7 32-bit container images
-    and `--arch=arm64` for ARMv8 64-bit container images.
+!!! hint "Multi-arch images"
+The component images are published as [multi-arch container images](https://docs.docker.com/docker-for-mac/multi-arch/)
+with support for Linux `amd64`, `arm64` and `armv7` (e.g. 32bit Raspberry Pi)
+architectures.
 
 The bootstrap command creates a repository if one doesn't exist,
 commits the manifests for the Flux components to the default branch at the specified path,

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -62,10 +62,10 @@ flux bootstrap <GIT-PROVIDER> \
   --version=latest
 ```
 
-!!! hint "ARM"
-    When deploying to a Kubernetes cluster with ARM architecture,
-    you can use `--arch=arm` for ARMv7 32-bit container images
-    and `--arch=arm64` for ARMv8 64-bit container images.
+!!! hint "Multi-arch images"
+The component images are published as [multi-arch container images](https://docs.docker.com/docker-for-mac/multi-arch/)
+with support for Linux `amd64`, `arm64` and `armv7` (e.g. 32bit Raspberry Pi)
+architectures.
 
 If you wish to install a specific version, use the Flux
 [release tag](https://github.com/fluxcd/flux2/releases) e.g. `--version=v0.2.0`.

--- a/pkg/manifestgen/install/options.go
+++ b/pkg/manifestgen/install/options.go
@@ -27,7 +27,6 @@ type Options struct {
 	EventsAddr             string
 	Registry               string
 	ImagePullSecret        string
-	Arch                   string
 	WatchAllNamespaces     bool
 	NetworkPolicy          bool
 	LogLevel               string
@@ -47,7 +46,6 @@ func MakeDefaultOptions() Options {
 		EventsAddr:             "",
 		Registry:               "ghcr.io/fluxcd",
 		ImagePullSecret:        "",
-		Arch:                   "amd64",
 		WatchAllNamespaces:     true,
 		NetworkPolicy:          true,
 		LogLevel:               "info",

--- a/pkg/manifestgen/install/templates.go
+++ b/pkg/manifestgen/install/templates.go
@@ -28,7 +28,6 @@ var kustomizationTmpl = `---
 {{- $eventsAddr := .EventsAddr }}
 {{- $watchAllNamespaces := .WatchAllNamespaces }}
 {{- $registry := .Registry }}
-{{- $arch := .Arch }}
 {{- $logLevel := .LogLevel }}
 {{- $clusterDomain := .ClusterDomain }}
 apiVersion: kustomize.config.k8s.io/v1beta1
@@ -110,11 +109,7 @@ patchesJson6902:
 images:
 {{- range $i, $component := .Components }}
   - name: fluxcd/{{$component}}
-{{- if eq $arch "amd64" }}
     newName: {{$registry}}/{{$component}}
-{{- else }}
-    newName: {{$registry}}/{{$component}}-arm64
-{{- end }}
 {{- end }}
 {{- end }}
 `
@@ -136,7 +131,6 @@ spec:
   template:
     spec:
       nodeSelector:
-        kubernetes.io/arch: {{.Arch}}
         kubernetes.io/os: linux
 {{- if .ImagePullSecret }}
       imagePullSecrets:


### PR DESCRIPTION
This commit deprecates the architecture flag (`--arch`) for the install
and bootstrap commands, in favor of the bundled multi-arch images that
will be available for the next MINOR range of GOTK controller releases.

Summary of changes:

* `*Arch` variables have been marked as deprecated for both commands.
* `-arm64` suffix is no longer selectively added to the image definition
  of a component's `Deployment`.
* `kubernetes.io/arch` node selector with the defined value has been
  removed from the components' `Deployment`s.
* `Arch` has been removed from the available `Options` in
  `manifestgen/install`.
* Documentation references have been changed to highlight existence
  of multi-arch images and supported architectures.

Fixes: https://github.com/fluxcd/flux2/issues/493