### PR TITLE
Exclude deleted resources on prometheus alerting query

### DIFF
--- a/docs/guides/monitoring.md
+++ b/docs/guides/monitoring.md
@@ -86,7 +86,7 @@ groups:
 - name: GitOpsToolkit
   rules:
   - alert: ReconciliationFailure
-    expr: gotk_reconcile_condition{type="Ready",status="False"} == 1
+    expr: max(gotk_reconcile_condition{status="False",type="Ready"}) by (namespace, name, kind) + on(namespace, name, kind) (max(gotk_reconcile_condition{status="Deleted"}) by (namespace, name, kind)) * 2 == 1
     for: 10m
     labels:
       severity: page


### PR DESCRIPTION
If a resource is deleted, the alert will fire indefinitely.

I multiply the "Deleted" count by 2 to have a distinct case.
* If the reconciliation fails, left part is valued 1.
* If the resource is deleted, right part is valued 2.