### PR TITLE
Include image spec and ref docs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -55,6 +55,18 @@ jobs:
           }
 
           {
+            # image-*-controller CRDs; these use the same API group
+            IMG_REFL_VER=$(controller_version image-reflector-controller)
+            curl -# -Lf "https://raw.githubusercontent.com/fluxcd/image-reflector-controller/$IMG_REFL_VER/docs/api/image-reflector.md" > docs/components/image/reflector-api.md
+            curl -# -Lf "https://raw.githubusercontent.com/fluxcd/image-reflector-controller/$IMG_REFL_VER/docs/spec/v1alpha1/imagerepositories.md" > docs/components/image/imagerepositories.md
+            curl -# -Lf "https://raw.githubusercontent.com/fluxcd/image-reflector-controller/$IMG_REFL_VER/docs/spec/v1alpha1/imagepolicies.md" > docs/components/image/imagepolicies.md
+
+            IMG_AUTO_VER=$(controller_version image-automation-controller)
+            curl -# -Lf "https://raw.githubusercontent.com/fluxcd/image-automation-controller/$IMG_AUTO_VER/docs/api/image-automation.md" > docs/components/image/automation-api.md
+            curl -# -Lf "https://raw.githubusercontent.com/fluxcd/image-automation-controller/$IMG_AUTO_VER/docs/spec/v1alpha1/imageupdateautomations.md" > docs/components/image/imageupdateautomations.md
+          }
+
+          {
             # install script
             cp install/flux.sh docs/install.sh
           }

--- a/docs/components/image/controller.md
+++ b/docs/components/image/controller.md
@@ -1,0 +1,16 @@
+# Image reflector and automation controllers
+
+The image-reflector-controller and image-automation-controller work together to update a Git
+repository when new container images are available.
+
+- The image-reflector-controller scans image repositories and reflects the image metadata in
+  Kubernetes resources.
+- The image-automation-controller updates YAML files based on the latest images scanned, and commits
+  the changes to a given Git repository.
+
+Links:
+
+- Source code [fluxcd/image-reflector-controller](https://github.com/fluxcd/image-reflector-controller)
+- Reflector [specification docs](https://github.com/fluxcd/image-reflector-controller/tree/main/docs/spec)
+- Source code [fluxcd/image-automation-controller](https://github.com/fluxcd/image-automation-controller)
+- Automation [specification docs](https://github.com/fluxcd/image-automation-controller/tree/main/docs/spec)

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -24,3 +24,7 @@ A reference for each component and API type is linked below.
     - [Provider CRD](notification/provider.md)
     - [Alert CRD](notification/alert.md)
     - [Receiver CRD](notification/receiver.md)
+- [Image automation controllers](image/controller.md)
+    - [ImageRepository CRD](image/imagerepositories.md)
+    - [ImagePolicy CRD](image/imagepolicies.md)
+    - [ImageUpdateAutomation CRD](image/imageupdateautomation.md)


### PR DESCRIPTION
This adds the image-* controllers, with their API refs, to the "components" part of the docs.
