### PR TITLE
Fix CRD deletion instruction in Helm Operator migration docs

### DIFF
--- a/docs/guides/helm-operator-migration.md
+++ b/docs/guides/helm-operator-migration.md
@@ -747,7 +747,7 @@ While doing this, make sure that once you scale up the Helm Operator again, ther
 Once you have migrated all your `HelmRelease` resources to the Helm Controller. You can remove all of the old resources by removing the old Custom Resource Definition.
 
 ```sh
-kubectl delete crd helm.fluxcd.io
+kubectl delete crd helmreleases.helm.fluxcd.io
 ```
 
 ## Frequently Asked Questions


### PR DESCRIPTION
The command to delete the old helm release crd in the docs does not work.