### PR TITLE
Allow egress traffic for controller pods

### DIFF
--- a/manifests/policies/deny-ingress.yaml
+++ b/manifests/policies/deny-ingress.yaml
@@ -5,7 +5,10 @@ metadata:
 spec:
   policyTypes:
     - Ingress
+    - Egress
   ingress:
   - from:
     - podSelector: {}
+  egress:
+    - {}
   podSelector: {}


### PR DESCRIPTION
Seems that AKS network policy addon blocks pod-to-pod communication by default, even if the pods are in the same namespace, this PR enabled egress traffic for Flux controller pods allowing kustomize/helm controllers to fetch artifacts from source-controller.

Fix: #703, #697, #690 