### PR TITLE
Make manifests dir `bundle.sh` configurable

### DIFF
--- a/.github/aur/flux-go/PKGBUILD.template
+++ b/.github/aur/flux-go/PKGBUILD.template
@@ -12,7 +12,7 @@ provides=("flux-bin")
 conflicts=("flux-bin")
 replaces=("flux-cli")
 depends=("glibc")
-makedepends=("go")
+makedepends=('go>=1.16', 'kustomize>=3.0')
 optdepends=('kubectl: for apply actions on the Kubernetes cluster',
 'bash-completion: auto-completion for flux in Bash',
 'zsh-completions: auto-completion for flux in ZSH')
@@ -30,8 +30,9 @@ build() {
   export CGO_CFLAGS="$CFLAGS"
   export CGO_CXXFLAGS="$CXXFLAGS"
   export CGO_CPPFLAGS="$CPPFLAGS"
-  export GOFLAGS="-buildmode=pie -trimpath -ldflags=-linkmode=external -mod=readonly -modcacherw"
-  go build -ldflags "-X main.VERSION=${pkgver}" -o ${_srcname} ./cmd/flux
+  export GOFLAGS="-buildmode=pie -trimpath -mod=readonly -modcacherw"
+  ./manifests/scripts/bundle.sh "${PWD}/manifests" "${PWD}/cmd/flux/manifests"
+  go build -ldflags "-linkmode=external -X main.VERSION=${pkgver}" -o ${_srcname} ./cmd/flux
 }
 
 check() {

--- a/.github/aur/flux-scm/PKGBUILD.template
+++ b/.github/aur/flux-scm/PKGBUILD.template
@@ -11,7 +11,7 @@ license=("APACHE")
 provides=("flux-bin")
 conflicts=("flux-bin")
 depends=("glibc")
-makedepends=("go")
+makedepends=('go>=1.16', 'kustomize>=3.0')
 optdepends=('kubectl: for apply actions on the Kubernetes cluster',
 'bash-completion: auto-completion for flux in Bash',
 'zsh-completions: auto-completion for flux in ZSH')
@@ -32,8 +32,9 @@ build() {
   export CGO_CFLAGS="$CFLAGS"
   export CGO_CXXFLAGS="$CXXFLAGS"
   export CGO_CPPFLAGS="$CPPFLAGS"
-  export GOFLAGS="-buildmode=pie -trimpath -ldflags=-linkmode=external -mod=readonly -modcacherw"
-  go build -ldflags "-X main.VERSION=${pkgver}" -o ${_srcname} ./cmd/flux
+  export GOFLAGS="-buildmode=pie -trimpath -mod=readonly -modcacherw"
+  make cmd/flux/manifests
+  go build -ldflags "-linkmode=external -X main.VERSION=${pkgver}" -o ${_srcname} ./cmd/flux
 }
 
 check() {

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Generate manifests
         run: |
           make cmd/flux/manifests
-          ./manifests/scripts/bundle.sh ./output manifests.tar.gz
+          ./manifests/scripts/bundle.sh "" ./output manifests.tar.gz
           kustomize build ./manifests/install > ./output/install.yaml
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1

--- a/manifests/scripts/bundle.sh
+++ b/manifests/scripts/bundle.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2020 The Flux authors. All rights reserved.
+# Copyright 2020, 2021 The Flux authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 
 set -e
 
-REPO_ROOT=$(git rev-parse --show-toplevel)
-OUT_PATH=${1:-"${REPO_ROOT}/cmd/flux/manifests"}
-TAR=${2}
+IN_PATH=${1:-"$(git rev-parse --show-toplevel)/manifests"}
+OUT_PATH=${2:-"$(git rev-parse --show-toplevel)/cmd/flux/manifests"}
+TAR=${3}
 
 info() {
     echo '[INFO] ' "$@"
@@ -45,20 +45,20 @@ files=""
 info using "$(kustomize version --short)"
 
 # build controllers
-for controller in ${REPO_ROOT}/manifests/bases/*/; do
+for controller in ${IN_PATH}/bases/*/; do
     output_path="${OUT_PATH}/$(basename $controller).yaml"
     build $controller $output_path
     files+=" $(basename $output_path)"
 done
 
 # build rbac
-rbac_path="${REPO_ROOT}/manifests/rbac"
+rbac_path="${IN_PATH}/rbac"
 rbac_output_path="${OUT_PATH}/rbac.yaml"
 build $rbac_path $rbac_output_path
 files+=" $(basename $rbac_output_path)"
 
 # build policies
-policies_path="${REPO_ROOT}/manifests/policies"
+policies_path="${IN_PATH}/policies"
 policies_output_path="${OUT_PATH}/policies.yaml"
 build $policies_path $policies_output_path
 files+=" $(basename $policies_output_path)"


### PR DESCRIPTION
There was an assumption in this script that it is always executed in Git
repository/directory, this is however not always true, for example when
one downloads the `.tar.gz` that is made available for every release
by GitHub (and used in one of our AUR packages).

This commit changes this, and makes the first argument of `bundle.sh`
configurable, so a custom manifests directory can always be defined
_without_ relying on Git.

Omitting it, or passing an empty string, will still fall back to the
previous behavior of using `git rev-parse --show-toplevel`.