### PR TITLE
Migration and Support Timetable

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -95,3 +95,28 @@ body {
   .progress-0plus .progress-bar {
     background-color: #ff1744;
   }
+
+/* Custom admonitions */
+/* See https://squidfunk.github.io/mkdocs-material/reference/admonitions */
+:root {
+  --md-admonition-icon--heart: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M14 20.408c-.492.308-.903.546-1.192.709-.153.086-.308.17-.463.252h-.002a.75.75 0 0 1-.686 0 16.709 16.709 0 0 1-.465-.252 31.147 31.147 0 0 1-4.803-3.34C3.8 15.572 1 12.331 1 8.513 1 5.052 3.829 2.5 6.736 2.5 9.03 2.5 10.881 3.726 12 5.605 13.12 3.726 14.97 2.5 17.264 2.5 20.17 2.5 23 5.052 23 8.514c0 3.818-2.801 7.06-5.389 9.262A31.146 31.146 0 0 1 14 20.408z"/></svg>')
+}
+.md-typeset .admonition.heart,
+.md-typeset details.heart {
+  border-color: rgb(233, 30, 99);
+}
+.md-typeset .heart > .admonition-title,
+.md-typeset .heart > summary {
+  background-color: rgba(233, 30, 99, 0.1);
+}
+.md-typeset .heart > .admonition-title::before,
+.md-typeset .heart > summary::before {
+  background-color: rgb(233, 30, 99);
+  -webkit-mask-image: var(--md-admonition-icon--heart);
+          mask-image: var(--md-admonition-icon--heart);
+}
+
+.timetable-explicit-col-widths th:nth-child(1) { width: 4%; }
+.timetable-explicit-col-widths th:nth-child(2) { width: 32%; }
+.timetable-explicit-col-widths th:nth-child(3) { width: 32%; }
+.timetable-explicit-col-widths th:nth-child(4) { width: 32%; }

--- a/docs/migration/timetable.md
+++ b/docs/migration/timetable.md
@@ -1,0 +1,38 @@
+---
+hide:
+  # The table data on this page is easier to read when wider
+  # The TOC right column is already blank anyway
+  - toc
+---
+# Migration and Support Timetable
+
+!!! heart "Flux Migration Commitment"
+    This public timetable clarifies our commitment to end users.
+    Its purpose is to help improve your experience in deciding how and when to plan infra decisions related to Flux versions.
+    Please refer to the [Roadmap](../roadmap/index.md) for additional details.
+
+<!-- Note: this div allows us to set fixed column widths in custom.css -->
+<!-- See: https://github.com/squidfunk/mkdocs-material/issues/118 -->
+<div markdown="1" class="timetable-explicit-col-widths">
+
+<!-- Requires mkdocs markdown_extensions footnotes and pymdownx.caret -->
+<!-- markdownlint-disable-file MD033 -->
+| Date | Flux 1 | Flux 2 CLI | GOTK[^1] |
+| -- | -- | -- | -- |
+| Oct 6, 2020 | ^^[Maintenance Mode](https://github.com/fluxcd/website/pull/25)^^<br><ul><li>Flux 1 releases only include critical bug fixes (which don’t require changing Flux 1 architecture), and security patches (for OS packages, Go runtime, and kubectl). No new features</li><li>Existing projects encouraged to test migration to Flux 2 pre-releases in non-production</li></ul> | ^^Development Mode^^<br><ul><li>Working to finish parity with Flux 1</li><li>New projects encouraged to test Flux 2 pre-releases in non-production</li></ul> | ^^All Alpha^^[^2] |
+Feb 18, 2021 | ^^Partial Migration Mode^^<br><ul><li>Existing projects encouraged to migrate to `v1beta1`/`v2beta1` if you only use those features (Flux 1 read-only mode, and Helm Operator)</li><li>Existing projects encouraged to test image automation Alpha in non-production</li></ul> | ^^Feature Parity^^ | ^^Image Automation Alpha. All others reached Feature Parity, Beta^^ |
+| TBD | ^^Superseded^^<br><ul><li>All existing projects encouraged to [migrate to Flux 2](https://toolkit.fluxcd.io/guides/flux-v1-migration/), and [report any bugs](https://github.com/fluxcd/flux2/issues/new/choose)</li><li>Flux 1 Helm Operator archived – no further updates due to unsupported dependencies</li></ul> | ^^Needs further testing, may get breaking changes^^<br><ul><li>CLI needs further user testing during this migration period</li></ul> | ^^All Beta, Production Ready^^[^3]<br><ul><li>All Flux 1 features stable and supported in Flux 2</li><li>Promoting Alpha versions to Beta makes this Production Ready</li></ul> |
+| TBD | ^^Migration and security support only^^<br><ul><li>Flux 1 releases only include security patches (no bug fixes)</li><li>Maintainers support users with migration to Flux 2 only, no longer with Flux 1 issues</li><li>Flux 1 archive date announced</li></ul> | ^^Public release (GA), Production Ready^^<br><ul><li>CLI commits to backwards compatibility moving forward</li><li>CLI follows kubectl style backwards compatibility support: +1 -1 MINOR version for server components (e.g., APIs, Controllers, validation webhooks)</li></ul> | ^^All Beta, Production Ready^^ |
+| TBD | ^^Archived^^<br><ul><li>Flux 1 obsolete, no further releases or maintainer support</li><li>Flux 1 repo archived</li></ul> | ^^Continued active development^^ | ^^Continued active development^^ |
+
+<!-- end .timetable-explicit-col-widths -->
+</div>
+
+[^1]: GOTK is shorthand for the [GitOps Toolkit](https://toolkit.fluxcd.io/components/) APIs and Controllers
+
+[^2]: Versioning: Flux 2 is a multi-service architecture, so requires a more complex explanation than Flux 1:
+     - Flux 2 CLI follows [Semantic Versioning](https://semver.org/) scheme
+     - The GitOps Toolkit APIs follow the [Kubernetes API versioning](https://kubernetes.io/docs/reference/using-api/#api-versioning) pattern. See [Roadmap](https://toolkit.fluxcd.io/roadmap/) for component versions.
+     - These are coordinated for cross-compatibility: For each Flux 2 CLI tag, CLI and GOTK versions are end-to-end tested together, so you may safely upgrade from one MINOR/PATCH version to another.
+
+[^3]: The GOTK Custom Resource Definitions which are at `v1beta1` and `v2beta1` and their controllers are considered stable and production ready. Going forward, breaking changes to the beta CRDs will be accompanied by a conversion mechanism.

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -4,6 +4,7 @@
     The Flux custom resource definitions which are at `v1beta1` and `v2beta1`
     and their controllers are considered stable and production ready.
     Going forward, breaking changes to the beta CRDs will be accompanied by a conversion mechanism.
+    Please see the [Migration and Suport Timetable](../migration/timetable.md) for our commitment to end users.
 
 The following components (included by default in [flux bootstrap](../guides/installation.md#bootstrap))
 are considered production ready:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,31 +26,34 @@ plugins:
 
 markdown_extensions:
   - admonition
-  - meta
   - codehilite:
       guess_lang: false
-  - toc:
-      permalink: true
+  - footnotes
+  - meta
+  - pymdownx.caret
+  - pymdownx.emoji:
+      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:materialx.emoji.twemoji
+  - pymdownx.extra
+  - pymdownx.progressbar
   - pymdownx.superfences:
       highlight_code: true
   - pymdownx.tabbed
-  - pymdownx.tilde
-  - pymdownx.progressbar
   - pymdownx.tasklist
-  - pymdownx.superfences
-  - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+  - pymdownx.tilde
+  - toc:
+      permalink: true
 
 nav:
   - Introduction: index.md
   - Core Concepts: core-concepts/index.md
   - Get Started: get-started/index.md
   - Migration:
-     - Migrate from Flux v1: guides/flux-v1-migration.md
-     - Migrate from Flux v1 image update automation: guides/flux-v1-automation-migration.md
-     - Migrate from the Helm Operator: guides/helm-operator-migration.md
-     - FAQ: guides/faq-migration.md
+    - Migration and Support Timetable: migration/timetable.md
+    - Migrate from Flux v1: guides/flux-v1-migration.md
+    - Migrate from Flux v1 image update automation: guides/flux-v1-automation-migration.md
+    - Migrate from the Helm Operator: guides/helm-operator-migration.md
+    - FAQ: guides/faq-migration.md
   - Guides:
       - Installation: guides/installation.md
       - Manage Helm Releases: guides/helmreleases.md


### PR DESCRIPTION
Thanks to @stefanprodan for collab on details, and to those who gave feedback on [my initial gist](https://gist.github.com/scottrigby/f9030494d8d6566a983e2d12c87d70de) during the [Feb 25 2001](https://docs.google.com/document/d/1l_M0om0qUEN_NNiGgpqJ2tvsF2iioHkaARDeh6b70B0/view#heading=h.7oos817jjrag) Flux dev meeting.

This PR additionally adds mkdocs `markdown_extensions` and sorts the list alphabetically (I noticed there was one duplicate. May be helpful). Also adds custom admonition for the Timetable page (and anywhere else we want to use it).

## Preview

You can see the timetable in a (mostly) readable format [HERE](https://github.com/scottrigby/flux2/blob/migration-timetable/docs/migration/timetable.md). That just won't render `^insert me^` as `<INS>`, or `[^1]` as footnotes without the mkdocs md extensions (see [caret insert](https://facelessuser.github.io/pymdown-extensions/extensions/caret/#insert) and [footnotes](https://squidfunk.github.io/mkdocs-material/reference/footnotes/)). 

But the best way to preview is locally:
1. `pip install mkdocs-material-extensions`
2. `mkdocs serve`

## Screenshots

Here's are pngs from serving locally with `mkdocs serve`:

### Timetable page

![screencapture-127-0-0-1-8000-migration-timetable-2021-03-09-16_48_33](https://user-images.githubusercontent.com/407675/110542822-8d402200-80f7-11eb-8c9d-0e2817654a40.png)

### Link on Roadmap

<img width="1267" alt="Screen Shot 2021-03-08 at 2 23 04 PM" src="https://user-images.githubusercontent.com/407675/110370967-5ba55900-801a-11eb-805b-8fb1a758adcd.png">
