### PR TITLE
Add webhook section to image update docs

### DIFF
--- a/action/README.md
+++ b/action/README.md
@@ -22,7 +22,7 @@ Note that this action can only be used on GitHub **Linux AMD64** runners.
 
 ### Automate Flux updates
 
-Example workflow for updating Flux's components generated with `flux bootstrap --arch=amd64 --path=clusters/production`:
+Example workflow for updating Flux's components generated with `flux bootstrap --path=clusters/production`:
 
 ```yaml
 name: update-flux
@@ -43,7 +43,7 @@ jobs:
       - name: Check for updates
         id: update
         run: |
-          flux install --arch=amd64 \
+          flux install \
             --export > ./clusters/production/flux-system/gotk-components.yaml
 
           VERSION="$(flux -v)"


### PR DESCRIPTION
Changes:
- document how to trigger image updates with webhooks
- add staging CI/CD pipeline to image automation use-cases
- provide an example of how to tag images for staging `${GIT_BRANCH}-${GIT_SHA:0:7}-$(date +%s)`