### PR TITLE
cmd/flux/export_source*: fix typo in comment

### DIFF
--- a/cmd/flux/export_source_bucket.go
+++ b/cmd/flux/export_source_bucket.go
@@ -34,7 +34,7 @@ import (
 var exportSourceBucketCmd = &cobra.Command{
 	Use:   "bucket [name]",
 	Short: "Export Bucket sources in YAML format",
-	Long:  "The export source git command exports on or all Bucket sources in YAML format.",
+	Long:  "The export source git command exports one or all Bucket sources in YAML format.",
 	Example: `  # Export all Bucket sources
   flux export source bucket --all > sources.yaml
 

--- a/cmd/flux/export_source_git.go
+++ b/cmd/flux/export_source_git.go
@@ -34,7 +34,7 @@ import (
 var exportSourceGitCmd = &cobra.Command{
 	Use:   "git [name]",
 	Short: "Export GitRepository sources in YAML format",
-	Long:  "The export source git command exports on or all GitRepository sources in YAML format.",
+	Long:  "The export source git command exports one or all GitRepository sources in YAML format.",
 	Example: `  # Export all GitRepository sources
   flux export source git --all > sources.yaml
 

--- a/cmd/flux/export_source_helm.go
+++ b/cmd/flux/export_source_helm.go
@@ -34,7 +34,7 @@ import (
 var exportSourceHelmCmd = &cobra.Command{
 	Use:   "helm [name]",
 	Short: "Export HelmRepository sources in YAML format",
-	Long:  "The export source git command exports on or all HelmRepository sources in YAML format.",
+	Long:  "The export source git command exports one or all HelmRepository sources in YAML format.",
 	Example: `  # Export all HelmRepository sources
   flux export source helm --all > sources.yaml
 

--- a/docs/cmd/flux_export_source_bucket.md
+++ b/docs/cmd/flux_export_source_bucket.md
@@ -4,7 +4,7 @@ Export Bucket sources in YAML format
 
 ### Synopsis
 
-The export source git command exports on or all Bucket sources in YAML format.
+The export source git command exports one or all Bucket sources in YAML format.
 
 ```
 flux export source bucket [name] [flags]

--- a/docs/cmd/flux_export_source_git.md
+++ b/docs/cmd/flux_export_source_git.md
@@ -4,7 +4,7 @@ Export GitRepository sources in YAML format
 
 ### Synopsis
 
-The export source git command exports on or all GitRepository sources in YAML format.
+The export source git command exports one or all GitRepository sources in YAML format.
 
 ```
 flux export source git [name] [flags]

--- a/docs/cmd/flux_export_source_helm.md
+++ b/docs/cmd/flux_export_source_helm.md
@@ -4,7 +4,7 @@ Export HelmRepository sources in YAML format
 
 ### Synopsis
 
-The export source git command exports on or all HelmRepository sources in YAML format.
+The export source git command exports one or all HelmRepository sources in YAML format.
 
 ```
 flux export source helm [name] [flags]


### PR DESCRIPTION
This commit fixes a small typo in the comments for the export source
commands.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>