### PR TITLE
Refactor components status check

### DIFF
--- a/cmd/flux/install.go
+++ b/cmd/flux/install.go
@@ -175,23 +175,16 @@ func installCmdRun(cmd *cobra.Command, args []string) error {
 	if installDryRun {
 		logger.Successf("install dry-run finished")
 		return nil
-	} else {
-		logger.Successf("install completed")
 	}
 
-	statusChecker := StatusChecker{}
-	err = statusChecker.New(time.Second, rootArgs.timeout)
+	statusChecker, err := NewStatusChecker(time.Second, time.Minute)
 	if err != nil {
-		return fmt.Errorf("install failed with: %v", err)
+		return fmt.Errorf("install failed: %w", err)
 	}
 
 	logger.Waitingf("verifying installation")
-	for _, deployment := range components {
-		err := statusChecker.Assess(deployment)
-		if err != nil {
-			return fmt.Errorf("%s: install failed while rolling out deployment", deployment)
-		}
-		logger.Successf("%s ready", deployment)
+	if err := statusChecker.Assess(components...); err != nil {
+		return fmt.Errorf("install failed")
 	}
 
 	logger.Successf("install finished")

--- a/docs/cmd/flux_check.md
+++ b/docs/cmd/flux_check.md
@@ -25,9 +25,10 @@ flux check [flags]
 ### Options
 
 ```
-      --components strings   list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
-  -h, --help                 help for check
-      --pre                  only run pre-installation checks
+      --components strings         list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
+      --components-extra strings   list of components in addition to those supplied or defaulted, accepts comma-separated values
+  -h, --help                       help for check
+      --pre                        only run pre-installation checks
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Changes:
- run install/bootstrap checks in parallel (1m timeout)
- list not found components
- add `--components-extra` arg to check command

Example output:
```console
$ flux check --components-extra=image-reflector-controller,image-automation-controller
► checking prerequisites
✔ kubectl 1.20.2 >=1.18.0
✔ Kubernetes 1.18.12-gke.1205 >=1.16.0
► checking controllers
✔ source-controller: healthy
► ghcr.io/fluxcd/source-controller:v0.7.3
✔ kustomize-controller: healthy
► ghcr.io/fluxcd/kustomize-controller:v0.7.4
✔ helm-controller: healthy
► ghcr.io/fluxcd/helm-controller:v0.6.1
✔ notification-controller: healthy
► ghcr.io/fluxcd/notification-controller:v0.7.1
✗ image-reflector-controller: unhealthy (timed out waiting for rollout)
► ghcr.io/fluxcd/image-reflector-controller2:v0.5.0
✗ image-automation-controller: deployment not found
```

Followup: #845