### PR TITLE
Add support for getting resources by name

### DIFF
--- a/cmd/flux/get.go
+++ b/cmd/flux/get.go
@@ -90,6 +90,11 @@ func (get getCommand) run(cmd *cobra.Command, args []string) error {
 	if !getArgs.allNamespaces {
 		listOpts = append(listOpts, client.InNamespace(rootArgs.namespace))
 	}
+
+	if len(args) > 0 {
+		listOpts = append(listOpts, client.MatchingFields{"metadata.name": args[0]})
+	}
+
 	err = kubeClient.List(ctx, get.list.asClientList(), listOpts...)
 	if err != nil {
 		return err

--- a/cmd/flux/get_alert.go
+++ b/cmd/flux/get_alert.go
@@ -33,9 +33,10 @@ import (
 )
 
 var getAlertCmd = &cobra.Command{
-	Use:   "alerts",
-	Short: "Get Alert statuses",
-	Long:  "The get alert command prints the statuses of the resources.",
+	Use:     "alerts",
+	Aliases: []string{"alert"},
+	Short:   "Get Alert statuses",
+	Long:    "The get alert command prints the statuses of the resources.",
 	Example: `  # List all Alerts and their status
   flux get alerts
 `,

--- a/cmd/flux/get_alertprovider.go
+++ b/cmd/flux/get_alertprovider.go
@@ -31,9 +31,10 @@ import (
 )
 
 var getAlertProviderCmd = &cobra.Command{
-	Use:   "alert-providers",
-	Short: "Get Provider statuses",
-	Long:  "The get alert-provider command prints the statuses of the resources.",
+	Use:     "alert-providers",
+	Aliases: []string{"alert-provider"},
+	Short:   "Get Provider statuses",
+	Long:    "The get alert-provider command prints the statuses of the resources.",
 	Example: `  # List all Providers and their status
   flux get alert-providers
 `,

--- a/cmd/flux/get_helmrelease.go
+++ b/cmd/flux/get_helmrelease.go
@@ -26,7 +26,7 @@ import (
 
 var getHelmReleaseCmd = &cobra.Command{
 	Use:     "helmreleases",
-	Aliases: []string{"hr"},
+	Aliases: []string{"hr", "helmrelease"},
 	Short:   "Get HelmRelease statuses",
 	Long:    "The get helmreleases command prints the statuses of the resources.",
 	Example: `  # List all Helm releases and their status

--- a/cmd/flux/get_image.go
+++ b/cmd/flux/get_image.go
@@ -21,9 +21,10 @@ import (
 )
 
 var getImageCmd = &cobra.Command{
-	Use:   "image",
-	Short: "Get image automation object status",
-	Long:  "The get image sub-commands print the status of image automation objects.",
+	Use:     "images",
+	Aliases: []string{"image"},
+	Short:   "Get image automation object status",
+	Long:    "The get image sub-commands print the status of image automation objects.",
 }
 
 func init() {

--- a/cmd/flux/get_kustomization.go
+++ b/cmd/flux/get_kustomization.go
@@ -26,7 +26,7 @@ import (
 
 var getKsCmd = &cobra.Command{
 	Use:     "kustomizations",
-	Aliases: []string{"ks"},
+	Aliases: []string{"ks", "kustomization"},
 	Short:   "Get Kustomization statuses",
 	Long:    "The get kustomizations command prints the statuses of the resources.",
 	Example: `  # List all kustomizations and their status

--- a/cmd/flux/get_receiver.go
+++ b/cmd/flux/get_receiver.go
@@ -33,9 +33,10 @@ import (
 )
 
 var getReceiverCmd = &cobra.Command{
-	Use:   "receivers",
-	Short: "Get Receiver statuses",
-	Long:  "The get receiver command prints the statuses of the resources.",
+	Use:     "receivers",
+	Aliases: []string{"receiver"},
+	Short:   "Get Receiver statuses",
+	Long:    "The get receiver command prints the statuses of the resources.",
 	Example: `  # List all Receiver and their status
   flux get receivers
 `,

--- a/cmd/flux/get_source.go
+++ b/cmd/flux/get_source.go
@@ -21,9 +21,10 @@ import (
 )
 
 var getSourceCmd = &cobra.Command{
-	Use:   "sources",
-	Short: "Get source statuses",
-	Long:  "The get source sub-commands print the statuses of the sources.",
+	Use:     "sources",
+	Aliases: []string{"source"},
+	Short:   "Get source statuses",
+	Long:    "The get source sub-commands print the statuses of the sources.",
 }
 
 func init() {

--- a/docs/cmd/flux_get.md
+++ b/docs/cmd/flux_get.md
@@ -29,7 +29,7 @@ The get sub-commands print the statuses of sources and resources.
 * [flux get alert-providers](flux_get_alert-providers.md)	 - Get Provider statuses
 * [flux get alerts](flux_get_alerts.md)	 - Get Alert statuses
 * [flux get helmreleases](flux_get_helmreleases.md)	 - Get HelmRelease statuses
-* [flux get image](flux_get_image.md)	 - Get image automation object status
+* [flux get images](flux_get_images.md)	 - Get image automation object status
 * [flux get kustomizations](flux_get_kustomizations.md)	 - Get Kustomization statuses
 * [flux get receivers](flux_get_receivers.md)	 - Get Receiver statuses
 * [flux get sources](flux_get_sources.md)	 - Get source statuses

--- a/docs/cmd/flux_get_images.md
+++ b/docs/cmd/flux_get_images.md
@@ -1,30 +1,15 @@
-## flux get image update
+## flux get images
 
-Get ImageUpdateAutomation status
+Get image automation object status
 
 ### Synopsis
 
-The get image update command prints the status of ImageUpdateAutomation objects.
-
-```
-flux get image update [flags]
-```
-
-### Examples
-
-```
-  # List all image update automation object and their status
-  flux get image update
-
- # List image update automations from all namespaces
-  flux get image update --all-namespaces
-
-```
+The get image sub-commands print the status of image automation objects.
 
 ### Options
 
 ```
-  -h, --help   help for update
+  -h, --help   help for images
 ```
 
 ### Options inherited from parent commands
@@ -40,5 +25,8 @@ flux get image update [flags]
 
 ### SEE ALSO
 
-* [flux get image](flux_get_image.md)	 - Get image automation object status
+* [flux get](flux_get.md)	 - Get sources and resources
+* [flux get images policy](flux_get_images_policy.md)	 - Get ImagePolicy status
+* [flux get images repository](flux_get_images_repository.md)	 - Get ImageRepository status
+* [flux get images update](flux_get_images_update.md)	 - Get ImageUpdateAutomation status
 

--- a/docs/cmd/flux_get_images_policy.md
+++ b/docs/cmd/flux_get_images_policy.md
@@ -1,30 +1,30 @@
-## flux get image repository
+## flux get images policy
 
-Get ImageRepository status
+Get ImagePolicy status
 
 ### Synopsis
 
-The get image repository command prints the status of ImageRepository objects.
+The get image policy command prints the status of ImagePolicy objects.
 
 ```
-flux get image repository [flags]
+flux get images policy [flags]
 ```
 
 ### Examples
 
 ```
-  # List all image repositories and their status
-  flux get image repository
+  # List all image policies and their status
+  flux get image policy
 
- # List image repositories from all namespaces
-  flux get image repository --all-namespaces
+ # List image policies from all namespaces
+  flux get image policy --all-namespaces
 
 ```
 
 ### Options
 
 ```
-  -h, --help   help for repository
+  -h, --help   help for policy
 ```
 
 ### Options inherited from parent commands
@@ -40,5 +40,5 @@ flux get image repository [flags]
 
 ### SEE ALSO
 
-* [flux get image](flux_get_image.md)	 - Get image automation object status
+* [flux get images](flux_get_images.md)	 - Get image automation object status
 

--- a/docs/cmd/flux_get_images_repository.md
+++ b/docs/cmd/flux_get_images_repository.md
@@ -1,15 +1,30 @@
-## flux get image
+## flux get images repository
 
-Get image automation object status
+Get ImageRepository status
 
 ### Synopsis
 
-The get image sub-commands print the status of image automation objects.
+The get image repository command prints the status of ImageRepository objects.
+
+```
+flux get images repository [flags]
+```
+
+### Examples
+
+```
+  # List all image repositories and their status
+  flux get image repository
+
+ # List image repositories from all namespaces
+  flux get image repository --all-namespaces
+
+```
 
 ### Options
 
 ```
-  -h, --help   help for image
+  -h, --help   help for repository
 ```
 
 ### Options inherited from parent commands
@@ -25,8 +40,5 @@ The get image sub-commands print the status of image automation objects.
 
 ### SEE ALSO
 
-* [flux get](flux_get.md)	 - Get sources and resources
-* [flux get image policy](flux_get_image_policy.md)	 - Get ImagePolicy status
-* [flux get image repository](flux_get_image_repository.md)	 - Get ImageRepository status
-* [flux get image update](flux_get_image_update.md)	 - Get ImageUpdateAutomation status
+* [flux get images](flux_get_images.md)	 - Get image automation object status
 

--- a/docs/cmd/flux_get_images_update.md
+++ b/docs/cmd/flux_get_images_update.md
@@ -1,30 +1,30 @@
-## flux get image policy
+## flux get images update
 
-Get ImagePolicy status
+Get ImageUpdateAutomation status
 
 ### Synopsis
 
-The get image policy command prints the status of ImagePolicy objects.
+The get image update command prints the status of ImageUpdateAutomation objects.
 
 ```
-flux get image policy [flags]
+flux get images update [flags]
 ```
 
 ### Examples
 
 ```
-  # List all image policies and their status
-  flux get image policy
+  # List all image update automation object and their status
+  flux get image update
 
- # List image policies from all namespaces
-  flux get image policy --all-namespaces
+ # List image update automations from all namespaces
+  flux get image update --all-namespaces
 
 ```
 
 ### Options
 
 ```
-  -h, --help   help for policy
+  -h, --help   help for update
 ```
 
 ### Options inherited from parent commands
@@ -40,5 +40,5 @@ flux get image policy [flags]
 
 ### SEE ALSO
 
-* [flux get image](flux_get_image.md)	 - Get image automation object status
+* [flux get images](flux_get_images.md)	 - Get image automation object status
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,10 +104,15 @@ nav:
     - Create alert provider: cmd/flux_create_alert-provider.md
     - Create alert: cmd/flux_create_alert.md
     - Create receiver: cmd/flux_create_receiver.md
+    - Create image: cmd/flux_create_image.md
+    - Create image policy: cmd/flux_create_image_policy.md
+    - Create image repository: cmd/flux_create_image_repository.md
+    - Create image update: cmd/flux_create_image_update.md
     - Create tenant: cmd/flux_create_tenant.md
     - Create secret: cmd/flux_create_secret.md
     - Create secret git: cmd/flux_create_secret_git.md
     - Create secret helm: cmd/flux_create_secret_helm.md
+    - Create secret tls: cmd/flux_create_secret_tls.md
     - Delete: cmd/flux_delete.md
     - Delete kustomization: cmd/flux_delete_kustomization.md
     - Delete helmrelease: cmd/flux_delete_helmrelease.md
@@ -115,6 +120,10 @@ nav:
     - Delete source git: cmd/flux_delete_source_git.md
     - Delete source helm: cmd/flux_delete_source_helm.md
     - Delete source bucket: cmd/flux_delete_source_bucket.md
+    - Delete image: cmd/flux_delete_image.md
+    - Delete image policy: cmd/flux_delete_image_policy.md
+    - Delete image repository: cmd/flux_delete_image_repository.md
+    - Delete image update: cmd/flux_delete_image_update.md
     - Export: cmd/flux_export.md
     - Export kustomization: cmd/flux_export_kustomization.md
     - Export helmrelease: cmd/flux_export_helmrelease.md
@@ -125,6 +134,10 @@ nav:
     - Export alert provider: cmd/flux_export_alert-provider.md
     - Export alert: cmd/flux_export_alert.md
     - Export receiver: cmd/flux_export_receiver.md
+    - Export image: cmd/flux_export_image.md
+    - Export image policy: cmd/flux_export_image_policy.md
+    - Export image repository: cmd/flux_export_image_repository.md
+    - Export image update: cmd/flux_export_image_update.md
     - Get: cmd/flux_get.md
     - Get kustomizations: cmd/flux_get_kustomizations.md
     - Get helmreleases: cmd/flux_get_helmreleases.md
@@ -134,8 +147,13 @@ nav:
     - Get sources chart: cmd/flux_get_sources_chart.md
     - Get sources bucket: cmd/flux_get_sources_bucket.md
     - Get alert provider: cmd/flux_get_alert-provider.md
-    - Get alert: cmd/flux_get_alert.md
-    - Get receiver: cmd/flux_get_receiver.md
+    - Get alerts: cmd/flux_get_alerts.md
+    - Get alert providers: cmd/flux_get_alert-providers.md
+    - Get receivers: cmd/flux_get_receivers.md
+    - Get images: cmd/flux_get_images.md
+    - Get images policy: cmd/flux_get_images_policy.md
+    - Get images repository: cmd/flux_get_images_repository.md
+    - Get images update: cmd/flux_get_images_update.md
     - Install: cmd/flux_install.md
     - Resume: cmd/flux_resume.md
     - Resume kustomization: cmd/flux_resume_kustomization.md
@@ -148,6 +166,9 @@ nav:
     - Resume alert provider: cmd/flux_resume_alert-provider.md
     - Resume alert: cmd/flux_resume_alert.md
     - Resume receiver: cmd/flux_resume_receiver.md
+    - Resume image: cmd/flux_resume_image.md
+    - Resume image repository: cmd/flux_resume_image_repository.md
+    - Resume image update: cmd/flux_resume_image_update.md
     - Suspend: cmd/flux_suspend.md
     - Suspend kustomization: cmd/flux_suspend_kustomization.md
     - Suspend helmrelease: cmd/flux_suspend_helmrelease.md
@@ -159,6 +180,9 @@ nav:
     - Suspend alert provider: cmd/flux_suspend_alert-provider.md
     - Suspend alert: cmd/flux_suspend_alert.md
     - Suspend receiver: cmd/flux_suspend_receiver.md
+    - Suspend image: cmd/flux_suspend_image.md
+    - Suspend image repository: cmd/flux_suspend_image_repository.md
+    - Suspend image update: cmd/flux_suspend_image_update.md
     - Reconcile: cmd/flux_reconcile.md
     - Reconcile kustomization: cmd/flux_reconcile_kustomization.md
     - Reconcile helmrelease: cmd/flux_reconcile_helmrelease.md
@@ -166,6 +190,9 @@ nav:
     - Reconcile source git: cmd/flux_reconcile_source_git.md
     - Reconcile source helm: cmd/flux_reconcile_source_helm.md
     - Reconcile source bucket: cmd/flux_reconcile_source_bucket.md
+    - Reconcile image: cmd/flux_reconcile_image.md
+    - Reconcile image repository: cmd/flux_reconcile_image_repository.md
+    - Reconcile image update: cmd/flux_reconcile_image_update.md
     - Uninstall: cmd/flux_uninstall.md
   - Dev Guides:
       - Watching for source changes: dev-guides/source-watcher.md


### PR DESCRIPTION
Changes:
- add singular alias to `flux get` commands
- allow filtering the `flux get` commands result by resource name
- add the image commands to mkdocs index

Example:
```console
$ flux get sources git
NAME    	READY	MESSAGE                                                          	REVISION                                       	SUSPENDED 
podinfo 	True 	Fetched revision: master/e43ebfa5bf4b87c46f2e1db495eb571cd398e2f7	master/e43ebfa5bf4b87c46f2e1db495eb571cd398e2f7	False    	
podinfo2	True 	Fetched revision: master/e43ebfa5bf4b87c46f2e1db495eb571cd398e2f7	master/e43ebfa5bf4b87c46f2e1db495eb571cd398e2f7	False    

$ flux get source git podinfo
NAME   	READY	MESSAGE                                                          	REVISION                                       	SUSPENDED 
podinfo	True 	Fetched revision: master/e43ebfa5bf4b87c46f2e1db495eb571cd398e2f7	master/e43ebfa5bf4b87c46f2e1db495eb571cd398e2f7	False 
```