### PR TITLE
Fix updating of `go.mod` entries for components

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -30,7 +30,7 @@ jobs:
               # bump kustomize
               sed -i "s/\($1\/releases\/download\/\)v.*\(\/.*\)/\1${RELEASE_VERSION}\2/g" "manifests/bases/$1/kustomization.yaml"
 
-              if [[ ! -z $(go list -m all | grep "github.com/fluxcd/$1/api" | awk '{print $2}') ]]; then
+              if [[ ! -z $(grep "github.com/fluxcd/$1/api" go.mod | awk '{print $2}') ]]; then
                 # bump go mod
                 go mod edit -require="github.com/fluxcd/$1/api@${RELEASE_VERSION}"
               fi


### PR DESCRIPTION
We noticed that some of our components had not received `go.mod` updates
while they did receive updates for the versions declared in the YAML
manifests.

Was able to trace this back to a behavior change in Go since `1.16.x`,
resulting in it no longer making automated changes to `go.mod` and
`go.sum`[1]. This is an issue for our updater script as it relies
on `go list -m all`, which now after the first `go mod edit` returns:

```console
$ go list -m all
go: github.com/fluxcd/notification-controller/api@v0.10.0: missing
go.sum entry; to add it:
        go mod download github.com/fluxcd/notification-controller/api
```

To work around the issue without having to repeatedly call `go mod tidy`,
I have opted to simply `grep` on the contents of `go.mod` as a
workaround.

[1]: https://blog.golang.org/go116-module-changes#TOC_3.
