### PR TITLE
Add permissions for controller leader election.

### DIFF
--- a/manifests/rbac/role.yaml
+++ b/manifests/rbac/role.yaml
@@ -28,6 +28,18 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
The v0.8.0 version of the controller-runtime uses both config maps and
leases to perform leader election. These permissions seem to be in the
individual controller repos, but not here. For example
https://github.com/fluxcd/kustomize-controller/blob/2d38de8779b68bde3366489a0b7657488c747fdb/config/rbac/leader_election_role.yaml#L33-L44