### PR TITLE
Use path with '/' slashes in created Kustomization

### DIFF
--- a/cmd/flux/create_kustomization.go
+++ b/cmd/flux/create_kustomization.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -142,7 +143,7 @@ func createKsCmdRun(cmd *cobra.Command, args []string) error {
 			Interval: metav1.Duration{
 				Duration: createArgs.interval,
 			},
-			Path:  kustomizationArgs.path.String(),
+			Path:  filepath.ToSlash(kustomizationArgs.path.String()),
 			Prune: kustomizationArgs.prune,
 			SourceRef: kustomizev1.CrossNamespaceSourceReference{
 				Kind: kustomizationArgs.source.Kind,


### PR DESCRIPTION
This fixes a bug on Windows where the safe relative path would contain
'\' slashes, which are not compatible with the controller.

Fixes: #1006 