### PR TITLE
Add repo path and push branch to image update cmd

### DIFF
--- a/cmd/flux/create_image_policy.go
+++ b/cmd/flux/create_image_policy.go
@@ -32,7 +32,7 @@ import (
 )
 
 var createImagePolicyCmd = &cobra.Command{
-	Use:   "policy <name>",
+	Use:   "policy [name]",
 	Short: "Create or update an ImagePolicy object",
 	Long: `The create image policy command generates an ImagePolicy resource.
 An ImagePolicy object calculates a "latest image" given an image
@@ -40,6 +40,18 @@ repository and a policy, e.g., semver.
 
 The image that sorts highest according to the policy is recorded in
 the status of the object.`,
+	Example: `  # Create an ImagePolicy to select the latest stable release
+  flux create image policy podinfo \
+    --image-ref=podinfo \
+    --select-semver=">=1.0.0"
+
+  # Create an ImagePolicy to select the latest main branch build tagged as "${GIT_BRANCH}-${GIT_SHA:0:7}-$(date +%s)"
+  flux create image policy podinfo \
+    --image-ref=podinfo \
+    --select-numeric=asc \
+	--filter-regex='^main-[a-f0-9]+-(?P<ts>[0-9]+)' \
+	--filter-extract='$ts'
+`,
 	RunE: createImagePolicyRun}
 
 type imagePolicyFlags struct {

--- a/cmd/flux/create_image_repository.go
+++ b/cmd/flux/create_image_repository.go
@@ -30,7 +30,7 @@ import (
 )
 
 var createImageRepositoryCmd = &cobra.Command{
-	Use:   "repository <name>",
+	Use:   "repository [name]",
 	Short: "Create or update an ImageRepository object",
 	Long: `The create image repository command generates an ImageRepository resource.
 An ImageRepository object specifies an image repository to scan.`,

--- a/cmd/flux/logs.go
+++ b/cmd/flux/logs.go
@@ -21,38 +21,37 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/fluxcd/flux2/internal/flags"
-	"github.com/fluxcd/flux2/internal/utils"
-	"github.com/spf13/cobra"
 	"html/template"
 	"io"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"os"
-	"strings"
-	"sync"
+
+	"github.com/fluxcd/flux2/internal/flags"
+	"github.com/fluxcd/flux2/internal/utils"
 )
 
 var logsCmd = &cobra.Command{
 	Use:   "logs",
-	Short: "Display formatted logs for toolkit components",
-	Long:  "The logs command displays formatted logs from various toolkit components.",
-	Example: `# Get logs from toolkit components
-	 flux logs
+	Short: "Display formatted logs for Flux components",
+	Long:  "The logs command displays formatted logs from various Flux components.",
+	Example: `  # Print the reconciliation logs of all Flux custom resources in your cluster
+	 flux logs --all-namespaces
 
-	# Stream logs from toolkit components
-	flux logs --follow
- 
-	# Get logs from toolkit components in a particular namespace
-	flux logs --flux-namespace my-namespace
+	# Stream logs for a particular log level
+	flux logs --follow --level=error --all-namespaces
 
-	# Get logs for a particular log level
-	flux logs --level=info
+	# Filter logs by kind, name and namespace
+	flux logs --kind=Kustomization --name=podinfo --namespace=default
 
-	# Filter logs by kind, name, or namespace
-	flux logs --kind=kustomization --name podinfo --namespace default
+	# Print logs when Flux is installed in a different namespace than flux-system
+	flux logs --flux-namespace=my-namespace
     `,
 	RunE: logsCmdRun,
 }
@@ -75,9 +74,9 @@ func init() {
 	logsCmd.Flags().Var(&logsArgs.logLevel, "level", logsArgs.logLevel.Description())
 	logsCmd.Flags().StringVarP(&logsArgs.kind, "kind", "", logsArgs.kind, "displays errors of a particular toolkit kind e.g GitRepository")
 	logsCmd.Flags().StringVarP(&logsArgs.name, "name", "", logsArgs.name, "specifies the name of the object logs to be displayed")
-	logsCmd.Flags().BoolVarP(&logsArgs.follow, "follow", "f", logsArgs.follow, "Specifies if the logs should be streamed")
+	logsCmd.Flags().BoolVarP(&logsArgs.follow, "follow", "f", logsArgs.follow, "specifies if the logs should be streamed")
 	logsCmd.Flags().Int64VarP(&logsArgs.tail, "tail", "", logsArgs.tail, "lines of recent log file to display")
-	logsCmd.Flags().StringVarP(&logsArgs.fluxNamespace, "flux-namespace", "", rootArgs.defaults.Namespace, "the namespace where the Flux components are running.")
+	logsCmd.Flags().StringVarP(&logsArgs.fluxNamespace, "flux-namespace", "", rootArgs.defaults.Namespace, "the namespace where the Flux components are running")
 	logsCmd.Flags().BoolVarP(&logsArgs.allNamespaces, "all-namespaces", "A", false, "displays logs for objects across all namespaces")
 	rootCmd.AddCommand(logsCmd)
 }

--- a/docs/cmd/flux.md
+++ b/docs/cmd/flux.md
@@ -85,7 +85,7 @@ Command line utility for assembling Kubernetes CD pipelines the GitOps way.
 * [flux export](flux_export.md)	 - Export resources in YAML format
 * [flux get](flux_get.md)	 - Get sources and resources
 * [flux install](flux_install.md)	 - Install or upgrade Flux
-* [flux logs](flux_logs.md)	 - Display formatted logs for toolkit components
+* [flux logs](flux_logs.md)	 - Display formatted logs for Flux components
 * [flux reconcile](flux_reconcile.md)	 - Reconcile sources and resources
 * [flux resume](flux_resume.md)	 - Resume suspended resources
 * [flux suspend](flux_suspend.md)	 - Suspend resources

--- a/docs/cmd/flux_create_image_policy.md
+++ b/docs/cmd/flux_create_image_policy.md
@@ -12,7 +12,24 @@ The image that sorts highest according to the policy is recorded in
 the status of the object.
 
 ```
-flux create image policy <name> [flags]
+flux create image policy [name] [flags]
+```
+
+### Examples
+
+```
+  # Create an ImagePolicy to select the latest stable release
+  flux create image policy podinfo \
+    --image-ref=podinfo \
+    --select-semver=">=1.0.0"
+
+  # Create an ImagePolicy to select the latest main branch build tagged as "${GIT_BRANCH}-${GIT_SHA:0:7}-$(date +%s)"
+  flux create image policy podinfo \
+    --image-ref=podinfo \
+    --select-numeric=asc \
+	--filter-regex='^main-[a-f0-9]+-(?P<ts>[0-9]+)' \
+	--filter-extract='$ts'
+
 ```
 
 ### Options

--- a/docs/cmd/flux_create_image_repository.md
+++ b/docs/cmd/flux_create_image_repository.md
@@ -8,7 +8,7 @@ The create image repository command generates an ImageRepository resource.
 An ImageRepository object specifies an image repository to scan.
 
 ```
-flux create image repository <name> [flags]
+flux create image repository [name] [flags]
 ```
 
 ### Examples

--- a/docs/cmd/flux_create_image_update.md
+++ b/docs/cmd/flux_create_image_update.md
@@ -9,7 +9,31 @@ An ImageUpdateAutomation object specifies an automated update to images
 mentioned in YAMLs in a git repository.
 
 ```
-flux create image update <name> [flags]
+flux create image update [name] [flags]
+```
+
+### Examples
+
+```
+  # Configure image updates for the main repository created by flux bootstrap
+  flux create image update flux-system \
+    --git-repo-ref=flux-system \
+    --git-repo-path="./clusters/my-cluster" \
+    --checkout-branch=main \
+	--author-name=flux \
+	--author-email=flux@example.com \
+	--commit-template="{{range .Updated.Images}}{{println .}}{{end}}"
+
+  # Configure image updates to push changes to a different branch, if the branch doesn't exists it will be created
+  flux create image update flux-system \
+    --git-repo-ref=flux-system \
+    --git-repo-path="./clusters/my-cluster" \
+    --checkout-branch=main \
+    --push-branch=image-updates \
+	--author-name=flux \
+	--author-email=flux@example.com \
+	--commit-template="{{range .Updated.Images}}{{println .}}{{end}}"
+
 ```
 
 ### Options
@@ -17,10 +41,12 @@ flux create image update <name> [flags]
 ```
       --author-email string      the email to use for commit author
       --author-name string       the name to use for commit author
-      --branch string            the branch to checkout and push commits to
+      --checkout-branch string   the branch to checkout
       --commit-template string   a template for commit messages
-      --git-repo-ref string      the name of a GitRepository resource with details of the upstream git repository
+      --git-repo-path string     path to the directory containing the manifests to be updated, defaults to the repository root
+      --git-repo-ref string      the name of a GitRepository resource with details of the upstream Git repository
   -h, --help                     help for update
+      --push-branch string       the branch to push commits to, defaults to the checkout branch if not specified
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/flux_logs.md
+++ b/docs/cmd/flux_logs.md
@@ -1,10 +1,10 @@
 ## flux logs
 
-Display formatted logs for toolkit components
+Display formatted logs for Flux components
 
 ### Synopsis
 
-The logs command displays formatted logs from various toolkit components.
+The logs command displays formatted logs from various Flux components.
 
 ```
 flux logs [flags]
@@ -13,20 +13,17 @@ flux logs [flags]
 ### Examples
 
 ```
-# Get logs from toolkit components
-	 flux logs
+  # Print the reconciliation logs of all Flux custom resources in your cluster
+	 flux logs --all-namespaces
 
-	# Stream logs from toolkit components
-	flux logs --follow
- 
-	# Get logs from toolkit components in a particular namespace
-	flux logs --flux-namespace my-namespace
+	# Stream logs for a particular log level
+	flux logs --follow --level=error --all-namespaces
 
-	# Get logs for a particular log level
-	flux logs --level=info
+	# Filter logs by kind, name and namespace
+	flux logs --kind=Kustomization --name=podinfo --namespace=default
 
-	# Filter logs by kind, name, or namespace
-	flux logs --kind=kustomization --name podinfo --namespace default
+	# Print logs when Flux is installed in a different namespace than flux-system
+	flux logs --flux-namespace=my-namespace
     
 ```
 
@@ -34,8 +31,8 @@ flux logs [flags]
 
 ```
   -A, --all-namespaces          displays logs for objects across all namespaces
-      --flux-namespace string   the namespace where the Flux components are running. (default "flux-system")
-  -f, --follow                  Specifies if the logs should be streamed
+      --flux-namespace string   the namespace where the Flux components are running (default "flux-system")
+  -f, --follow                  specifies if the logs should be streamed
   -h, --help                    help for logs
       --kind string             displays errors of a particular toolkit kind e.g GitRepository
       --level logLevel          log level, available options are: (debug, info, error)


### PR DESCRIPTION
Changes:
- add `--git-repo-path` and `--push-branch` to `flux create image update` cmd
- rename `--branch` to `--checkout-branch` in `flux create image update` cmd
- add examples to `flux create image policy` cmd docs
- update `flux logs` examples 