### PR TITLE
Fire 'Update Components' workflow on push to main

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 * * * *"
+  push:
+    branches: [main]
 
 jobs:
   update-components:


### PR DESCRIPTION
This results in the automatic rebase of an outstanding PR on merges to
this branch, removing the need of manually firing it.