### PR TITLE
Fix create secret commands

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -50,6 +50,15 @@ jobs:
       - name: flux install --manifests
         run: |
           ./bin/flux install --manifests ./manifests/install/
+      - name: flux create secret
+        run: |
+          ./bin/flux create secret git git-ssh-test \
+            --url ssh://git@github.com/stefanprodan/podinfo
+          ./bin/flux create secret git git-https-test \
+            --url https://github.com/stefanprodan/podinfo \
+            --username=test --password=test
+          ./bin/flux create secret helm helm-test \
+            --username=test --password=test
       - name: flux create source git
         run: |
           ./bin/flux create source git podinfo \

--- a/cmd/flux/create_secret.go
+++ b/cmd/flux/create_secret.go
@@ -51,6 +51,8 @@ func makeSecret(name string) (corev1.Secret, error) {
 			Namespace: rootArgs.namespace,
 			Labels:    secretLabels,
 		},
+		StringData: map[string]string{},
+		Data:       nil,
 	}, nil
 }
 

--- a/cmd/flux/create_secret_git.go
+++ b/cmd/flux/create_secret_git.go
@@ -133,10 +133,10 @@ func createSecretGitCmdRun(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		secret.Data = map[string][]byte{
-			"identity":     pair.PrivateKey,
-			"identity.pub": pair.PublicKey,
-			"known_hosts":  hostKey,
+		secret.StringData = map[string]string{
+			"identity":     string(pair.PrivateKey),
+			"identity.pub": string(pair.PublicKey),
+			"known_hosts":  string(hostKey),
 		}
 
 		if !createArgs.export {
@@ -148,9 +148,9 @@ func createSecretGitCmdRun(cmd *cobra.Command, args []string) error {
 		}
 
 		// TODO: add cert data when it's implemented in source-controller
-		secret.Data = map[string][]byte{
-			"username": []byte(secretGitArgs.username),
-			"password": []byte(secretGitArgs.password),
+		secret.StringData = map[string]string{
+			"username": secretGitArgs.username,
+			"password": secretGitArgs.password,
 		}
 	default:
 		return fmt.Errorf("git URL scheme '%s' not supported, can be: ssh, http and https", u.Scheme)


### PR DESCRIPTION
The `flux create secret` commands are throwing panic errors due to regression bug introduced in https://github.com/fluxcd/flux2/pull/788 (the secret StringData wasn't initialised).

Fix: #826