### PR TITLE
Embed the Kubernetes manifests in flux binary

### DIFF
--- a/.github/workflows/bootstrap.yaml
+++ b/.github/workflows/bootstrap.yaml
@@ -17,23 +17,27 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go1.16-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-
+            ${{ runner.os }}-go1.16-
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.16.x
       - name: Setup Kubernetes
         uses: engineerd/setup-kind@v0.5.0
+      - name: Setup Kustomize
+        uses: fluxcd/pkg//actions/kustomize@main
+      - name: Build
+        run: |
+          make build-manifests
+          go build -o /tmp/flux ./cmd/flux
       - name: Set outputs
         id: vars
         run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-      - name: Build
-        run: sudo go build -o ./bin/flux ./cmd/flux
       - name: bootstrap init
         run: |
-          ./bin/flux bootstrap github --manifests ./manifests/install/ \
+          /tmp/flux bootstrap github --manifests ./manifests/install/ \
           --owner=fluxcd-testing \
           --repository=flux-test-${{ steps.vars.outputs.sha_short }} \
           --branch=main \
@@ -42,7 +46,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITPROVIDER_BOT_TOKEN }}
       - name: bootstrap no-op
         run: |
-          ./bin/flux bootstrap github --manifests ./manifests/install/ \
+          /tmp/flux bootstrap github --manifests ./manifests/install/ \
           --owner=fluxcd-testing \
           --repository=flux-test-${{ steps.vars.outputs.sha_short }} \
           --branch=main \
@@ -51,11 +55,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITPROVIDER_BOT_TOKEN }}
       - name: uninstall
         run: |
-          ./bin/flux uninstall -s --keep-namespace
+          /tmp/flux uninstall -s --keep-namespace
           kubectl delete ns flux-system --timeout=10m --wait=true
       - name: bootstrap reinstall
         run: |
-          ./bin/flux bootstrap github --manifests ./manifests/install/ \
+          /tmp/flux bootstrap github --manifests ./manifests/install/ \
           --owner=fluxcd-testing \
           --repository=flux-test-${{ steps.vars.outputs.sha_short }} \
           --branch=main \
@@ -64,7 +68,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITPROVIDER_BOT_TOKEN }}
       - name: delete repository
         run: |
-          ./bin/flux bootstrap github --manifests ./manifests/install/ \
+          /tmp/flux bootstrap github --manifests ./manifests/install/ \
           --owner=fluxcd-testing \
           --repository=flux-test-${{ steps.vars.outputs.sha_short }} \
           --branch=main \

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -16,9 +16,9 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go1.16-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-
+            ${{ runner.os }}-go1.16-
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
@@ -33,6 +33,8 @@ jobs:
         run: |
           kubectl apply -f https://docs.projectcalico.org/v3.16/manifests/calico.yaml
           kubectl -n kube-system set env daemonset/calico-node FELIX_IGNORELOOSERPF=true
+      - name: Setup Kustomize
+        uses: fluxcd/pkg//actions/kustomize@main
       - name: Run test
         run: make test
       - name: Check if working tree is dirty
@@ -43,43 +45,44 @@ jobs:
             exit 1
           fi
       - name: Build
-        run: sudo go build -o ./bin/flux ./cmd/flux
+        run: |
+          go build -o /tmp/flux ./cmd/flux
       - name: flux check --pre
         run: |
-          ./bin/flux check --pre
+          /tmp/flux check --pre
       - name: flux install --manifests
         run: |
-          ./bin/flux install --manifests ./manifests/install/
+          /tmp/flux install --manifests ./manifests/install/
       - name: flux create secret
         run: |
-          ./bin/flux create secret git git-ssh-test \
+          /tmp/flux create secret git git-ssh-test \
             --url ssh://git@github.com/stefanprodan/podinfo
-          ./bin/flux create secret git git-https-test \
+          /tmp/flux create secret git git-https-test \
             --url https://github.com/stefanprodan/podinfo \
             --username=test --password=test
-          ./bin/flux create secret helm helm-test \
+          /tmp/flux create secret helm helm-test \
             --username=test --password=test
       - name: flux create source git
         run: |
-          ./bin/flux create source git podinfo \
+          /tmp/flux create source git podinfo \
             --url https://github.com/stefanprodan/podinfo  \
             --tag-semver=">=3.2.3"
       - name: flux create source git export apply
         run: |
-          ./bin/flux create source git podinfo-export \
+          /tmp/flux create source git podinfo-export \
             --url https://github.com/stefanprodan/podinfo  \
             --tag-semver=">=3.2.3" \
             --export | kubectl apply -f -
-          ./bin/flux delete source git podinfo-export --silent
+          /tmp/flux delete source git podinfo-export --silent
       - name: flux get sources git
         run: |
-          ./bin/flux get sources git
+          /tmp/flux get sources git
       - name: flux get sources git --all-namespaces
         run: |
-          ./bin/flux get sources git --all-namespaces
+          /tmp/flux get sources git --all-namespaces
       - name: flux create kustomization
         run: |
-          ./bin/flux create kustomization podinfo \
+          /tmp/flux create kustomization podinfo \
             --source=podinfo \
             --path="./deploy/overlays/dev" \
             --prune=true \
@@ -90,112 +93,112 @@ jobs:
             --health-check-timeout=3m
       - name: flux reconcile kustomization --with-source
         run: |
-          ./bin/flux reconcile kustomization podinfo --with-source
+          /tmp/flux reconcile kustomization podinfo --with-source
       - name: flux get kustomizations
         run: |
-          ./bin/flux get kustomizations
+          /tmp/flux get kustomizations
       - name: flux get kustomizations --all-namespaces
         run: |
-          ./bin/flux get kustomizations --all-namespaces
+          /tmp/flux get kustomizations --all-namespaces
       - name: flux suspend kustomization
         run: |
-          ./bin/flux suspend kustomization podinfo
+          /tmp/flux suspend kustomization podinfo
       - name: flux resume kustomization
         run: |
-          ./bin/flux resume kustomization podinfo
+          /tmp/flux resume kustomization podinfo
       - name: flux export
         run: |
-          ./bin/flux export source git --all
-          ./bin/flux export kustomization --all
+          /tmp/flux export source git --all
+          /tmp/flux export kustomization --all
       - name: flux delete kustomization
         run: |
-          ./bin/flux delete kustomization podinfo --silent
+          /tmp/flux delete kustomization podinfo --silent
       - name: flux create source helm
         run: |
-          ./bin/flux create source helm podinfo \
+          /tmp/flux create source helm podinfo \
             --url https://stefanprodan.github.io/podinfo
       - name: flux create helmrelease --source=HelmRepository/podinfo
         run: |
-          ./bin/flux create hr podinfo-helm \
+          /tmp/flux create hr podinfo-helm \
             --target-namespace=default \
             --source=HelmRepository/podinfo \
             --chart=podinfo \
             --chart-version=">4.0.0 <5.0.0"
       - name: flux create helmrelease --source=GitRepository/podinfo
         run: |
-          ./bin/flux create hr podinfo-git \
+          /tmp/flux create hr podinfo-git \
             --target-namespace=default \
             --source=GitRepository/podinfo \
             --chart=./charts/podinfo
       - name: flux reconcile helmrelease --with-source
         run: |
-          ./bin/flux reconcile helmrelease podinfo-git --with-source
+          /tmp/flux reconcile helmrelease podinfo-git --with-source
       - name: flux get helmreleases
         run: |
-          ./bin/flux get helmreleases
+          /tmp/flux get helmreleases
       - name: flux get helmreleases --all-namespaces
         run: |
-          ./bin/flux get helmreleases --all-namespaces
+          /tmp/flux get helmreleases --all-namespaces
       - name: flux export helmrelease
         run: |
-          ./bin/flux export hr --all
+          /tmp/flux export hr --all
       - name: flux delete helmrelease podinfo-helm
         run: |
-          ./bin/flux delete hr podinfo-helm --silent
+          /tmp/flux delete hr podinfo-helm --silent
       - name: flux delete helmrelease podinfo-git
         run: |
-          ./bin/flux delete hr podinfo-git --silent
+          /tmp/flux delete hr podinfo-git --silent
       - name: flux delete source helm
         run: |
-          ./bin/flux delete source helm podinfo --silent
+          /tmp/flux delete source helm podinfo --silent
       - name: flux delete source git
         run: |
-          ./bin/flux delete source git podinfo --silent
+          /tmp/flux delete source git podinfo --silent
       - name: flux create tenant
         run: |
-          ./bin/flux create tenant dev-team --with-namespace=apps
-          ./bin/flux -n apps create source helm podinfo \
+          /tmp/flux create tenant dev-team --with-namespace=apps
+          /tmp/flux -n apps create source helm podinfo \
             --url https://stefanprodan.github.io/podinfo
-          ./bin/flux -n apps create hr podinfo-helm \
+          /tmp/flux -n apps create hr podinfo-helm \
             --source=HelmRepository/podinfo \
             --chart=podinfo \
             --chart-version="5.0.x" \
             --service-account=dev-team
       - name: flux create image repository
         run: |
-          ./bin/flux create image repository podinfo \
+          /tmp/flux create image repository podinfo \
             --image=ghcr.io/stefanprodan/podinfo \
             --interval=1m
       - name: flux create image policy
         run: |
-          ./bin/flux create image policy podinfo \
+          /tmp/flux create image policy podinfo \
             --image-ref=podinfo \
             --interval=1m \
             --select-semver=5.0.x
       - name: flux create image policy podinfo-select-alpha
         run: |
-          ./bin/flux create image policy podinfo-alpha \
+          /tmp/flux create image policy podinfo-alpha \
             --image-ref=podinfo \
             --interval=1m \
             --select-alpha=desc
       - name: flux get image policy
         run: |
-          ./bin/flux get image policy podinfo | grep '5.0.3'
+          /tmp/flux get image policy podinfo | grep '5.0.3'
       - name: flux2-kustomize-helm-example
         run: |
-          ./bin/flux create source git flux-system \
+          /tmp/flux create source git flux-system \
           --url=https://github.com/fluxcd/flux2-kustomize-helm-example \
           --branch=main
-          ./bin/flux create kustomization flux-system \
+          /tmp/flux create kustomization flux-system \
           --source=flux-system \
           --path=./clusters/staging
           kubectl -n flux-system wait kustomization/apps --for=condition=ready --timeout=2m
       - name: flux check
         run: |
-          ./bin/flux check
+          /tmp/flux check
       - name: flux uninstall
         run: |
-          ./bin/flux uninstall --silent
+          /tmp/flux uninstall --silent
       - name: Debug failure
         if: failure()
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: release
 
 on:
   push:
-    tags: [ '*' ]
+    tags: [ 'v*' ]
 
 jobs:
   goreleaser:
@@ -28,38 +28,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Kustomize
         uses: fluxcd/pkg//actions/kustomize@main
-      - name: Generate manifests tarball
+      - name: Generate manifests
         run: |
-          mkdir -p ./output
-          files=""
-
-          # build controllers
-          for controller in ./manifests/bases/*/; do
-              output_path="./output/$(basename $controller).yaml"
-              echo "building $controller to $output_path"
-
-              kustomize build $controller > $output_path
-              files+=" $(basename $output_path)"
-          done
-
-          # build rbac
-          rbac_path="./manifests/rbac"
-          rbac_output_path="./output/rbac.yaml"
-          echo "building $rbac_path to $rbac_output_path"
-          kustomize build $rbac_path > $rbac_output_path
-          files+=" $(basename $rbac_output_path)"
-
-          # build policies
-          policies_path="./manifests/policies"
-          policies_output_path="./output/policies.yaml"
-          echo "building $policies_path to $policies_output_path"
-          kustomize build $policies_path > $policies_output_path
-          files+=" $(basename $policies_output_path)"
-
-          # create tarball
-          cd ./output && tar -cvzf manifests.tar.gz $files
-      - name: Generate install manifest
-        run: |
+          make build-manifests
+          ./manifests/scripts/bundle.sh ./output manifests.tar.gz
           kustomize build ./manifests/install > ./output/install.yaml
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -27,6 +27,11 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v2
+      - name: Setup Kustomize
+        uses: fluxcd/pkg//actions/kustomize@main
+      - name: Build manifests
+        run: |
+          make build-manifests
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/golang@master
         continue-on-error: true

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 # vendor/
 bin/
 output/
+cmd/flux/manifests/

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,11 @@ fmt:
 vet:
 	go vet ./...
 
-test: tidy fmt vet docs
+test: build-manifests tidy fmt vet docs
 	go test ./... -coverprofile cover.out
+
+build-manifests:
+	./manifests/scripts/bundle.sh
 
 build:
 	CGO_ENABLED=0 go build -o ./bin/flux ./cmd/flux

--- a/cmd/flux/embed.go
+++ b/cmd/flux/embed.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+)
+
+//go:embed manifests/*.yaml
+var embeddedManifests embed.FS
+
+func writeEmbeddedManifests(dir string) error {
+	manifests, err := fs.ReadDir(embeddedManifests, "manifests")
+	if err != nil {
+		return err
+	}
+	for _, manifest := range manifests {
+		data, err := fs.ReadFile(embeddedManifests, path.Join("manifests", manifest.Name()))
+		if err != nil {
+			return fmt.Errorf("reading file failed: %w", err)
+		}
+
+		err = os.WriteFile(path.Join(dir, manifest.Name()), data, 0666)
+		if err != nil {
+			return fmt.Errorf("writing file failed: %w", err)
+		}
+	}
+	return nil
+}

--- a/cmd/flux/main.go
+++ b/cmd/flux/main.go
@@ -115,10 +115,12 @@ func init() {
 }
 
 func NewRootFlags() rootFlags {
-	return rootFlags{
+	rf := rootFlags{
 		pollInterval: 2 * time.Second,
 		defaults:     install.MakeDefaultOptions(),
 	}
+	rf.defaults.Version = "v" + VERSION
+	return rf
 }
 
 func main() {

--- a/cmd/flux/version.go
+++ b/cmd/flux/version.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/fluxcd/flux2/internal/utils"
+	"github.com/fluxcd/flux2/pkg/manifestgen/install"
+)
+
+func getVersion(input string) (string, error) {
+	if input == "" {
+		return rootArgs.defaults.Version, nil
+	}
+
+	if isEmbeddedVersion(input) {
+		return input, nil
+	}
+
+	var err error
+	if input == install.MakeDefaultOptions().Version {
+		input, err = install.GetLatestVersion()
+		if err != nil {
+			return "", err
+		}
+	} else {
+		if ok, err := install.ExistingVersion(input); err != nil || !ok {
+			if err == nil {
+				err = fmt.Errorf("targeted version '%s' does not exist", input)
+			}
+			return "", err
+		}
+	}
+
+	if !utils.CompatibleVersion(VERSION, input) {
+		return "", fmt.Errorf("targeted version '%s' is not compatible with your current version of flux (%s)", input, VERSION)
+	}
+	return input, nil
+}
+
+func isEmbeddedVersion(input string) bool {
+	return input == rootArgs.defaults.Version
+}

--- a/docs/cmd/flux_bootstrap.md
+++ b/docs/cmd/flux_bootstrap.md
@@ -20,7 +20,7 @@ The bootstrap sub-commands bootstrap the toolkit components on the targeted Git 
       --registry string            container registry where the toolkit images are published (default "ghcr.io/fluxcd")
       --token-auth                 when enabled, the personal access token will be used instead of SSH deploy key
       --toleration-keys strings    list of toleration keys used to schedule the components pods onto nodes with matching taints
-  -v, --version string             toolkit version (default "latest")
+  -v, --version string             toolkit version, when specified the manifests are downloaded from https://github.com/fluxcd/flux2/releases
       --watch-all-namespaces       watch for custom resources in all namespaces, if set to false it will only watch the namespace where the toolkit is installed (default true)
 ```
 

--- a/docs/cmd/flux_bootstrap_github.md
+++ b/docs/cmd/flux_bootstrap_github.md
@@ -76,7 +76,7 @@ flux bootstrap github [flags]
       --token-auth                 when enabled, the personal access token will be used instead of SSH deploy key
       --toleration-keys strings    list of toleration keys used to schedule the components pods onto nodes with matching taints
       --verbose                    print generated objects
-  -v, --version string             toolkit version (default "latest")
+  -v, --version string             toolkit version, when specified the manifests are downloaded from https://github.com/fluxcd/flux2/releases
       --watch-all-namespaces       watch for custom resources in all namespaces, if set to false it will only watch the namespace where the toolkit is installed (default true)
 ```
 

--- a/docs/cmd/flux_bootstrap_gitlab.md
+++ b/docs/cmd/flux_bootstrap_gitlab.md
@@ -72,7 +72,7 @@ flux bootstrap gitlab [flags]
       --token-auth                 when enabled, the personal access token will be used instead of SSH deploy key
       --toleration-keys strings    list of toleration keys used to schedule the components pods onto nodes with matching taints
       --verbose                    print generated objects
-  -v, --version string             toolkit version (default "latest")
+  -v, --version string             toolkit version, when specified the manifests are downloaded from https://github.com/fluxcd/flux2/releases
       --watch-all-namespaces       watch for custom resources in all namespaces, if set to false it will only watch the namespace where the toolkit is installed (default true)
 ```
 

--- a/docs/cmd/flux_install.md
+++ b/docs/cmd/flux_install.md
@@ -45,7 +45,7 @@ flux install [flags]
       --network-policy             deny ingress access to the toolkit controllers from other namespaces using network policies (default true)
       --registry string            container registry where the toolkit images are published (default "ghcr.io/fluxcd")
       --toleration-keys strings    list of toleration keys used to schedule the components pods onto nodes with matching taints
-  -v, --version string             toolkit version (default "latest")
+  -v, --version string             toolkit version, when specified the manifests are downloaded from https://github.com/fluxcd/flux2/releases
       --watch-all-namespaces       watch for custom resources in all namespaces, if set to false it will only watch the namespace where the toolkit is installed (default true)
 ```
 

--- a/manifests/scripts/bundle.sh
+++ b/manifests/scripts/bundle.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Flux authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+OUT_PATH=${1:-"${REPO_ROOT}/cmd/flux/manifests"}
+TAR=${2}
+
+info() {
+    echo '[INFO] ' "$@"
+}
+
+fatal() {
+    echo '[ERROR] ' "$@" >&2
+    exit 1
+}
+
+build() {
+  info "building $(basename $2)"
+  kustomize build "$1" > "$2"
+}
+
+if ! [ -x "$(command -v kustomize)" ]; then
+  fatal 'kustomize is not installed'
+fi
+
+rm -rf $OUT_PATH
+mkdir -p $OUT_PATH
+files=""
+
+info using "$(kustomize version --short)"
+
+# build controllers
+for controller in ${REPO_ROOT}/manifests/bases/*/; do
+    output_path="${OUT_PATH}/$(basename $controller).yaml"
+    build $controller $output_path
+    files+=" $(basename $output_path)"
+done
+
+# build rbac
+rbac_path="${REPO_ROOT}/manifests/rbac"
+rbac_output_path="${OUT_PATH}/rbac.yaml"
+build $rbac_path $rbac_output_path
+files+=" $(basename $rbac_output_path)"
+
+# build policies
+policies_path="${REPO_ROOT}/manifests/policies"
+policies_output_path="${OUT_PATH}/policies.yaml"
+build $policies_path $policies_output_path
+files+=" $(basename $policies_output_path)"
+
+# create tarball
+if [[ -n $TAR ]];then
+  info "archiving $TAR"
+  cd ${OUT_PATH} && tar -czf $TAR $files
+fi

--- a/pkg/manifestgen/install/install_test.go
+++ b/pkg/manifestgen/install/install_test.go
@@ -25,7 +25,7 @@ import (
 func TestGenerate(t *testing.T) {
 	opts := MakeDefaultOptions()
 	opts.TolerationKeys = []string{"node.kubernetes.io/controllers"}
-	output, err := Generate(opts)
+	output, err := Generate(opts, "")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR allows using the flux `install` and `bootstrap` commands in environments without access to GitHub releases (ref: https://github.com/fluxcd/flux2/discussions/913). 

Changes:
- add make target for generating the manifests using kustomize
- embed the generated manifests in flux binary
- use the embedded manifests by default in install and bootstrap commands
- download the manifests from GitHub only if the install/bootstrap `--version` arg is set to `latest` or to a value that's different to the CLI version
