### PR TITLE
Restore default key algorithm flag create source

### DIFF
--- a/cmd/flux/create_secret_git.go
+++ b/cmd/flux/create_secret_git.go
@@ -96,7 +96,7 @@ func init() {
 
 func NewSecretGitFlags() secretGitFlags {
 	return secretGitFlags{
-		keyAlgorithm: "rsa",
+		keyAlgorithm: flags.PublicKeyAlgorithm(sourcesecret.RSAPrivateKeyAlgorithm),
 		rsaBits:      2048,
 		ecdsaCurve:   flags.ECDSACurve{Curve: elliptic.P384()},
 	}

--- a/cmd/flux/create_source_git.go
+++ b/cmd/flux/create_source_git.go
@@ -122,6 +122,7 @@ func init() {
 
 func newSourceGitFlags() sourceGitFlags {
 	return sourceGitFlags{
+		keyAlgorithm:  flags.PublicKeyAlgorithm(sourcesecret.RSAPrivateKeyAlgorithm),
 		keyRSABits:    2048,
 		keyECDSACurve: flags.ECDSACurve{Curve: elliptic.P384()},
 	}

--- a/docs/cmd/flux_create_source_git.md
+++ b/docs/cmd/flux_create_source_git.md
@@ -62,7 +62,7 @@ flux create source git [name] [flags]
   -p, --password string                        basic authentication password
       --secret-ref string                      the name of an existing secret containing SSH or basic credentials
       --ssh-ecdsa-curve ecdsaCurve             SSH ECDSA public key curve (p256, p384, p521) (default p384)
-      --ssh-key-algorithm publicKeyAlgorithm   SSH public key algorithm (rsa, ecdsa, ed25519)
+      --ssh-key-algorithm publicKeyAlgorithm   SSH public key algorithm (rsa, ecdsa, ed25519) (default rsa)
       --ssh-rsa-bits rsaKeyBits                SSH RSA public key bit size (multiplies of 8) (default 2048)
       --tag string                             git tag
       --tag-semver string                      git tag semver range


### PR DESCRIPTION
This was removed by accident in the PR that introduced the new
`manifestgen` packages, and now restored in full glory.