### PR TITLE
Make `flux uninstall` warning verbiage much stronger

### DIFF
--- a/cmd/flux/uninstall.go
+++ b/cmd/flux/uninstall.go
@@ -78,7 +78,7 @@ func uninstallCmdRun(cmd *cobra.Command, args []string) error {
 
 	if !uninstallArgs.dryRun && !uninstallArgs.silent {
 		prompt := promptui.Prompt{
-			Label:     fmt.Sprintf("Are you sure you want to delete the %s namespace", rootArgs.namespace),
+			Label:     fmt.Sprintf("Are you sure you want to delete the %s namespace (including all Flux CRDs and resources, as well as Flux v1 helm.fluxcd.io HelmReleases)", rootArgs.namespace),
 			IsConfirm: true,
 		}
 		if _, err := prompt.Run(); err != nil {


### PR DESCRIPTION
I am nearly sure it is not intended to delete helmreleases.helm.fluxcd.io HelmReleases when users run `flux uninstall`, but the effect is there currently, it does delete helm releases from the old API version. So until a behavior change can be implemented (if one makes sense), a more strongly worded warning might be appropriate such as this. (#811 first reported this.)

I would expect `flux uninstall` to only remove resources that come from Flux v2 CRDs, not Helm Operator HRs, since a person may try to upgrade their cluster to Flux v2, run into some issue, and then abort, thinking it's safe to just run `flux uninstall`.

I think the risk may be slightly overblown, so far only developer clusters have been impacted by this that we know of, at least. But the worst case scenario modes of failure are pretty bleak. Now that we both know it does this, we won't make this mistake again! It was discussed at another Flux team meeting that some migrations might not take place at once, so we should take some extra care around scenarios that may impact users who have only partially migrated their cluster from Flux v1 to Flux v2.

Does it make sense to merge in a change to the warning message such as this?

Is it possible to change the uninstall routine to refer to a blessed list of CRDs (maybe one exists) or at least regex filter the fully qualified names so that `helm.fluxcd.io` HelmReleases are not uninstalled too when this code runs? I think we have other CRDs with names that overlap other well-known types that could be affected by this, like Kustomization.