### PR TITLE
Add regex filter arg to policy command

### DIFF
--- a/cmd/flux/create_image_policy.go
+++ b/cmd/flux/create_image_policy.go
@@ -38,8 +38,9 @@ the status of the object.`,
 	RunE: createImagePolicyRun}
 
 type imagePolicyFlags struct {
-	imageRef string
-	semver   string
+	imageRef    string
+	semver      string
+	filterRegex string
 }
 
 var imagePolicyArgs = imagePolicyFlags{}
@@ -48,6 +49,7 @@ func init() {
 	flags := createImagePolicyCmd.Flags()
 	flags.StringVar(&imagePolicyArgs.imageRef, "image-ref", "", "the name of an image repository object")
 	flags.StringVar(&imagePolicyArgs.semver, "semver", "", "a semver range to apply to tags; e.g., '1.x'")
+	flags.StringVar(&imagePolicyArgs.filterRegex, "filter-regex", "", " regular expression pattern used to filter the image tags")
 
 	createImageCmd.AddCommand(createImagePolicyCmd)
 }
@@ -93,6 +95,12 @@ func createImagePolicyRun(cmd *cobra.Command, args []string) error {
 		}
 	default:
 		return fmt.Errorf("a policy must be provided with --semver")
+	}
+
+	if imagePolicyArgs.filterRegex != "" {
+		policy.Spec.FilterTags = &imagev1.TagFilter{
+			Pattern: imagePolicyArgs.filterRegex,
+		}
 	}
 
 	if export {

--- a/cmd/flux/create_image_updateauto.go
+++ b/cmd/flux/create_image_updateauto.go
@@ -50,7 +50,7 @@ var imageUpdateArgs = imageUpdateFlags{}
 func init() {
 	flags := createImageUpdateCmd.Flags()
 	flags.StringVar(&imageUpdateArgs.gitRepoRef, "git-repo-ref", "", "the name of a GitRepository resource with details of the upstream git repository")
-	flags.StringVar(&imageUpdateArgs.branch, "branch", "", "the branch to push commits to")
+	flags.StringVar(&imageUpdateArgs.branch, "branch", "", "the branch to checkout and push commits to")
 	flags.StringVar(&imageUpdateArgs.commitTemplate, "commit-template", "", "a template for commit messages")
 	flags.StringVar(&imageUpdateArgs.authorName, "author-name", "", "the name to use for commit author")
 	flags.StringVar(&imageUpdateArgs.authorEmail, "author-email", "", "the email to use for commit author")
@@ -66,6 +66,10 @@ func createImageUpdateRun(cmd *cobra.Command, args []string) error {
 
 	if imageUpdateArgs.gitRepoRef == "" {
 		return fmt.Errorf("a reference to a GitRepository is required (--git-repo-ref)")
+	}
+
+	if imageUpdateArgs.branch == "" {
+		return fmt.Errorf("the Git repoistory branch is required (--branch)")
 	}
 
 	labels, err := parseLabels()

--- a/docs/cmd/flux_create_image_policy.md
+++ b/docs/cmd/flux_create_image_policy.md
@@ -18,9 +18,10 @@ flux create image policy <name> [flags]
 ### Options
 
 ```
-  -h, --help               help for policy
-      --image-ref string   the name of an image repository object
-      --semver string      a semver range to apply to tags; e.g., '1.x'
+      --filter-regex string    regular expression pattern used to filter the image tags
+  -h, --help                  help for policy
+      --image-ref string      the name of an image repository object
+      --semver string         a semver range to apply to tags; e.g., '1.x'
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/flux_create_image_update.md
+++ b/docs/cmd/flux_create_image_update.md
@@ -17,7 +17,7 @@ flux create image update <name> [flags]
 ```
       --author-email string      the email to use for commit author
       --author-name string       the name to use for commit author
-      --branch string            the branch to push commits to
+      --branch string            the branch to checkout and push commits to
       --commit-template string   a template for commit messages
       --git-repo-ref string      the name of a GitRepository resource with details of the upstream git repository
   -h, --help                     help for update


### PR DESCRIPTION
Changes:
- Make `--branch` arg required for `flux create image update` to match the API changes
- Add optional `--filter-regex` arg to `flux create image policy` command