### PR TITLE
Properly setup Go version in update workflow

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -13,7 +13,10 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
-
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
       - name: Update component versions
         id: update
         run: |


### PR DESCRIPTION
To prevent false `go.mod` modifications.
