### PR TITLE
Remove branch switch for image update cmd in guide

### DIFF
--- a/docs/guides/image-update.md
+++ b/docs/guides/image-update.md
@@ -246,7 +246,6 @@ Create an `ImageUpdateAutomation` to tell Flux which Git repository to write ima
 ```sh
 flux create image update flux-system \
 --git-repo-ref=flux-system \
---branch=main \
 --git-repo-path="./clusters/my-cluster" \
 --checkout-branch=main \
 --push-branch=main \


### PR DESCRIPTION
--branch is not a valid flag for this command.

```
Flags:
      --author-email string      the email to use for commit author
      --author-name string       the name to use for commit author
      --checkout-branch string   the branch to checkout
      --commit-template string   a template for commit messages
      --git-repo-path string     path to the directory containing the manifests to be updated, defaults to the repository root
      --git-repo-ref string      the name of a GitRepository resource with details of the upstream Git repository
  -h, --help                     help for update
      --push-branch string       the branch to push commits to, defaults to the checkout branch if not specified
```