### PR TITLE
Add support for multiple values files to create hr

### DIFF
--- a/docs/cmd/flux_create_helmrelease.md
+++ b/docs/cmd/flux_create_helmrelease.md
@@ -32,11 +32,12 @@ flux create helmrelease [name] [flags]
     --source=Bucket/podinfo \
     --chart=./charts/podinfo
 
-  # Create a HelmRelease with values from a local YAML file
+  # Create a HelmRelease with values from local YAML files
   flux create hr podinfo \
     --source=HelmRepository/podinfo \
     --chart=podinfo \
-    --values=./my-values.yaml
+    --values=./my-values1.yaml \
+    --values=./my-values2.yaml
 
   # Create a HelmRelease with values from a Kubernetes secret
   kubectl -n app create secret generic my-secret-values \
@@ -78,7 +79,7 @@ flux create helmrelease [name] [flags]
       --service-account string              the name of the service account to impersonate when reconciling this HelmRelease
       --source helmChartSource              source that contains the chart in the format '<kind>/<name>', where kind must be one of: (HelmRepository, GitRepository, Bucket)
       --target-namespace string             namespace to install this release, defaults to the HelmRelease namespace
-      --values string                       local path to the values.yaml file
+      --values stringArray                  local path to values.yaml files
       --values-from helmReleaseValuesFrom   Kubernetes object reference that contains the values.yaml data key in the format '<kind>/<name>', where kind must be one of: (Secret, ConfigMap)
 ```
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -393,3 +393,24 @@ func ValidateComponents(components []string) error {
 
 	return nil
 }
+
+// TODO(stefan): move this to fluxcd/pkg
+// taken from: https://github.com/fluxcd/helm-controller/blob/main/internal/util/util.go
+func MergeMaps(a, b map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(a))
+	for k, v := range a {
+		out[k] = v
+	}
+	for k, v := range b {
+		if v, ok := v.(map[string]interface{}); ok {
+			if bv, ok := out[k]; ok {
+				if bv, ok := bv.(map[string]interface{}); ok {
+					out[k] = MergeMaps(bv, v)
+					continue
+				}
+			}
+		}
+		out[k] = v
+	}
+	return out
+}


### PR DESCRIPTION
This PR adds support for providing multiple values files to `flux create helmrelease` command.

Example:
```sh
flux create helmrelease podinfo \
--source=HelmRepository/podinfo \
--chart=podinfo \
--values=./replicas.yaml \
--values=./resources.yaml
```

Fix: #865