### PR TITLE
Remove Git implementation default from bootstrap

### DIFF
--- a/cmd/flux/bootstrap.go
+++ b/cmd/flux/bootstrap.go
@@ -171,7 +171,6 @@ func generateSyncManifests(url, branch, name, namespace, targetPath, tmpDir stri
 		Interval:          interval,
 		TargetPath:        targetPath,
 		ManifestFile:      sync.MakeDefaultOptions().ManifestFile,
-		GitImplementation: sync.MakeDefaultOptions().GitImplementation,
 	}
 
 	manifest, err := sync.Generate(opts)


### PR DESCRIPTION
This fixes the upgrade for users running flux2 < 0.5.x