### PR TITLE
Fix hint in Flux v1 Migration guide

### DIFF
--- a/docs/guides/flux-v1-automation-migration.md
+++ b/docs/guides/flux-v1-automation-migration.md
@@ -431,8 +431,8 @@ spec:
 ```
 
 !!! hint
-  If you are using the same image repository in several manifests, you only need one
-  `ImageRepository` object for it.
+    If you are using the same image repository in several manifests, you only need one
+    `ImageRepository` object for it.
 
 ##### Using image registry credentials for scanning
 


### PR DESCRIPTION
The wrong indenting here means the hint body will not display as a hint, this fixes it.