### PR TITLE
Add `sourcesecret` and `kustomization` manifestgen

### DIFF
--- a/cmd/flux/bootstrap_gitlab.go
+++ b/cmd/flux/bootstrap_gitlab.go
@@ -29,12 +29,13 @@ import (
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 
 	"github.com/fluxcd/pkg/git"
 
 	"github.com/fluxcd/flux2/internal/flags"
 	"github.com/fluxcd/flux2/internal/utils"
+	"github.com/fluxcd/flux2/pkg/manifestgen/sourcesecret"
 )
 
 var bootstrapGitLabCmd = &cobra.Command{
@@ -218,44 +219,48 @@ func bootstrapGitLabCmdRun(cmd *cobra.Command, args []string) error {
 		logger.Successf("install completed")
 	}
 
-	repoURL := repository.GetURL()
-
+	repoURL := repository.GetSSH()
+	secretOpts := sourcesecret.Options{
+		Name:      rootArgs.namespace,
+		Namespace: rootArgs.namespace,
+	}
 	if bootstrapArgs.tokenAuth {
-		// setup HTTPS token auth
-		secret := corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      rootArgs.namespace,
-				Namespace: rootArgs.namespace,
-			},
-			StringData: map[string]string{
-				"username": "git",
-				"password": glToken,
-			},
+		// Setup HTTPS token auth
+		repoURL = repository.GetURL()
+		secretOpts.Username = "git"
+		secretOpts.Password = glToken
+	} else if shouldCreateDeployKey(ctx, kubeClient, rootArgs.namespace) {
+		// Setup SSH auth
+		u, err := url.Parse(repoURL)
+		if err != nil {
+			return fmt.Errorf("git URL parse failed: %w", err)
 		}
-		if err := upsertSecret(ctx, kubeClient, secret); err != nil {
+		secretOpts.SSHHostname = u.Hostname()
+		secretOpts.PrivateKeyAlgorithm = sourcesecret.RSAPrivateKeyAlgorithm
+		secretOpts.RSAKeyBits = 2048
+	}
+
+	secret, err := sourcesecret.Generate(secretOpts)
+	if err != nil {
+		return err
+	}
+	var s corev1.Secret
+	if err := yaml.Unmarshal([]byte(secret.Content), &s); err != nil {
+		return err
+	}
+	if len(s.StringData) > 0 {
+		logger.Actionf("configuring deploy key")
+		if err := upsertSecret(ctx, kubeClient, s); err != nil {
 			return err
 		}
-	} else {
-		// setup SSH deploy key
-		repoURL = repository.GetSSH()
-		if shouldCreateDeployKey(ctx, kubeClient, rootArgs.namespace) {
-			logger.Actionf("configuring deploy key")
-			u, err := url.Parse(repoURL)
-			if err != nil {
-				return fmt.Errorf("git URL parse failed: %w", err)
-			}
 
-			key, err := generateDeployKey(ctx, kubeClient, u, rootArgs.namespace)
-			if err != nil {
-				return fmt.Errorf("generating deploy key failed: %w", err)
-			}
-
+		if ppk, ok := s.StringData[sourcesecret.PublicKeySecretKey]; ok {
 			keyName := "flux"
 			if gitlabArgs.path != "" {
 				keyName = fmt.Sprintf("flux-%s", gitlabArgs.path)
 			}
 
-			if changed, err := provider.AddDeployKey(ctx, repository, key, keyName); err != nil {
+			if changed, err := provider.AddDeployKey(ctx, repository, ppk, keyName); err != nil {
 				return err
 			} else if changed {
 				logger.Successf("deploy key configured")

--- a/cmd/flux/create_secret.go
+++ b/cmd/flux/create_secret.go
@@ -18,15 +18,12 @@ package main
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/yaml"
 )
 
 var createSecretCmd = &cobra.Command{
@@ -37,23 +34,6 @@ var createSecretCmd = &cobra.Command{
 
 func init() {
 	createCmd.AddCommand(createSecretCmd)
-}
-
-func makeSecret(name string) (corev1.Secret, error) {
-	secretLabels, err := parseLabels()
-	if err != nil {
-		return corev1.Secret{}, err
-	}
-
-	return corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: rootArgs.namespace,
-			Labels:    secretLabels,
-		},
-		StringData: map[string]string{},
-		Data:       nil,
-	}, nil
 }
 
 func upsertSecret(ctx context.Context, kubeClient client.Client, secret corev1.Secret) error {
@@ -79,21 +59,5 @@ func upsertSecret(ctx context.Context, kubeClient client.Client, secret corev1.S
 	if err := kubeClient.Update(ctx, &existing); err != nil {
 		return err
 	}
-	return nil
-}
-
-func exportSecret(secret corev1.Secret) error {
-	secret.TypeMeta = metav1.TypeMeta{
-		APIVersion: "v1",
-		Kind:       "Secret",
-	}
-
-	data, err := yaml.Marshal(secret)
-	if err != nil {
-		return err
-	}
-
-	fmt.Println("---")
-	fmt.Println(resourceToString(data))
 	return nil
 }

--- a/cmd/flux/create_secret_tls.go
+++ b/cmd/flux/create_secret_tls.go
@@ -19,13 +19,14 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
 
 	"github.com/fluxcd/flux2/internal/utils"
+	"github.com/fluxcd/flux2/pkg/manifestgen/sourcesecret"
 )
 
 var createSecretTLSCmd = &cobra.Command{
@@ -68,61 +69,48 @@ func init() {
 	createSecretCmd.AddCommand(createSecretTLSCmd)
 }
 
-func populateSecretTLS(secret *corev1.Secret, args secretTLSFlags) error {
-	if args.certFile != "" && args.keyFile != "" {
-		cert, err := ioutil.ReadFile(args.certFile)
-		if err != nil {
-			return fmt.Errorf("failed to read repository cert file '%s': %w", args.certFile, err)
-		}
-		secret.StringData["certFile"] = string(cert)
-
-		key, err := ioutil.ReadFile(args.keyFile)
-		if err != nil {
-			return fmt.Errorf("failed to read repository key file '%s': %w", args.keyFile, err)
-		}
-		secret.StringData["keyFile"] = string(key)
-	}
-
-	if args.caFile != "" {
-		ca, err := ioutil.ReadFile(args.caFile)
-		if err != nil {
-			return fmt.Errorf("failed to read repository CA file '%s': %w", args.caFile, err)
-		}
-		secret.StringData["caFile"] = string(ca)
-	}
-	return nil
-}
-
 func createSecretTLSCmdRun(cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return fmt.Errorf("secret name is required")
 	}
 	name := args[0]
-	secret, err := makeSecret(name)
+
+	labels, err := parseLabels()
 	if err != nil {
 		return err
 	}
 
-	if err = populateSecretTLS(&secret, secretTLSArgs); err != nil {
+	opts := sourcesecret.Options{
+		Name:         name,
+		Namespace:    rootArgs.namespace,
+		Labels:       labels,
+		CAFilePath:   secretTLSArgs.caFile,
+		CertFilePath: secretTLSArgs.certFile,
+		KeyFilePath:  secretTLSArgs.keyFile,
+	}
+	secret, err := sourcesecret.Generate(opts)
+	if err != nil {
 		return err
 	}
 
 	if createArgs.export {
-		return exportSecret(secret)
+		fmt.Println(secret.Content)
+		return nil
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
 	defer cancel()
-
 	kubeClient, err := utils.KubeClient(rootArgs.kubeconfig, rootArgs.kubecontext)
 	if err != nil {
 		return err
 	}
-
-	if err := upsertSecret(ctx, kubeClient, secret); err != nil {
+	var s corev1.Secret
+	if err := yaml.Unmarshal([]byte(secret.Content), &s); err != nil {
 		return err
 	}
-	logger.Actionf("secret '%s' created in '%s' namespace", name, rootArgs.namespace)
+	if err := upsertSecret(ctx, kubeClient, s); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/docs/cmd/flux_create_secret_helm.md
+++ b/docs/cmd/flux_create_secret_helm.md
@@ -14,8 +14,8 @@ flux create secret helm [name] [flags]
 ### Examples
 
 ```
-    # Create a Helm authentication secret on disk and encrypt it with Mozilla SOPS
 
+  # Create a Helm authentication secret on disk and encrypt it with Mozilla SOPS
   flux create secret helm repo-auth \
     --namespace=my-namespace \
     --username=my-username \

--- a/docs/cmd/flux_create_source_git.md
+++ b/docs/cmd/flux_create_source_git.md
@@ -62,7 +62,7 @@ flux create source git [name] [flags]
   -p, --password string                        basic authentication password
       --secret-ref string                      the name of an existing secret containing SSH or basic credentials
       --ssh-ecdsa-curve ecdsaCurve             SSH ECDSA public key curve (p256, p384, p521) (default p384)
-      --ssh-key-algorithm publicKeyAlgorithm   SSH public key algorithm (rsa, ecdsa, ed25519) (default rsa)
+      --ssh-key-algorithm publicKeyAlgorithm   SSH public key algorithm (rsa, ecdsa, ed25519)
       --ssh-rsa-bits rsaKeyBits                SSH RSA public key bit size (multiplies of 8) (default 2048)
       --tag string                             git tag
       --tag-semver string                      git tag semver range

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
+	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0
 	k8s.io/api v0.20.2
 	k8s.io/apiextensions-apiserver v0.20.2
 	k8s.io/apimachinery v0.20.2

--- a/pkg/manifestgen/kustomization/kustomization.go
+++ b/pkg/manifestgen/kustomization/kustomization.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2021 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kustomization
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"sigs.k8s.io/kustomize/api/k8sdeps/kunstruct"
+	"sigs.k8s.io/kustomize/api/konfig"
+	kustypes "sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/yaml"
+
+	"github.com/fluxcd/flux2/pkg/manifestgen"
+)
+
+func Generate(options Options) (*manifestgen.Manifest, error) {
+	kfile := filepath.Join(options.TargetPath, konfig.DefaultKustomizationFileName())
+	abskfile := filepath.Join(options.BaseDir, kfile)
+
+	scan := func(base string) ([]string, error) {
+		var paths []string
+		uf := kunstruct.NewKunstructuredFactoryImpl()
+		err := options.FileSystem.Walk(base, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if path == base {
+				return nil
+			}
+			if info.IsDir() {
+				// If a sub-directory contains an existing Kustomization file add the
+				// directory as a resource and do not decent into it.
+				for _, kfilename := range konfig.RecognizedKustomizationFileNames() {
+					if options.FileSystem.Exists(filepath.Join(path, kfilename)) {
+						paths = append(paths, path)
+						return filepath.SkipDir
+					}
+				}
+				return nil
+			}
+			fContents, err := options.FileSystem.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			if _, err := uf.SliceFromBytes(fContents); err != nil {
+				return nil
+			}
+			paths = append(paths, path)
+			return nil
+		})
+		return paths, err
+	}
+
+	if _, err := os.Stat(abskfile); err != nil {
+		abs, err := filepath.Abs(filepath.Dir(abskfile))
+		if err != nil {
+			return nil, err
+		}
+
+		files, err := scan(abs)
+		if err != nil {
+			return nil, err
+		}
+
+		f, err := options.FileSystem.Create(abskfile)
+		if err != nil {
+			return nil, err
+		}
+		f.Close()
+
+		kus := kustypes.Kustomization{
+			TypeMeta: kustypes.TypeMeta{
+				APIVersion: kustypes.KustomizationVersion,
+				Kind:       kustypes.KustomizationKind,
+			},
+		}
+
+		var resources []string
+		for _, file := range files {
+			relP, err := filepath.Rel(abs, file)
+			if err != nil {
+				return nil, err
+			}
+			resources = append(resources, relP)
+		}
+
+		kus.Resources = resources
+		kd, err := yaml.Marshal(kus)
+		if err != nil {
+			return nil, err
+		}
+
+		return &manifestgen.Manifest{
+			Path:    kfile,
+			Content: string(kd),
+		}, nil
+	}
+
+	kd, err := ioutil.ReadFile(abskfile)
+	if err != nil {
+		return nil, err
+	}
+	return &manifestgen.Manifest{
+		Path:    kfile,
+		Content: string(kd),
+	}, nil
+}

--- a/pkg/manifestgen/kustomization/options.go
+++ b/pkg/manifestgen/kustomization/options.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Flux authors
+Copyright 2021 The Flux authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,34 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package sync
+package kustomization
 
-import (
-	"time"
-)
+import "sigs.k8s.io/kustomize/api/filesys"
 
 type Options struct {
-	Interval          time.Duration
-	URL               string
-	Name              string
-	Namespace         string
-	Branch            string
-	Secret            string
-	TargetPath        string
-	ManifestFile      string
-	GitImplementation string
+	FileSystem filesys.FileSystem
+	BaseDir    string
+	TargetPath string
 }
 
 func MakeDefaultOptions() Options {
 	return Options{
-		Interval:          1 * time.Minute,
-		URL:               "",
-		Name:              "flux-system",
-		Namespace:         "flux-system",
-		Branch:            "main",
-		Secret:            "flux-system",
-		ManifestFile:      "gotk-sync.yaml",
-		TargetPath:        "",
-		GitImplementation: "",
+		FileSystem: filesys.MakeFsOnDisk(),
+		BaseDir:    "",
+		TargetPath: "",
 	}
 }

--- a/pkg/manifestgen/sourcesecret/options.go
+++ b/pkg/manifestgen/sourcesecret/options.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2021 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sourcesecret
+
+import (
+	"crypto/elliptic"
+)
+
+type PrivateKeyAlgorithm string
+
+const (
+	RSAPrivateKeyAlgorithm     PrivateKeyAlgorithm = "rsa"
+	ECDSAPrivateKeyAlgorithm   PrivateKeyAlgorithm = "ecdsa"
+	Ed25519PrivateKeyAlgorithm PrivateKeyAlgorithm = "ed25519"
+)
+
+const (
+	UsernameSecretKey   = "username"
+	PasswordSecretKey   = "password"
+	CAFileSecretKey     = "caFile"
+	CertFileSecretKey   = "certFile"
+	KeyFileSecretKey    = "keyFile"
+	PrivateKeySecretKey = "identity"
+	PublicKeySecretKey  = "identity.pub"
+	KnownHostsSecretKey = "known_hosts"
+)
+
+type Options struct {
+	Name                string
+	Namespace           string
+	Labels              map[string]string
+	SSHHostname         string
+	PrivateKeyAlgorithm PrivateKeyAlgorithm
+	RSAKeyBits          int
+	ECDSACurve          elliptic.Curve
+	PrivateKeyPath      string
+	Username            string
+	Password            string
+	CAFilePath          string
+	CertFilePath        string
+	KeyFilePath         string
+	TargetPath          string
+	ManifestFile        string
+}
+
+func MakeDefaultOptions() Options {
+	return Options{
+		Name:                "flux-system",
+		Namespace:           "flux-system",
+		Labels:              map[string]string{},
+		PrivateKeyAlgorithm: RSAPrivateKeyAlgorithm,
+		PrivateKeyPath:      "",
+		Username:            "",
+		Password:            "",
+		CAFilePath:          "",
+		CertFilePath:        "",
+		KeyFilePath:         "",
+		ManifestFile:        "secret.yaml",
+	}
+}

--- a/pkg/manifestgen/sourcesecret/sourcesecret.go
+++ b/pkg/manifestgen/sourcesecret/sourcesecret.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2021 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sourcesecret
+
+import (
+	"bytes"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"path"
+	"time"
+
+	cryptssh "golang.org/x/crypto/ssh"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	"github.com/fluxcd/pkg/ssh"
+
+	"github.com/fluxcd/flux2/pkg/manifestgen"
+)
+
+const defaultSSHPort = 22
+
+func Generate(options Options) (*manifestgen.Manifest, error) {
+	var err error
+
+	var keypair *ssh.KeyPair
+	switch {
+	case options.Username != "", options.Password != "":
+		// noop
+	case len(options.PrivateKeyPath) > 0:
+		if keypair, err = loadKeyPair(options.PrivateKeyPath); err != nil {
+			return nil, err
+		}
+	case len(options.PrivateKeyAlgorithm) > 0:
+		if keypair, err = generateKeyPair(options); err != nil {
+			return nil, err
+		}
+	}
+
+	var hostKey []byte
+	if keypair != nil {
+		if hostKey, err = scanHostKey(options.SSHHostname); err != nil {
+			return nil, err
+		}
+	}
+
+	var caFile []byte
+	if options.CAFilePath != "" {
+		if caFile, err = ioutil.ReadFile(options.CAFilePath); err != nil {
+			return nil, fmt.Errorf("failed to read CA file: %w", err)
+		}
+	}
+
+	var certFile, keyFile []byte
+	if options.CertFilePath != "" && options.KeyFilePath != "" {
+		if certFile, err = ioutil.ReadFile(options.CertFilePath); err != nil {
+			return nil, fmt.Errorf("failed to read cert file: %w", err)
+		}
+		if keyFile, err = ioutil.ReadFile(options.KeyFilePath); err != nil {
+			return nil, fmt.Errorf("failed to read key file: %w", err)
+		}
+	}
+
+	secret := buildSecret(keypair, hostKey, caFile, certFile, keyFile, options)
+	b, err := yaml.Marshal(secret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &manifestgen.Manifest{
+		Path:    path.Join(options.TargetPath, options.Namespace, options.ManifestFile),
+		Content: fmt.Sprintf("---\n%s", resourceToString(b)),
+	}, nil
+}
+
+func buildSecret(keypair *ssh.KeyPair, hostKey, caFile, certFile, keyFile []byte, options Options) (secret corev1.Secret) {
+	secret.TypeMeta = metav1.TypeMeta{
+		APIVersion: "v1",
+		Kind:       "Secret",
+	}
+	secret.ObjectMeta = metav1.ObjectMeta{
+		Name:      options.Name,
+		Namespace: options.Namespace,
+	}
+	secret.Labels = options.Labels
+	secret.StringData = map[string]string{}
+
+	if options.Username != "" || options.Password != "" {
+		secret.StringData[UsernameSecretKey] = options.Username
+		secret.StringData[PasswordSecretKey] = options.Password
+	}
+
+	if caFile != nil {
+		secret.StringData[CAFileSecretKey] = string(caFile)
+	}
+
+	if certFile != nil && keyFile != nil {
+		secret.StringData[CertFileSecretKey] = string(certFile)
+		secret.StringData[KeyFileSecretKey] = string(keyFile)
+	}
+
+	if keypair != nil && hostKey != nil {
+		secret.StringData[PrivateKeySecretKey] = string(keypair.PrivateKey)
+		secret.StringData[PublicKeySecretKey] = string(keypair.PublicKey)
+		secret.StringData[KnownHostsSecretKey] = string(hostKey)
+	}
+
+	return
+}
+
+func loadKeyPair(path string) (*ssh.KeyPair, error) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open private key file: %w", err)
+	}
+
+	block, _ := pem.Decode(b)
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode PEM block")
+	}
+
+	ppk, err := cryptssh.ParsePrivateKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ssh.KeyPair{
+		PublicKey:  cryptssh.MarshalAuthorizedKey(ppk.PublicKey()),
+		PrivateKey: b,
+	}, nil
+}
+
+func generateKeyPair(options Options) (*ssh.KeyPair, error) {
+	var keyGen ssh.KeyPairGenerator
+	switch options.PrivateKeyAlgorithm {
+	case RSAPrivateKeyAlgorithm:
+		keyGen = ssh.NewRSAGenerator(options.RSAKeyBits)
+	case ECDSAPrivateKeyAlgorithm:
+		keyGen = ssh.NewECDSAGenerator(options.ECDSACurve)
+	case Ed25519PrivateKeyAlgorithm:
+		keyGen = ssh.NewEd25519Generator()
+	default:
+		return nil, fmt.Errorf("unsupported public key algorithm: %s", options.PrivateKeyAlgorithm)
+	}
+	pair, err := keyGen.Generate()
+	if err != nil {
+		return nil, fmt.Errorf("key pair generation failed, error: %w", err)
+	}
+	return pair, nil
+}
+
+func scanHostKey(host string) ([]byte, error) {
+	if _, _, err := net.SplitHostPort(host); err != nil {
+		// Assume we are dealing with a hostname without a port,
+		// append the default SSH port as this is required for
+		// host key scanning to work.
+		host = fmt.Sprintf("%s:%d", host, defaultSSHPort)
+	}
+	hostKey, err := ssh.ScanHostKey(host, 30*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("SSH key scan for host %s failed, error: %w", host, err)
+	}
+	return bytes.TrimSpace(hostKey), nil
+}
+
+func resourceToString(data []byte) string {
+	data = bytes.Replace(data, []byte("  creationTimestamp: null\n"), []byte(""), 1)
+	data = bytes.Replace(data, []byte("status: {}\n"), []byte(""), 1)
+	return string(data)
+}

--- a/pkg/manifestgen/sync/sync.go
+++ b/pkg/manifestgen/sync/sync.go
@@ -53,7 +53,7 @@ func Generate(options Options) (*manifestgen.Manifest, error) {
 				Branch: options.Branch,
 			},
 			SecretRef: &meta.LocalObjectReference{
-				Name: options.Name,
+				Name: options.Secret,
 			},
 			GitImplementation: options.GitImplementation,
 		},


### PR DESCRIPTION
This includes a change to the `sync` generator to make the deploy
secret name configurable for future implementation by deploy refactor in #968.