### PR TITLE
Add a dedicated service account per controller

### DIFF
--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -242,9 +242,7 @@ mkdir -p ./clusters/my-cluster/flux-system
 Generate the Flux manifests with:
 
 ```sh
-# on ARM64/AARCH64 clusters use --arch=arm64
 flux install --version=latest \
-  --arch=amd64 \
   --export > ./clusters/my-cluster/flux-system/gotk-components.yaml
 ```
 
@@ -388,7 +386,6 @@ Kubernetes manifests that can be used to install or upgrade Flux:
 ```hcl
 data "flux_install" "main" {
   target_path    = "clusters/my-cluster"
-  arch           = "amd64"
   network_policy = false
   version        = "latest"
 }

--- a/docs/guides/mozilla-sops.md
+++ b/docs/guides/mozilla-sops.md
@@ -107,8 +107,9 @@ secrets by iterating over all the private keys until it finds one that works.
 ### Using various cloud providers
 
 When using AWS/GCP KMS, you don't have to include the gpg `secretRef` under
-`spec.provider` (you can skip the `--decryption-secret` flag when running `flux create kustomization`), instead you'll have to bind an IAM Role with access to the KMS
-keys to the `default` service account of the `flux-system` namespace for
+`spec.provider` (you can skip the `--decryption-secret` flag when running `flux create kustomization`),
+instead you'll have to bind an IAM Role with access to the KMS
+keys to the `kustomize-controller` service account of the `flux-system` namespace for
 kustomize-controller to be able to fetch keys from KMS.
 
 #### AWS 
@@ -145,13 +146,12 @@ or with [add-pod-identity](https://github.com/Azure/aad-pod-identity).
 Please ensure that the GKE cluster has Workload Identity enabled.
 
 1. Create a service account with the role `Cloud KMS CryptoKey Encrypter/Decrypter`.
-2. Create an IAM policy binding between the GCP service account to the `default` service account of the `flux-system`.
-3. Annotate the `default` service account in the `flux-system` with the GCP service account.
+2. Create an IAM policy binding between the GCP service account to the `kustomize-controller` service account of the `flux-system`.
+3. Annotate the `kustomize-controller` service account in the `flux-system` with the GCP service account.
 
 ```sh
-kubectl annotate serviceaccount \
+kubectl annotate serviceaccount kustomize-controller \
   --namespace flux-system \
-  default \
   iam.gke.io/gcp-service-account=<name-of-serviceaccount>@project-id.iam.gserviceaccount.com
 ```
 

--- a/manifests/bases/helm-controller/account.yaml
+++ b/manifests/bases/helm-controller/account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: helm-controller

--- a/manifests/bases/helm-controller/kustomization.yaml
+++ b/manifests/bases/helm-controller/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - https://github.com/fluxcd/helm-controller/archive/v0.6.0.zip//helm-controller-0.6.0/config/crd
 - https://github.com/fluxcd/helm-controller/archive/v0.6.0.zip//helm-controller-0.6.0/config/manager
+- account.yaml
 patchesJson6902:
 - target:
     group: apps

--- a/manifests/bases/helm-controller/patch.yaml
+++ b/manifests/bases/helm-controller/patch.yaml
@@ -1,3 +1,6 @@
 - op: add
   path: /spec/template/spec/containers/0/args/0
   value: --events-addr=http://notification-controller/
+- op: add
+  path: /spec/template/spec/serviceAccountName
+  value: helm-controller

--- a/manifests/bases/image-automation-controller/account.yaml
+++ b/manifests/bases/image-automation-controller/account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: image-automation-controller

--- a/manifests/bases/image-automation-controller/kustomization.yaml
+++ b/manifests/bases/image-automation-controller/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - https://github.com/fluxcd/image-automation-controller/archive/v0.4.0.zip//image-automation-controller-0.4.0/config/crd
 - https://github.com/fluxcd/image-automation-controller/archive/v0.4.0.zip//image-automation-controller-0.4.0/config/manager
+- account.yaml
 patchesJson6902:
 - target:
     group: apps

--- a/manifests/bases/image-automation-controller/patch.yaml
+++ b/manifests/bases/image-automation-controller/patch.yaml
@@ -1,3 +1,6 @@
 - op: add
   path: /spec/template/spec/containers/0/args/0
   value: --events-addr=http://notification-controller/
+- op: add
+  path: /spec/template/spec/serviceAccountName
+  value: image-automation-controller

--- a/manifests/bases/image-reflector-controller/account.yaml
+++ b/manifests/bases/image-reflector-controller/account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: image-reflector-controller

--- a/manifests/bases/image-reflector-controller/kustomization.yaml
+++ b/manifests/bases/image-reflector-controller/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - https://github.com/fluxcd/image-reflector-controller/archive/v0.4.1.zip//image-reflector-controller-0.4.1/config/crd
 - https://github.com/fluxcd/image-reflector-controller/archive/v0.4.1.zip//image-reflector-controller-0.4.1/config/manager
+- account.yaml
 patchesJson6902:
 - target:
     group: apps

--- a/manifests/bases/image-reflector-controller/patch.yaml
+++ b/manifests/bases/image-reflector-controller/patch.yaml
@@ -1,3 +1,6 @@
 - op: add
   path: /spec/template/spec/containers/0/args/0
   value: --events-addr=http://notification-controller/
+- op: add
+  path: /spec/template/spec/serviceAccountName
+  value: image-reflector-controller

--- a/manifests/bases/kustomize-controller/account.yaml
+++ b/manifests/bases/kustomize-controller/account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kustomize-controller

--- a/manifests/bases/kustomize-controller/kustomization.yaml
+++ b/manifests/bases/kustomize-controller/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - https://github.com/fluxcd/kustomize-controller/archive/v0.7.0.zip//kustomize-controller-0.7.0/config/crd
 - https://github.com/fluxcd/kustomize-controller/archive/v0.7.0.zip//kustomize-controller-0.7.0/config/manager
+- account.yaml
 patchesJson6902:
 - target:
     group: apps

--- a/manifests/bases/kustomize-controller/patch.yaml
+++ b/manifests/bases/kustomize-controller/patch.yaml
@@ -1,3 +1,6 @@
 - op: add
   path: /spec/template/spec/containers/0/args/0
   value: --events-addr=http://notification-controller/
+- op: add
+  path: /spec/template/spec/serviceAccountName
+  value: kustomize-controller

--- a/manifests/bases/notification-controller/account.yaml
+++ b/manifests/bases/notification-controller/account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: notification-controller

--- a/manifests/bases/notification-controller/kustomization.yaml
+++ b/manifests/bases/notification-controller/kustomization.yaml
@@ -3,3 +3,11 @@ kind: Kustomization
 resources:
 - https://github.com/fluxcd/notification-controller/archive/v0.7.0.zip//notification-controller-0.7.0/config/crd
 - https://github.com/fluxcd/notification-controller/archive/v0.7.0.zip//notification-controller-0.7.0/config/manager
+- account.yaml
+patchesJson6902:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: notification-controller
+    path: patch.yaml

--- a/manifests/bases/notification-controller/patch.yaml
+++ b/manifests/bases/notification-controller/patch.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/template/spec/serviceAccountName
+  value: notification-controller

--- a/manifests/bases/source-controller/account.yaml
+++ b/manifests/bases/source-controller/account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: source-controller

--- a/manifests/bases/source-controller/kustomization.yaml
+++ b/manifests/bases/source-controller/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - https://github.com/fluxcd/source-controller/archive/v0.7.0.zip//source-controller-0.7.0/config/crd
 - https://github.com/fluxcd/source-controller/archive/v0.7.0.zip//source-controller-0.7.0/config/manager
+- account.yaml
 patchesJson6902:
 - target:
     group: apps

--- a/manifests/bases/source-controller/patch.yaml
+++ b/manifests/bases/source-controller/patch.yaml
@@ -1,3 +1,6 @@
 - op: add
   path: /spec/template/spec/containers/0/args/0
   value: --events-addr=http://notification-controller/
+- op: add
+  path: /spec/template/spec/serviceAccountName
+  value: source-controller

--- a/manifests/rbac/controller.yaml
+++ b/manifests/rbac/controller.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: crd-controller
 rules:
@@ -15,12 +15,17 @@ rules:
 - apiGroups: ['notification.toolkit.fluxcd.io']
   resources: ['*']
   verbs: ['*']
+- apiGroups: ['image.toolkit.fluxcd.io']
+  resources: ['*']
+  verbs: ['*']
 - apiGroups:
   - ""
   resources:
-  - configmaps
-  - configmaps/status
-  verbs: ['*']
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -28,6 +33,19 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - configmaps/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 - apiGroups:
   - "coordination.k8s.io"
   resources:
@@ -42,14 +60,23 @@ rules:
   - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: crd-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: crd-controller
 subjects:
   - kind: ServiceAccount
-    name: default
-    namespace: system
+    name: kustomize-controller
+  - kind: ServiceAccount
+    name: helm-controller
+  - kind: ServiceAccount
+    name: source-controller
+  - kind: ServiceAccount
+    name: notification-controller
+  - kind: ServiceAccount
+    name: image-reflector-controller
+  - kind: ServiceAccount
+    name: image-automation-controller

--- a/manifests/rbac/kustomization.yaml
+++ b/manifests/rbac/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - role.yaml
-  - cluster-role.yaml
+  - controller.yaml
+  - reconciler.yaml

--- a/manifests/rbac/reconciler.yaml
+++ b/manifests/rbac/reconciler.yaml
@@ -8,5 +8,6 @@ roleRef:
   name: cluster-admin
 subjects:
   - kind: ServiceAccount
-    name: default
-    namespace: system
+    name: kustomize-controller
+  - kind: ServiceAccount
+    name: helm-controller


### PR DESCRIPTION
This PR assigns each controller a service account named the same as the controller. 

At install/upgrade time, `flux bootstrap` and `flux install` will create two cluster roles and bindings prefixed with the `--namespace` value. This change will also apply to Flux Terraform provider.

### crd-controller-flux-system 

This `ClusterRoleBinding` grands cluster wide RW access to the `toolkit.fluxcd.io` custom resources (required by controller runtime), RO access to Kubernetes secrets (required by `secretRef`) and RW access to Kubernetes leases (required by leader election). All the controller service accounts are bind to this cluster role.

### cluster-reconciler-flux-system

This `ClusterRoleBinding` grands `cluster-admin` access to kustomize-controller and helm-controller using their dedicate service account.

Fix: #243 