### PR TITLE
Azure ACR reconcile script fix parameter order

### DIFF
--- a/manifests/integrations/registry-credentials-sync/_base/sync.yaml
+++ b/manifests/integrations/registry-credentials-sync/_base/sync.yaml
@@ -47,9 +47,9 @@ spec:
 
           apply-secret() {
             /kbin/kubectl create secret docker-registry "${1}" \
-              --docker-server="${2}" \
+              --docker-password="${2}" \
               --docker-username="${3}" \
-              --docker-password="${4}" \
+              --docker-server="${4}" \
               --dry-run=client -o=yaml \
               | grep -v "creationTimestamp:" \
               | /kbin/kubectl apply -f -

--- a/manifests/integrations/registry-credentials-sync/_cronjobs/_base/sync.yaml
+++ b/manifests/integrations/registry-credentials-sync/_cronjobs/_base/sync.yaml
@@ -49,9 +49,9 @@ spec:
 
               apply-secret() {
                 /kbin/kubectl create secret docker-registry "${1}" \
-                  --docker-server="${2}" \
+                  --docker-passwrod="${2}" \
                   --docker-username="${3}" \
-                  --docker-password="${4}" \
+                  --docker-server="${4}" \
                   --dry-run=client -o=yaml \
                   | grep -v "creationTimestamp:" \
                   | /kbin/kubectl apply -f -

--- a/manifests/integrations/registry-credentials-sync/_cronjobs/azure/reconcile-patch.yaml
+++ b/manifests/integrations/registry-credentials-sync/_cronjobs/azure/reconcile-patch.yaml
@@ -23,14 +23,7 @@ spec:
                   read token server <<< "${output}"
                   user="00000000-0000-0000-0000-000000000000"
 
-                  echo "Creating secret: ${KUBE_SECRET}"
-                  /kbin/kubectl create secret docker-registry "${KUBE_SECRET}" \
-                    --docker-server="${server}" \
-                    --docker-username="00000000-0000-0000-0000-000000000000" \
-                    --docker-password="${token}" \
-                    --dry-run=client -o=yaml \
-                    | grep -v "creationTimestamp:" \
-                    | /kbin/kubectl apply -f -
+                  apply-secret "${KUBE_SECRET}" "${token}" "${user}" "${server}"
 
                   echo "Finished ACR token sync -- $(date)"
                   echo

--- a/manifests/integrations/registry-credentials-sync/azure/reconcile-patch.yaml
+++ b/manifests/integrations/registry-credentials-sync/azure/reconcile-patch.yaml
@@ -23,8 +23,8 @@ spec:
               user="00000000-0000-0000-0000-000000000000"
 
               echo "Creating secret: ${KUBE_SECRET}"
-              apply-secret "${KUBE_SECRET}" "${server}" "${user}" "${token}"
+              apply-secret "${KUBE_SECRET}" "${token}" "${user}" "${server}"
 
-              echo "Finished ECR token sync -- $(date)"
+              echo "Finished ACR token sync -- $(date)"
               echo
             }

--- a/manifests/integrations/registry-credentials-sync/azure/reconcile-patch.yaml
+++ b/manifests/integrations/registry-credentials-sync/azure/reconcile-patch.yaml
@@ -23,7 +23,7 @@ spec:
               user="00000000-0000-0000-0000-000000000000"
 
               echo "Creating secret: ${KUBE_SECRET}"
-              apply-secret "${KUBE_SECRET}" "${token}" "${user}" "${server}"
+              apply-secret "${KUBE_SECRET}" "${server}" "${user}" "${token}"
 
               echo "Finished ECR token sync -- $(date)"
               echo


### PR DESCRIPTION
Hello.

The order of the parameters when calling `apply-secret` on Azure's ACR secret reconcile script is incorrect, it's setting the token where it should be the ACR server name and the other way around.

It's being called like this:
```
apply-secret "${KUBE_SECRET}" "${token}" "${user}" "${server}"
```

but the `apply-secret` function defined on `_base` is: 
```
          apply-secret() {
            /kbin/kubectl create secret docker-registry "${1}" \
              --docker-server="${2}" \
              --docker-username="${3}" \
              --docker-password="${4}" \
              --dry-run=client -o=yaml \
              | grep -v "creationTimestamp:" \
              | /kbin/kubectl apply -f -
          }
```

Since the password is the forth parameter it must be changed to:
```
apply-secret "${KUBE_SECRET}" "${server}" "${user}" "${token}"
```

Kind regards, MA
