### PR TITLE
Exclude ARM archs from Darwin release builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,6 +20,8 @@ builds:
     id: darwin
     goos:
       - darwin
+    goarch:
+      - amd64
   - <<: *build_defaults
     id: windows
     goos:


### PR DESCRIPTION
As we are not on Go 1.16 yet.