### PR TITLE
[docs] Fix fish completions example

### DIFF
--- a/cmd/flux/completion_fish.go
+++ b/cmd/flux/completion_fish.go
@@ -25,9 +25,7 @@ import (
 var completionFishCmd = &cobra.Command{
 	Use:   "fish",
 	Short: "Generates fish completion scripts",
-	Example: `To load completion run
-
-To configure your fish shell to load completions for each session write this script to your completions dir:
+	Example: `To configure your fish shell to load completions for each session write this script to your completions dir:
 
 flux completion fish > ~/.config/fish/completions/flux.fish
 

--- a/cmd/flux/completion_fish.go
+++ b/cmd/flux/completion_fish.go
@@ -27,11 +27,9 @@ var completionFishCmd = &cobra.Command{
 	Short: "Generates fish completion scripts",
 	Example: `To load completion run
 
-. <(flux completion fish)
-
 To configure your fish shell to load completions for each session write this script to your completions dir:
 
-flux completion fish > ~/.config/fish/completions/flux
+flux completion fish > ~/.config/fish/completions/flux.fish
 
 See http://fishshell.com/docs/current/index.html#completion-own for more details
 `,

--- a/docs/cmd/flux_completion_fish.md
+++ b/docs/cmd/flux_completion_fish.md
@@ -9,13 +9,9 @@ flux completion fish [flags]
 ### Examples
 
 ```
-To load completion run
-
-. <(flux completion fish)
-
 To configure your fish shell to load completions for each session write this script to your completions dir:
 
-flux completion fish > ~/.config/fish/completions/flux
+flux completion fish > ~/.config/fish/completions/flux.fish
 
 See http://fishshell.com/docs/current/index.html#completion-own for more details
 


### PR DESCRIPTION
Fixes #995 

This PR updates the documentation and removes the posix style sourcing for fish completions and corrects the file extension for the fish auto-completions.  