### PR TITLE
Add source namespace arg to create commands

### DIFF
--- a/cmd/flux/create_helmrelease.go
+++ b/cmd/flux/create_helmrelease.go
@@ -104,6 +104,7 @@ var createHelmReleaseCmd = &cobra.Command{
 type helmReleaseFlags struct {
 	name            string
 	source          flags.HelmChartSource
+	sourceNamespace string
 	dependsOn       []string
 	chart           string
 	chartVersion    string
@@ -118,6 +119,7 @@ var helmReleaseArgs helmReleaseFlags
 func init() {
 	createHelmReleaseCmd.Flags().StringVar(&helmReleaseArgs.name, "release-name", "", "name used for the Helm release, defaults to a composition of '[<target-namespace>-]<HelmRelease-name>'")
 	createHelmReleaseCmd.Flags().Var(&helmReleaseArgs.source, "source", helmReleaseArgs.source.Description())
+	createHelmReleaseCmd.Flags().StringVar(&helmReleaseArgs.sourceNamespace, "source-namespace", "", "the namespace of the source, defaults to the HelmRelease namespace")
 	createHelmReleaseCmd.Flags().StringVar(&helmReleaseArgs.chart, "chart", "", "Helm chart name or path")
 	createHelmReleaseCmd.Flags().StringVar(&helmReleaseArgs.chartVersion, "chart-version", "", "Helm chart version, accepts a semver range (ignored for charts from GitRepository sources)")
 	createHelmReleaseCmd.Flags().StringArrayVar(&helmReleaseArgs.dependsOn, "depends-on", nil, "HelmReleases that must be ready before this release can be installed, supported formats '<name>' and '<namespace>/<name>'")
@@ -165,8 +167,9 @@ func createHelmReleaseCmdRun(cmd *cobra.Command, args []string) error {
 					Chart:   helmReleaseArgs.chart,
 					Version: helmReleaseArgs.chartVersion,
 					SourceRef: helmv2.CrossNamespaceObjectReference{
-						Kind: helmReleaseArgs.source.Kind,
-						Name: helmReleaseArgs.source.Name,
+						Kind:      helmReleaseArgs.source.Kind,
+						Name:      helmReleaseArgs.source.Name,
+						Namespace: helmReleaseArgs.sourceNamespace,
 					},
 				},
 			},

--- a/cmd/flux/create_kustomization.go
+++ b/cmd/flux/create_kustomization.go
@@ -75,6 +75,7 @@ var createKsCmd = &cobra.Command{
 
 type kustomizationFlags struct {
 	source             flags.KustomizationSource
+	sourceNamespace    string
 	path               flags.SafeRelativePath
 	prune              bool
 	dependsOn          []string
@@ -91,6 +92,7 @@ var kustomizationArgs = NewKustomizationFlags()
 
 func init() {
 	createKsCmd.Flags().Var(&kustomizationArgs.source, "source", kustomizationArgs.source.Description())
+	createKsCmd.Flags().StringVar(&kustomizationArgs.sourceNamespace, "source-namespace", "", "the namespace of the source, defaults to the Kustomization namespace")
 	createKsCmd.Flags().Var(&kustomizationArgs.path, "path", "path to the directory containing a kustomization.yaml file")
 	createKsCmd.Flags().BoolVar(&kustomizationArgs.prune, "prune", false, "enable garbage collection")
 	createKsCmd.Flags().StringArrayVar(&kustomizationArgs.healthCheck, "health-check", nil, "workload to be included in the health assessment, in the format '<kind>/<name>.<namespace>'")
@@ -146,8 +148,9 @@ func createKsCmdRun(cmd *cobra.Command, args []string) error {
 			Path:  filepath.ToSlash(kustomizationArgs.path.String()),
 			Prune: kustomizationArgs.prune,
 			SourceRef: kustomizev1.CrossNamespaceSourceReference{
-				Kind: kustomizationArgs.source.Kind,
-				Name: kustomizationArgs.source.Name,
+				Kind:      kustomizationArgs.source.Kind,
+				Name:      kustomizationArgs.source.Name,
+				Namespace: kustomizationArgs.sourceNamespace,
 			},
 			Suspend:         false,
 			Validation:      kustomizationArgs.validation,

--- a/docs/cmd/flux_create_helmrelease.md
+++ b/docs/cmd/flux_create_helmrelease.md
@@ -78,6 +78,7 @@ flux create helmrelease [name] [flags]
       --release-name string                 name used for the Helm release, defaults to a composition of '[<target-namespace>-]<HelmRelease-name>'
       --service-account string              the name of the service account to impersonate when reconciling this HelmRelease
       --source helmChartSource              source that contains the chart in the format '<kind>/<name>', where kind must be one of: (HelmRepository, GitRepository, Bucket)
+      --source-namespace string             the namespace of the source, defaults to the HelmRelease namespace
       --target-namespace string             namespace to install this release, defaults to the HelmRelease namespace
       --values stringArray                  local path to values.yaml files
       --values-from helmReleaseValuesFrom   Kubernetes object reference that contains the values.yaml data key in the format '<kind>/<name>', where kind must be one of: (Secret, ConfigMap)

--- a/docs/cmd/flux_create_kustomization.md
+++ b/docs/cmd/flux_create_kustomization.md
@@ -54,6 +54,7 @@ flux create kustomization [name] [flags]
       --prune                                    enable garbage collection
       --service-account string                   the name of the service account to impersonate when reconciling this Kustomization
       --source kustomizationSource               source that contains the Kubernetes manifests in the format '[<kind>/]<name>', where kind must be one of: (GitRepository, Bucket), if kind is not specified it defaults to GitRepository
+      --source-namespace string                  the namespace of the source, defaults to the Kustomization namespace
       --target-namespace string                  overrides the namespace of all Kustomization objects reconciled by this Kustomization
       --validation string                        validate the manifests before applying them on the cluster, can be 'client' or 'server'
 ```


### PR DESCRIPTION
This PR adds an optional arg `--source-namespace` to `flux create kustomization` and `flux create helmrelease` commands.