### PR TITLE
Use reconcile request annotation

### DIFF
--- a/cmd/flux/reconcile.go
+++ b/cmd/flux/reconcile.go
@@ -131,10 +131,10 @@ func requestReconciliation(ctx context.Context, kubeClient client.Client,
 		}
 		if ann := obj.GetAnnotations(); ann == nil {
 			obj.SetAnnotations(map[string]string{
-				meta.ReconcileAtAnnotation: time.Now().Format(time.RFC3339Nano),
+				meta.ReconcileRequestAnnotation: time.Now().Format(time.RFC3339Nano),
 			})
 		} else {
-			ann[meta.ReconcileAtAnnotation] = time.Now().Format(time.RFC3339Nano)
+			ann[meta.ReconcileRequestAnnotation] = time.Now().Format(time.RFC3339Nano)
 			obj.SetAnnotations(ann)
 		}
 		return kubeClient.Update(ctx, obj.asClientObject())

--- a/cmd/flux/reconcile_alert.go
+++ b/cmd/flux/reconcile_alert.go
@@ -77,10 +77,10 @@ func reconcileAlertCmdRun(cmd *cobra.Command, args []string) error {
 	logger.Actionf("annotating Alert %s in %s namespace", name, namespace)
 	if alert.Annotations == nil {
 		alert.Annotations = map[string]string{
-			meta.ReconcileAtAnnotation: time.Now().Format(time.RFC3339Nano),
+			meta.ReconcileRequestAnnotation: time.Now().Format(time.RFC3339Nano),
 		}
 	} else {
-		alert.Annotations[meta.ReconcileAtAnnotation] = time.Now().Format(time.RFC3339Nano)
+		alert.Annotations[meta.ReconcileRequestAnnotation] = time.Now().Format(time.RFC3339Nano)
 	}
 
 	if err := kubeClient.Update(ctx, &alert); err != nil {

--- a/cmd/flux/reconcile_alertprovider.go
+++ b/cmd/flux/reconcile_alertprovider.go
@@ -73,10 +73,10 @@ func reconcileAlertProviderCmdRun(cmd *cobra.Command, args []string) error {
 
 	if alertProvider.Annotations == nil {
 		alertProvider.Annotations = map[string]string{
-			meta.ReconcileAtAnnotation: time.Now().Format(time.RFC3339Nano),
+			meta.ReconcileRequestAnnotation: time.Now().Format(time.RFC3339Nano),
 		}
 	} else {
-		alertProvider.Annotations[meta.ReconcileAtAnnotation] = time.Now().Format(time.RFC3339Nano)
+		alertProvider.Annotations[meta.ReconcileRequestAnnotation] = time.Now().Format(time.RFC3339Nano)
 	}
 	if err := kubeClient.Update(ctx, &alertProvider); err != nil {
 		return err

--- a/cmd/flux/reconcile_helmrelease.go
+++ b/cmd/flux/reconcile_helmrelease.go
@@ -153,10 +153,10 @@ func requestHelmReleaseReconciliation(ctx context.Context, kubeClient client.Cli
 		}
 		if helmRelease.Annotations == nil {
 			helmRelease.Annotations = map[string]string{
-				meta.ReconcileAtAnnotation: time.Now().Format(time.RFC3339Nano),
+				meta.ReconcileRequestAnnotation: time.Now().Format(time.RFC3339Nano),
 			}
 		} else {
-			helmRelease.Annotations[meta.ReconcileAtAnnotation] = time.Now().Format(time.RFC3339Nano)
+			helmRelease.Annotations[meta.ReconcileRequestAnnotation] = time.Now().Format(time.RFC3339Nano)
 		}
 		return kubeClient.Update(ctx, helmRelease)
 	})

--- a/cmd/flux/reconcile_kustomization.go
+++ b/cmd/flux/reconcile_kustomization.go
@@ -142,10 +142,10 @@ func requestKustomizeReconciliation(ctx context.Context, kubeClient client.Clien
 		}
 		if kustomization.Annotations == nil {
 			kustomization.Annotations = map[string]string{
-				meta.ReconcileAtAnnotation: time.Now().Format(time.RFC3339Nano),
+				meta.ReconcileRequestAnnotation: time.Now().Format(time.RFC3339Nano),
 			}
 		} else {
-			kustomization.Annotations[meta.ReconcileAtAnnotation] = time.Now().Format(time.RFC3339Nano)
+			kustomization.Annotations[meta.ReconcileRequestAnnotation] = time.Now().Format(time.RFC3339Nano)
 		}
 		return kubeClient.Update(ctx, kustomization)
 	})

--- a/cmd/flux/reconcile_receiver.go
+++ b/cmd/flux/reconcile_receiver.go
@@ -77,10 +77,10 @@ func reconcileReceiverCmdRun(cmd *cobra.Command, args []string) error {
 	logger.Actionf("annotating Receiver %s in %s namespace", name, namespace)
 	if receiver.Annotations == nil {
 		receiver.Annotations = map[string]string{
-			meta.ReconcileAtAnnotation: time.Now().Format(time.RFC3339Nano),
+			meta.ReconcileRequestAnnotation: time.Now().Format(time.RFC3339Nano),
 		}
 	} else {
-		receiver.Annotations[meta.ReconcileAtAnnotation] = time.Now().Format(time.RFC3339Nano)
+		receiver.Annotations[meta.ReconcileRequestAnnotation] = time.Now().Format(time.RFC3339Nano)
 	}
 	if err := kubeClient.Update(ctx, &receiver); err != nil {
 		return err

--- a/cmd/flux/reconcile_source_bucket.go
+++ b/cmd/flux/reconcile_source_bucket.go
@@ -145,10 +145,10 @@ func requestBucketReconciliation(ctx context.Context, kubeClient client.Client,
 		}
 		if bucket.Annotations == nil {
 			bucket.Annotations = map[string]string{
-				meta.ReconcileAtAnnotation: time.Now().Format(time.RFC3339Nano),
+				meta.ReconcileRequestAnnotation: time.Now().Format(time.RFC3339Nano),
 			}
 		} else {
-			bucket.Annotations[meta.ReconcileAtAnnotation] = time.Now().Format(time.RFC3339Nano)
+			bucket.Annotations[meta.ReconcileRequestAnnotation] = time.Now().Format(time.RFC3339Nano)
 		}
 		return kubeClient.Update(ctx, bucket)
 	})

--- a/cmd/flux/reconcile_source_git.go
+++ b/cmd/flux/reconcile_source_git.go
@@ -116,10 +116,10 @@ func requestGitRepositoryReconciliation(ctx context.Context, kubeClient client.C
 		}
 		if repository.Annotations == nil {
 			repository.Annotations = map[string]string{
-				meta.ReconcileAtAnnotation: time.Now().Format(time.RFC3339Nano),
+				meta.ReconcileRequestAnnotation: time.Now().Format(time.RFC3339Nano),
 			}
 		} else {
-			repository.Annotations[meta.ReconcileAtAnnotation] = time.Now().Format(time.RFC3339Nano)
+			repository.Annotations[meta.ReconcileRequestAnnotation] = time.Now().Format(time.RFC3339Nano)
 		}
 		return kubeClient.Update(ctx, repository)
 	})

--- a/cmd/flux/reconcile_source_helm.go
+++ b/cmd/flux/reconcile_source_helm.go
@@ -117,10 +117,10 @@ func requestHelmRepositoryReconciliation(ctx context.Context, kubeClient client.
 		}
 		if repository.Annotations == nil {
 			repository.Annotations = map[string]string{
-				meta.ReconcileAtAnnotation: time.Now().Format(time.RFC3339Nano),
+				meta.ReconcileRequestAnnotation: time.Now().Format(time.RFC3339Nano),
 			}
 		} else {
-			repository.Annotations[meta.ReconcileAtAnnotation] = time.Now().Format(time.RFC3339Nano)
+			repository.Annotations[meta.ReconcileRequestAnnotation] = time.Now().Format(time.RFC3339Nano)
 		}
 		return kubeClient.Update(ctx, repository)
 	})


### PR DESCRIPTION
Replace deprecated `ReconcileAtAnnotation` with `ReconcileRequestAnnotation`.

Fix: #542