### PR TITLE
Use correct type in various get source commands

### DIFF
--- a/cmd/flux/get_source_chart.go
+++ b/cmd/flux/get_source_chart.go
@@ -35,7 +35,7 @@ var getSourceHelmChartCmd = &cobra.Command{
   flux get sources chart --all-namespaces
 `,
 	RunE: getCommand{
-		apiType: bucketType,
+		apiType: helmChartType,
 		list:    &helmChartListAdapter{&sourcev1.HelmChartList{}},
 	}.run,
 }

--- a/cmd/flux/get_source_git.go
+++ b/cmd/flux/get_source_git.go
@@ -35,7 +35,7 @@ var getSourceGitCmd = &cobra.Command{
   flux get sources git --all-namespaces
 `,
 	RunE: getCommand{
-		apiType: bucketType,
+		apiType: gitRepositoryType,
 		list:    &gitRepositoryListAdapter{&sourcev1.GitRepositoryList{}},
 	}.run,
 }

--- a/cmd/flux/get_source_helm.go
+++ b/cmd/flux/get_source_helm.go
@@ -35,7 +35,7 @@ var getSourceHelmCmd = &cobra.Command{
   flux get sources helm --all-namespaces
 `,
 	RunE: getCommand{
-		apiType: bucketType,
+		apiType: helmRepositoryType,
 		list:    &helmRepositoryListAdapter{&sourcev1.HelmRepositoryList{}},
 	}.run,
 }


### PR DESCRIPTION
This fixes a bug where the wrong type was displayed for various
`get source` commands.

```console
$ flux get sources helm --namespace default
✗ no Bucket objects found in default namespace
```

Regression bug introduced in #761