### PR TITLE
Update installation guide for Azure DevOps GitRepository Source

### DIFF
--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -358,7 +358,7 @@ If you don't specify the SSH algorithm, then `flux` will generate an RSA 2048 bi
       --git-implementation=libgit2 \
       --url=https://dev.azure.com/<org>/<project>/_git/<repository> \
       --branch=master \
-      --username=git \
+      --username='' \
       --password=token \
       --interval=1m
     ```


### PR DESCRIPTION
Update installation guide updating `username` to be empty inside tip for Azure DevOps with HTTP basic authentication, in order to reflect the documentation on Azure DevOps about using Personal Access Token for HTTP authentication:
https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=preview-page#use-a-pat