### PR TITLE
Use git remote-base instead of zip-archive for cloud image-update example

### DIFF
--- a/docs/guides/image-update.md
+++ b/docs/guides/image-update.md
@@ -819,7 +819,7 @@ Create a directory in your control repository and save this `kustomization.yaml`
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/fluxcd/flux2/archive/main.zip//manifests/integrations/registry-credentials-sync/azure
+- git@github.com/fluxcd/flux2//manifests/integrations/registry-credentials-sync/azure
 patchesStrategicMerge:
 - config-patches.yaml
 ```


### PR DESCRIPTION
Kustomize doesn't support local bases in sibling directories from the same archive.
( go-getter limitation: https://github.com/kubernetes-sigs/kustomize/issues/2538#issuecomment-634970648 )

Quick fix for this broken example while we work on additional docs to help people fork into their repos.
@stefanprodan @kingdonb


problem:
```shell
# building /_base via zip works
kustomize build https://github.com/fluxcd/flux2/archive/main.zip//flux2-main/manifests/integrations/registry-credentials-sync/_base

# building /azure via zip fails because of the sibling dependency
kustomize build https://github.com/fluxcd/flux2/archive/main.zip//flux2-main/manifests/integrations/registry-credentials-sync/azure
Error: accumulating resources: 2 errors occurred:
        * accumulateFile error: "accumulating resources from '../_base': evalsymlink failure on '/tmp/kustomize-462235843/_base' : lstat /tmp/kustomize-462235843/_base: no such file or directory"
        * loader.New error: "error loading ../_base with git: url lacks host: ../_base, dir: evalsymlink failure on '/tmp/kustomize-462235843/_base' : lstat /tmp/kustomize-462235843/_base: no such file or directory, get: invalid source string: ../_base"
```

solution:
```shell
# build via git
kustomize build git@github.com/fluxcd/flux2//manifests/integrations/registry-credentials-sync/azure
```