### PR TITLE
Add git implementation to generate sync options

### DIFF
--- a/cmd/flux/bootstrap.go
+++ b/cmd/flux/bootstrap.go
@@ -164,13 +164,14 @@ func applyInstallManifests(ctx context.Context, manifestPath string, components 
 
 func generateSyncManifests(url, branch, name, namespace, targetPath, tmpDir string, interval time.Duration) (string, error) {
 	opts := sync.Options{
-		Name:         name,
-		Namespace:    namespace,
-		URL:          url,
-		Branch:       branch,
-		Interval:     interval,
-		TargetPath:   targetPath,
-		ManifestFile: sync.MakeDefaultOptions().ManifestFile,
+		Name:              name,
+		Namespace:         namespace,
+		URL:               url,
+		Branch:            branch,
+		Interval:          interval,
+		TargetPath:        targetPath,
+		ManifestFile:      sync.MakeDefaultOptions().ManifestFile,
+		GitImplementation: sync.MakeDefaultOptions().GitImplementation,
 	}
 
 	manifest, err := sync.Generate(opts)

--- a/cmd/flux/bootstrap_github.go
+++ b/cmd/flux/bootstrap_github.go
@@ -57,7 +57,7 @@ the bootstrap command will perform an upgrade if needed.`,
   flux bootstrap github --owner=<organization> --repository=<repo name> --path=dev-cluster
 
   # Run bootstrap for a public repository on a personal account
-  flux bootstrap github --owner=<user> --repository=<repo name> --private=false --personal=true 
+  flux bootstrap github --owner=<user> --repository=<repo name> --private=false --personal=true
 
   # Run bootstrap for a private repo hosted on GitHub Enterprise using SSH auth
   flux bootstrap github --owner=<organization> --repository=<repo name> --hostname=<domain> --ssh-hostname=<domain>

--- a/cmd/flux/bootstrap_gitlab.go
+++ b/cmd/flux/bootstrap_gitlab.go
@@ -48,7 +48,7 @@ the bootstrap command will perform an upgrade if needed.`,
 	Example: `  # Create a GitLab API token and export it as an env var
   export GITLAB_TOKEN=<my-token>
 
-  # Run bootstrap for a private repo using HTTPS token authentication 
+  # Run bootstrap for a private repo using HTTPS token authentication
   flux bootstrap gitlab --owner=<group> --repository=<repo name> --token-auth
 
   # Run bootstrap for a private repo using SSH authentication
@@ -60,7 +60,7 @@ the bootstrap command will perform an upgrade if needed.`,
   # Run bootstrap for a public repository on a personal account
   flux bootstrap gitlab --owner=<user> --repository=<repo name> --private=false --personal --token-auth
 
-  # Run bootstrap for a private repo hosted on a GitLab server 
+  # Run bootstrap for a private repo hosted on a GitLab server
   flux bootstrap gitlab --owner=<group> --repository=<repo name> --hostname=<domain> --token-auth
 
   # Run bootstrap for a an existing repository with a branch named main

--- a/docs/cmd/flux_bootstrap_github.md
+++ b/docs/cmd/flux_bootstrap_github.md
@@ -30,7 +30,7 @@ flux bootstrap github [flags]
   flux bootstrap github --owner=<organization> --repository=<repo name> --path=dev-cluster
 
   # Run bootstrap for a public repository on a personal account
-  flux bootstrap github --owner=<user> --repository=<repo name> --private=false --personal=true 
+  flux bootstrap github --owner=<user> --repository=<repo name> --private=false --personal=true
 
   # Run bootstrap for a private repo hosted on GitHub Enterprise using SSH auth
   flux bootstrap github --owner=<organization> --repository=<repo name> --hostname=<domain> --ssh-hostname=<domain>

--- a/docs/cmd/flux_bootstrap_gitlab.md
+++ b/docs/cmd/flux_bootstrap_gitlab.md
@@ -20,7 +20,7 @@ flux bootstrap gitlab [flags]
   # Create a GitLab API token and export it as an env var
   export GITLAB_TOKEN=<my-token>
 
-  # Run bootstrap for a private repo using HTTPS token authentication 
+  # Run bootstrap for a private repo using HTTPS token authentication
   flux bootstrap gitlab --owner=<group> --repository=<repo name> --token-auth
 
   # Run bootstrap for a private repo using SSH authentication
@@ -32,7 +32,7 @@ flux bootstrap gitlab [flags]
   # Run bootstrap for a public repository on a personal account
   flux bootstrap gitlab --owner=<user> --repository=<repo name> --private=false --personal --token-auth
 
-  # Run bootstrap for a private repo hosted on a GitLab server 
+  # Run bootstrap for a private repo hosted on a GitLab server
   flux bootstrap gitlab --owner=<group> --repository=<repo name> --hostname=<domain> --token-auth
 
   # Run bootstrap for a an existing repository with a branch named main

--- a/pkg/manifestgen/sync/options.go
+++ b/pkg/manifestgen/sync/options.go
@@ -19,23 +19,25 @@ package sync
 import "time"
 
 type Options struct {
-	Interval     time.Duration
-	URL          string
-	Name         string
-	Namespace    string
-	Branch       string
-	TargetPath   string
-	ManifestFile string
+	Interval          time.Duration
+	URL               string
+	Name              string
+	Namespace         string
+	Branch            string
+	TargetPath        string
+	ManifestFile      string
+	GitImplementation string
 }
 
 func MakeDefaultOptions() Options {
 	return Options{
-		Interval:     1 * time.Minute,
-		URL:          "",
-		Name:         "flux-system",
-		Namespace:    "flux-system",
-		Branch:       "main",
-		ManifestFile: "gotk-sync.yaml",
-		TargetPath:   "",
+		Interval:          1 * time.Minute,
+		URL:               "",
+		Name:              "flux-system",
+		Namespace:         "flux-system",
+		Branch:            "main",
+		ManifestFile:      "gotk-sync.yaml",
+		TargetPath:        "",
+		GitImplementation: "go-git",
 	}
 }

--- a/pkg/manifestgen/sync/options.go
+++ b/pkg/manifestgen/sync/options.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package sync
 
-import "time"
+import (
+	"time"
+
+	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
+)
 
 type Options struct {
 	Interval          time.Duration
@@ -38,6 +42,6 @@ func MakeDefaultOptions() Options {
 		Branch:            "main",
 		ManifestFile:      "gotk-sync.yaml",
 		TargetPath:        "",
-		GitImplementation: "go-git",
+		GitImplementation: sourcev1.GoGitImplementation,
 	}
 }

--- a/pkg/manifestgen/sync/sync.go
+++ b/pkg/manifestgen/sync/sync.go
@@ -55,6 +55,7 @@ func Generate(options Options) (*manifestgen.Manifest, error) {
 			SecretRef: &corev1.LocalObjectReference{
 				Name: options.Name,
 			},
+			GitImplementation: options.GitImplementation,
 		},
 	}
 


### PR DESCRIPTION
Add git implementations to options. I don't think it is pertinent to add this as a flag to the GitHub or GitLab bootstrap commands as they will probably not be used. I guess we should reconsider if we add self signed cert support which would only work in libgit2.