### PR TITLE
Enable network policy in e2e

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -26,7 +26,8 @@ jobs:
       - name: Setup Kubernetes
         uses: engineerd/setup-kind@v0.5.0
         with:
-          image: kindest/node:v1.16.9
+          version: "v0.10.0"
+          image: kindest/node:v1.16.15@sha256:c10a63a5bda231c0a379bf91aebf8ad3c79146daca59db816fb963f731852a99
           config: .github/workflows/e2e_kind_config.yaml # disable KIND-net
       - name: Setup Calico for network policy
         run: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -27,6 +27,11 @@ jobs:
         uses: engineerd/setup-kind@v0.5.0
         with:
           image: kindest/node:v1.16.9
+          config: .github/workflows/e2e_kind_config.yaml # disable KIND-net
+      - name: Setup Calico for network policy
+        run: |
+          kubectl apply -f https://docs.projectcalico.org/v3.16/manifests/calico.yaml
+          kubectl -n kube-system set env daemonset/calico-node FELIX_IGNORELOOSERPF=true
       - name: Run test
         run: make test
       - name: Check if working tree is dirty

--- a/.github/workflows/e2e_kind_config.yaml
+++ b/.github/workflows/e2e_kind_config.yaml
@@ -1,0 +1,5 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  disableDefaultCNI: true   # disable kindnet
+  podSubnet: 192.168.0.0/16 # set to Calico's default subnet


### PR DESCRIPTION
This PR disables the default KIND-net, and uses Calico CNI instead to enable network policy for the KIND cluster in e2e testing.

fixes #800 