### PR TITLE
don't default to prune=yes in migration documents. 

### DIFF
--- a/docs/guides/flux-v1-migration.md
+++ b/docs/guides/flux-v1-migration.md
@@ -169,7 +169,7 @@ Configure the reconciliation of the `deploy` dir on your cluster:
 $ flux create kustomization app \
   --source=app \
   --path="./deploy" \
-  --prune=true \
+  --prune=false \
   --interval=10m
 ✚ generating Kustomization
 ► applying Kustomization
@@ -244,7 +244,7 @@ Configure the reconciliation of the `prod` overlay on your cluster:
 flux create kustomization app \
   --source=GitRepository/app \
   --path="./overlays/prod" \
-  --prune=true \
+  --prune=false \
   --interval=10m
 ```
 


### PR DESCRIPTION
When following these instructions migrating an existing cluster you can accidentally prune resources if you're not paying attention. This could cause a catastrophic loss of cluster resources and ruin some ones day.