### PR TITLE
Fix cmd links

### DIFF
--- a/cmd/flux/docgen.go
+++ b/cmd/flux/docgen.go
@@ -32,8 +32,7 @@ title: "%s"
 `
 
 var (
-	cmdDocPath    string
-	cmdDocURLPath string
+	cmdDocPath string
 )
 
 var docgenCmd = &cobra.Command{
@@ -45,7 +44,6 @@ var docgenCmd = &cobra.Command{
 
 func init() {
 	docgenCmd.Flags().StringVar(&cmdDocPath, "path", "./docs/cmd", "path to write the generated documentation to")
-	docgenCmd.Flags().StringVar(&cmdDocURLPath, "url-path", "/cmd/", "URL path the documentation is available at")
 
 	rootCmd.AddCommand(docgenCmd)
 }
@@ -67,5 +65,5 @@ func frontmatterPrepender(filename string) string {
 
 func linkHandler(name string) string {
 	base := strings.TrimSuffix(name, path.Ext(name))
-	return cmdDocURLPath + strings.ToLower(base) + "/"
+	return "../" + strings.ToLower(base) + "/"
 }

--- a/docs/cmd/flux.md
+++ b/docs/cmd/flux.md
@@ -80,17 +80,17 @@ Command line utility for assembling Kubernetes CD pipelines the GitOps way.
 
 ### SEE ALSO
 
-* [flux bootstrap](/cmd/flux_bootstrap/)	 - Bootstrap toolkit components
-* [flux check](/cmd/flux_check/)	 - Check requirements and installation
-* [flux completion](/cmd/flux_completion/)	 - Generates completion scripts for various shells
-* [flux create](/cmd/flux_create/)	 - Create or update sources and resources
-* [flux delete](/cmd/flux_delete/)	 - Delete sources and resources
-* [flux export](/cmd/flux_export/)	 - Export resources in YAML format
-* [flux get](/cmd/flux_get/)	 - Get the resources and their status
-* [flux install](/cmd/flux_install/)	 - Install or upgrade Flux
-* [flux logs](/cmd/flux_logs/)	 - Display formatted logs for Flux components
-* [flux reconcile](/cmd/flux_reconcile/)	 - Reconcile sources and resources
-* [flux resume](/cmd/flux_resume/)	 - Resume suspended resources
-* [flux suspend](/cmd/flux_suspend/)	 - Suspend resources
-* [flux uninstall](/cmd/flux_uninstall/)	 - Uninstall Flux and its custom resource definitions
+* [flux bootstrap](../flux_bootstrap/)	 - Bootstrap toolkit components
+* [flux check](../flux_check/)	 - Check requirements and installation
+* [flux completion](../flux_completion/)	 - Generates completion scripts for various shells
+* [flux create](../flux_create/)	 - Create or update sources and resources
+* [flux delete](../flux_delete/)	 - Delete sources and resources
+* [flux export](../flux_export/)	 - Export resources in YAML format
+* [flux get](../flux_get/)	 - Get the resources and their status
+* [flux install](../flux_install/)	 - Install or upgrade Flux
+* [flux logs](../flux_logs/)	 - Display formatted logs for Flux components
+* [flux reconcile](../flux_reconcile/)	 - Reconcile sources and resources
+* [flux resume](../flux_resume/)	 - Resume suspended resources
+* [flux suspend](../flux_suspend/)	 - Suspend resources
+* [flux uninstall](../flux_uninstall/)	 - Uninstall Flux and its custom resource definitions
 

--- a/docs/cmd/flux_bootstrap.md
+++ b/docs/cmd/flux_bootstrap.md
@@ -39,7 +39,7 @@ The bootstrap sub-commands bootstrap the toolkit components on the targeted Git 
 
 ### SEE ALSO
 
-* [flux](/cmd/flux/)	 - Command line utility for assembling Kubernetes CD pipelines
-* [flux bootstrap github](/cmd/flux_bootstrap_github/)	 - Bootstrap toolkit components in a GitHub repository
-* [flux bootstrap gitlab](/cmd/flux_bootstrap_gitlab/)	 - Bootstrap toolkit components in a GitLab repository
+* [flux](../flux/)	 - Command line utility for assembling Kubernetes CD pipelines
+* [flux bootstrap github](../flux_bootstrap_github/)	 - Bootstrap toolkit components in a GitHub repository
+* [flux bootstrap gitlab](../flux_bootstrap_gitlab/)	 - Bootstrap toolkit components in a GitLab repository
 

--- a/docs/cmd/flux_bootstrap_github.md
+++ b/docs/cmd/flux_bootstrap_github.md
@@ -84,5 +84,5 @@ flux bootstrap github [flags]
 
 ### SEE ALSO
 
-* [flux bootstrap](/cmd/flux_bootstrap/)	 - Bootstrap toolkit components
+* [flux bootstrap](../flux_bootstrap/)	 - Bootstrap toolkit components
 

--- a/docs/cmd/flux_bootstrap_gitlab.md
+++ b/docs/cmd/flux_bootstrap_gitlab.md
@@ -80,5 +80,5 @@ flux bootstrap gitlab [flags]
 
 ### SEE ALSO
 
-* [flux bootstrap](/cmd/flux_bootstrap/)	 - Bootstrap toolkit components
+* [flux bootstrap](../flux_bootstrap/)	 - Bootstrap toolkit components
 

--- a/docs/cmd/flux_check.md
+++ b/docs/cmd/flux_check.md
@@ -45,5 +45,5 @@ flux check [flags]
 
 ### SEE ALSO
 
-* [flux](/cmd/flux/)	 - Command line utility for assembling Kubernetes CD pipelines
+* [flux](../flux/)	 - Command line utility for assembling Kubernetes CD pipelines
 

--- a/docs/cmd/flux_completion.md
+++ b/docs/cmd/flux_completion.md
@@ -27,9 +27,9 @@ The completion sub-command generates completion scripts for various shells
 
 ### SEE ALSO
 
-* [flux](/cmd/flux/)	 - Command line utility for assembling Kubernetes CD pipelines
-* [flux completion bash](/cmd/flux_completion_bash/)	 - Generates bash completion scripts
-* [flux completion fish](/cmd/flux_completion_fish/)	 - Generates fish completion scripts
-* [flux completion powershell](/cmd/flux_completion_powershell/)	 - Generates powershell completion scripts
-* [flux completion zsh](/cmd/flux_completion_zsh/)	 - Generates zsh completion scripts
+* [flux](../flux/)	 - Command line utility for assembling Kubernetes CD pipelines
+* [flux completion bash](../flux_completion_bash/)	 - Generates bash completion scripts
+* [flux completion fish](../flux_completion_fish/)	 - Generates fish completion scripts
+* [flux completion powershell](../flux_completion_powershell/)	 - Generates powershell completion scripts
+* [flux completion zsh](../flux_completion_zsh/)	 - Generates zsh completion scripts
 

--- a/docs/cmd/flux_completion_bash.md
+++ b/docs/cmd/flux_completion_bash.md
@@ -40,5 +40,5 @@ command -v flux >/dev/null && . <(flux completion bash)
 
 ### SEE ALSO
 
-* [flux completion](/cmd/flux_completion/)	 - Generates completion scripts for various shells
+* [flux completion](../flux_completion/)	 - Generates completion scripts for various shells
 

--- a/docs/cmd/flux_completion_fish.md
+++ b/docs/cmd/flux_completion_fish.md
@@ -37,5 +37,5 @@ See http://fishshell.com/docs/current/index.html#completion-own for more details
 
 ### SEE ALSO
 
-* [flux completion](/cmd/flux_completion/)	 - Generates completion scripts for various shells
+* [flux completion](../flux_completion/)	 - Generates completion scripts for various shells
 

--- a/docs/cmd/flux_completion_powershell.md
+++ b/docs/cmd/flux_completion_powershell.md
@@ -47,5 +47,5 @@ flux completion >> flux-completions.ps1
 
 ### SEE ALSO
 
-* [flux completion](/cmd/flux_completion/)	 - Generates completion scripts for various shells
+* [flux completion](../flux_completion/)	 - Generates completion scripts for various shells
 

--- a/docs/cmd/flux_completion_zsh.md
+++ b/docs/cmd/flux_completion_zsh.md
@@ -48,5 +48,5 @@ mv _flux ~/.zprezto/modules/completion/external/src/  # zprezto
 
 ### SEE ALSO
 
-* [flux completion](/cmd/flux_completion/)	 - Generates completion scripts for various shells
+* [flux completion](../flux_completion/)	 - Generates completion scripts for various shells
 

--- a/docs/cmd/flux_create.md
+++ b/docs/cmd/flux_create.md
@@ -30,14 +30,14 @@ The create sub-commands generate sources and resources.
 
 ### SEE ALSO
 
-* [flux](/cmd/flux/)	 - Command line utility for assembling Kubernetes CD pipelines
-* [flux create alert](/cmd/flux_create_alert/)	 - Create or update a Alert resource
-* [flux create alert-provider](/cmd/flux_create_alert-provider/)	 - Create or update a Provider resource
-* [flux create helmrelease](/cmd/flux_create_helmrelease/)	 - Create or update a HelmRelease resource
-* [flux create image](/cmd/flux_create_image/)	 - Create or update resources dealing with image automation
-* [flux create kustomization](/cmd/flux_create_kustomization/)	 - Create or update a Kustomization resource
-* [flux create receiver](/cmd/flux_create_receiver/)	 - Create or update a Receiver resource
-* [flux create secret](/cmd/flux_create_secret/)	 - Create or update Kubernetes secrets
-* [flux create source](/cmd/flux_create_source/)	 - Create or update sources
-* [flux create tenant](/cmd/flux_create_tenant/)	 - Create or update a tenant
+* [flux](../flux/)	 - Command line utility for assembling Kubernetes CD pipelines
+* [flux create alert](../flux_create_alert/)	 - Create or update a Alert resource
+* [flux create alert-provider](../flux_create_alert-provider/)	 - Create or update a Provider resource
+* [flux create helmrelease](../flux_create_helmrelease/)	 - Create or update a HelmRelease resource
+* [flux create image](../flux_create_image/)	 - Create or update resources dealing with image automation
+* [flux create kustomization](../flux_create_kustomization/)	 - Create or update a Kustomization resource
+* [flux create receiver](../flux_create_receiver/)	 - Create or update a Receiver resource
+* [flux create secret](../flux_create_secret/)	 - Create or update Kubernetes secrets
+* [flux create source](../flux_create_source/)	 - Create or update sources
+* [flux create tenant](../flux_create_tenant/)	 - Create or update a tenant
 

--- a/docs/cmd/flux_create_alert-provider.md
+++ b/docs/cmd/flux_create_alert-provider.md
@@ -56,5 +56,5 @@ flux create alert-provider [name] [flags]
 
 ### SEE ALSO
 
-* [flux create](/cmd/flux_create/)	 - Create or update sources and resources
+* [flux create](../flux_create/)	 - Create or update sources and resources
 

--- a/docs/cmd/flux_create_alert.md
+++ b/docs/cmd/flux_create_alert.md
@@ -48,5 +48,5 @@ flux create alert [name] [flags]
 
 ### SEE ALSO
 
-* [flux create](/cmd/flux_create/)	 - Create or update sources and resources
+* [flux create](../flux_create/)	 - Create or update sources and resources
 

--- a/docs/cmd/flux_create_helmrelease.md
+++ b/docs/cmd/flux_create_helmrelease.md
@@ -100,5 +100,5 @@ flux create helmrelease [name] [flags]
 
 ### SEE ALSO
 
-* [flux create](/cmd/flux_create/)	 - Create or update sources and resources
+* [flux create](../flux_create/)	 - Create or update sources and resources
 

--- a/docs/cmd/flux_create_image.md
+++ b/docs/cmd/flux_create_image.md
@@ -32,8 +32,8 @@ being available.
 
 ### SEE ALSO
 
-* [flux create](/cmd/flux_create/)	 - Create or update sources and resources
-* [flux create image policy](/cmd/flux_create_image_policy/)	 - Create or update an ImagePolicy object
-* [flux create image repository](/cmd/flux_create_image_repository/)	 - Create or update an ImageRepository object
-* [flux create image update](/cmd/flux_create_image_update/)	 - Create or update an ImageUpdateAutomation object
+* [flux create](../flux_create/)	 - Create or update sources and resources
+* [flux create image policy](../flux_create_image_policy/)	 - Create or update an ImagePolicy object
+* [flux create image repository](../flux_create_image_repository/)	 - Create or update an ImageRepository object
+* [flux create image update](../flux_create_image_update/)	 - Create or update an ImageUpdateAutomation object
 

--- a/docs/cmd/flux_create_image_policy.md
+++ b/docs/cmd/flux_create_image_policy.md
@@ -61,5 +61,5 @@ flux create image policy [name] [flags]
 
 ### SEE ALSO
 
-* [flux create image](/cmd/flux_create_image/)	 - Create or update resources dealing with image automation
+* [flux create image](../flux_create_image/)	 - Create or update resources dealing with image automation
 

--- a/docs/cmd/flux_create_image_repository.md
+++ b/docs/cmd/flux_create_image_repository.md
@@ -68,5 +68,5 @@ flux create image repository [name] [flags]
 
 ### SEE ALSO
 
-* [flux create image](/cmd/flux_create_image/)	 - Create or update resources dealing with image automation
+* [flux create image](../flux_create_image/)	 - Create or update resources dealing with image automation
 

--- a/docs/cmd/flux_create_image_update.md
+++ b/docs/cmd/flux_create_image_update.md
@@ -66,5 +66,5 @@ flux create image update [name] [flags]
 
 ### SEE ALSO
 
-* [flux create image](/cmd/flux_create_image/)	 - Create or update resources dealing with image automation
+* [flux create image](../flux_create_image/)	 - Create or update resources dealing with image automation
 

--- a/docs/cmd/flux_create_kustomization.md
+++ b/docs/cmd/flux_create_kustomization.md
@@ -75,5 +75,5 @@ flux create kustomization [name] [flags]
 
 ### SEE ALSO
 
-* [flux create](/cmd/flux_create/)	 - Create or update sources and resources
+* [flux create](../flux_create/)	 - Create or update sources and resources
 

--- a/docs/cmd/flux_create_receiver.md
+++ b/docs/cmd/flux_create_receiver.md
@@ -51,5 +51,5 @@ flux create receiver [name] [flags]
 
 ### SEE ALSO
 
-* [flux create](/cmd/flux_create/)	 - Create or update sources and resources
+* [flux create](../flux_create/)	 - Create or update sources and resources
 

--- a/docs/cmd/flux_create_secret.md
+++ b/docs/cmd/flux_create_secret.md
@@ -30,8 +30,8 @@ The create source sub-commands generate Kubernetes secrets specific to Flux.
 
 ### SEE ALSO
 
-* [flux create](/cmd/flux_create/)	 - Create or update sources and resources
-* [flux create secret git](/cmd/flux_create_secret_git/)	 - Create or update a Kubernetes secret for Git authentication
-* [flux create secret helm](/cmd/flux_create_secret_helm/)	 - Create or update a Kubernetes secret for Helm repository authentication
-* [flux create secret tls](/cmd/flux_create_secret_tls/)	 - Create or update a Kubernetes secret with TLS certificates
+* [flux create](../flux_create/)	 - Create or update sources and resources
+* [flux create secret git](../flux_create_secret_git/)	 - Create or update a Kubernetes secret for Git authentication
+* [flux create secret helm](../flux_create_secret_helm/)	 - Create or update a Kubernetes secret for Helm repository authentication
+* [flux create secret tls](../flux_create_secret_tls/)	 - Create or update a Kubernetes secret with TLS certificates
 

--- a/docs/cmd/flux_create_secret_git.md
+++ b/docs/cmd/flux_create_secret_git.md
@@ -83,5 +83,5 @@ flux create secret git [name] [flags]
 
 ### SEE ALSO
 
-* [flux create secret](/cmd/flux_create_secret/)	 - Create or update Kubernetes secrets
+* [flux create secret](../flux_create_secret/)	 - Create or update Kubernetes secrets
 

--- a/docs/cmd/flux_create_secret_helm.md
+++ b/docs/cmd/flux_create_secret_helm.md
@@ -61,5 +61,5 @@ flux create secret helm [name] [flags]
 
 ### SEE ALSO
 
-* [flux create secret](/cmd/flux_create_secret/)	 - Create or update Kubernetes secrets
+* [flux create secret](../flux_create_secret/)	 - Create or update Kubernetes secrets
 

--- a/docs/cmd/flux_create_secret_tls.md
+++ b/docs/cmd/flux_create_secret_tls.md
@@ -52,5 +52,5 @@ flux create secret tls [name] [flags]
 
 ### SEE ALSO
 
-* [flux create secret](/cmd/flux_create_secret/)	 - Create or update Kubernetes secrets
+* [flux create secret](../flux_create_secret/)	 - Create or update Kubernetes secrets
 

--- a/docs/cmd/flux_create_source.md
+++ b/docs/cmd/flux_create_source.md
@@ -30,8 +30,8 @@ The create source sub-commands generate sources.
 
 ### SEE ALSO
 
-* [flux create](/cmd/flux_create/)	 - Create or update sources and resources
-* [flux create source bucket](/cmd/flux_create_source_bucket/)	 - Create or update a Bucket source
-* [flux create source git](/cmd/flux_create_source_git/)	 - Create or update a GitRepository source
-* [flux create source helm](/cmd/flux_create_source_helm/)	 - Create or update a HelmRepository source
+* [flux create](../flux_create/)	 - Create or update sources and resources
+* [flux create source bucket](../flux_create_source_bucket/)	 - Create or update a Bucket source
+* [flux create source git](../flux_create_source_git/)	 - Create or update a GitRepository source
+* [flux create source helm](../flux_create_source_helm/)	 - Create or update a HelmRepository source
 

--- a/docs/cmd/flux_create_source_bucket.md
+++ b/docs/cmd/flux_create_source_bucket.md
@@ -64,5 +64,5 @@ flux create source bucket [name] [flags]
 
 ### SEE ALSO
 
-* [flux create source](/cmd/flux_create_source/)	 - Create or update sources
+* [flux create source](../flux_create_source/)	 - Create or update sources
 

--- a/docs/cmd/flux_create_source_git.md
+++ b/docs/cmd/flux_create_source_git.md
@@ -95,5 +95,5 @@ flux create source git [name] [flags]
 
 ### SEE ALSO
 
-* [flux create source](/cmd/flux_create_source/)	 - Create or update sources
+* [flux create source](../flux_create_source/)	 - Create or update sources
 

--- a/docs/cmd/flux_create_source_helm.md
+++ b/docs/cmd/flux_create_source_helm.md
@@ -64,5 +64,5 @@ flux create source helm [name] [flags]
 
 ### SEE ALSO
 
-* [flux create source](/cmd/flux_create_source/)	 - Create or update sources
+* [flux create source](../flux_create_source/)	 - Create or update sources
 

--- a/docs/cmd/flux_create_tenant.md
+++ b/docs/cmd/flux_create_tenant.md
@@ -52,5 +52,5 @@ flux create tenant [flags]
 
 ### SEE ALSO
 
-* [flux create](/cmd/flux_create/)	 - Create or update sources and resources
+* [flux create](../flux_create/)	 - Create or update sources and resources
 

--- a/docs/cmd/flux_delete.md
+++ b/docs/cmd/flux_delete.md
@@ -28,12 +28,12 @@ The delete sub-commands delete sources and resources.
 
 ### SEE ALSO
 
-* [flux](/cmd/flux/)	 - Command line utility for assembling Kubernetes CD pipelines
-* [flux delete alert](/cmd/flux_delete_alert/)	 - Delete a Alert resource
-* [flux delete alert-provider](/cmd/flux_delete_alert-provider/)	 - Delete a Provider resource
-* [flux delete helmrelease](/cmd/flux_delete_helmrelease/)	 - Delete a HelmRelease resource
-* [flux delete image](/cmd/flux_delete_image/)	 - Delete image automation objects
-* [flux delete kustomization](/cmd/flux_delete_kustomization/)	 - Delete a Kustomization resource
-* [flux delete receiver](/cmd/flux_delete_receiver/)	 - Delete a Receiver resource
-* [flux delete source](/cmd/flux_delete_source/)	 - Delete sources
+* [flux](../flux/)	 - Command line utility for assembling Kubernetes CD pipelines
+* [flux delete alert](../flux_delete_alert/)	 - Delete a Alert resource
+* [flux delete alert-provider](../flux_delete_alert-provider/)	 - Delete a Provider resource
+* [flux delete helmrelease](../flux_delete_helmrelease/)	 - Delete a HelmRelease resource
+* [flux delete image](../flux_delete_image/)	 - Delete image automation objects
+* [flux delete kustomization](../flux_delete_kustomization/)	 - Delete a Kustomization resource
+* [flux delete receiver](../flux_delete_receiver/)	 - Delete a Receiver resource
+* [flux delete source](../flux_delete_source/)	 - Delete sources
 

--- a/docs/cmd/flux_delete_alert-provider.md
+++ b/docs/cmd/flux_delete_alert-provider.md
@@ -39,5 +39,5 @@ flux delete alert-provider [name] [flags]
 
 ### SEE ALSO
 
-* [flux delete](/cmd/flux_delete/)	 - Delete sources and resources
+* [flux delete](../flux_delete/)	 - Delete sources and resources
 

--- a/docs/cmd/flux_delete_alert.md
+++ b/docs/cmd/flux_delete_alert.md
@@ -39,5 +39,5 @@ flux delete alert [name] [flags]
 
 ### SEE ALSO
 
-* [flux delete](/cmd/flux_delete/)	 - Delete sources and resources
+* [flux delete](../flux_delete/)	 - Delete sources and resources
 

--- a/docs/cmd/flux_delete_helmrelease.md
+++ b/docs/cmd/flux_delete_helmrelease.md
@@ -39,5 +39,5 @@ flux delete helmrelease [name] [flags]
 
 ### SEE ALSO
 
-* [flux delete](/cmd/flux_delete/)	 - Delete sources and resources
+* [flux delete](../flux_delete/)	 - Delete sources and resources
 

--- a/docs/cmd/flux_delete_image.md
+++ b/docs/cmd/flux_delete_image.md
@@ -28,8 +28,8 @@ The delete image sub-commands delete image automation objects.
 
 ### SEE ALSO
 
-* [flux delete](/cmd/flux_delete/)	 - Delete sources and resources
-* [flux delete image policy](/cmd/flux_delete_image_policy/)	 - Delete an ImagePolicy object
-* [flux delete image repository](/cmd/flux_delete_image_repository/)	 - Delete an ImageRepository object
-* [flux delete image update](/cmd/flux_delete_image_update/)	 - Delete an ImageUpdateAutomation object
+* [flux delete](../flux_delete/)	 - Delete sources and resources
+* [flux delete image policy](../flux_delete_image_policy/)	 - Delete an ImagePolicy object
+* [flux delete image repository](../flux_delete_image_repository/)	 - Delete an ImageRepository object
+* [flux delete image update](../flux_delete_image_update/)	 - Delete an ImageUpdateAutomation object
 

--- a/docs/cmd/flux_delete_image_policy.md
+++ b/docs/cmd/flux_delete_image_policy.md
@@ -39,5 +39,5 @@ flux delete image policy [name] [flags]
 
 ### SEE ALSO
 
-* [flux delete image](/cmd/flux_delete_image/)	 - Delete image automation objects
+* [flux delete image](../flux_delete_image/)	 - Delete image automation objects
 

--- a/docs/cmd/flux_delete_image_repository.md
+++ b/docs/cmd/flux_delete_image_repository.md
@@ -39,5 +39,5 @@ flux delete image repository [name] [flags]
 
 ### SEE ALSO
 
-* [flux delete image](/cmd/flux_delete_image/)	 - Delete image automation objects
+* [flux delete image](../flux_delete_image/)	 - Delete image automation objects
 

--- a/docs/cmd/flux_delete_image_update.md
+++ b/docs/cmd/flux_delete_image_update.md
@@ -39,5 +39,5 @@ flux delete image update [name] [flags]
 
 ### SEE ALSO
 
-* [flux delete image](/cmd/flux_delete_image/)	 - Delete image automation objects
+* [flux delete image](../flux_delete_image/)	 - Delete image automation objects
 

--- a/docs/cmd/flux_delete_kustomization.md
+++ b/docs/cmd/flux_delete_kustomization.md
@@ -39,5 +39,5 @@ flux delete kustomization [name] [flags]
 
 ### SEE ALSO
 
-* [flux delete](/cmd/flux_delete/)	 - Delete sources and resources
+* [flux delete](../flux_delete/)	 - Delete sources and resources
 

--- a/docs/cmd/flux_delete_receiver.md
+++ b/docs/cmd/flux_delete_receiver.md
@@ -39,5 +39,5 @@ flux delete receiver [name] [flags]
 
 ### SEE ALSO
 
-* [flux delete](/cmd/flux_delete/)	 - Delete sources and resources
+* [flux delete](../flux_delete/)	 - Delete sources and resources
 

--- a/docs/cmd/flux_delete_source.md
+++ b/docs/cmd/flux_delete_source.md
@@ -28,8 +28,8 @@ The delete source sub-commands delete sources.
 
 ### SEE ALSO
 
-* [flux delete](/cmd/flux_delete/)	 - Delete sources and resources
-* [flux delete source bucket](/cmd/flux_delete_source_bucket/)	 - Delete a Bucket source
-* [flux delete source git](/cmd/flux_delete_source_git/)	 - Delete a GitRepository source
-* [flux delete source helm](/cmd/flux_delete_source_helm/)	 - Delete a HelmRepository source
+* [flux delete](../flux_delete/)	 - Delete sources and resources
+* [flux delete source bucket](../flux_delete_source_bucket/)	 - Delete a Bucket source
+* [flux delete source git](../flux_delete_source_git/)	 - Delete a GitRepository source
+* [flux delete source helm](../flux_delete_source_helm/)	 - Delete a HelmRepository source
 

--- a/docs/cmd/flux_delete_source_bucket.md
+++ b/docs/cmd/flux_delete_source_bucket.md
@@ -39,5 +39,5 @@ flux delete source bucket [name] [flags]
 
 ### SEE ALSO
 
-* [flux delete source](/cmd/flux_delete_source/)	 - Delete sources
+* [flux delete source](../flux_delete_source/)	 - Delete sources
 

--- a/docs/cmd/flux_delete_source_git.md
+++ b/docs/cmd/flux_delete_source_git.md
@@ -39,5 +39,5 @@ flux delete source git [name] [flags]
 
 ### SEE ALSO
 
-* [flux delete source](/cmd/flux_delete_source/)	 - Delete sources
+* [flux delete source](../flux_delete_source/)	 - Delete sources
 

--- a/docs/cmd/flux_delete_source_helm.md
+++ b/docs/cmd/flux_delete_source_helm.md
@@ -39,5 +39,5 @@ flux delete source helm [name] [flags]
 
 ### SEE ALSO
 
-* [flux delete source](/cmd/flux_delete_source/)	 - Delete sources
+* [flux delete source](../flux_delete_source/)	 - Delete sources
 

--- a/docs/cmd/flux_export.md
+++ b/docs/cmd/flux_export.md
@@ -28,12 +28,12 @@ The export sub-commands export resources in YAML format.
 
 ### SEE ALSO
 
-* [flux](/cmd/flux/)	 - Command line utility for assembling Kubernetes CD pipelines
-* [flux export alert](/cmd/flux_export_alert/)	 - Export Alert resources in YAML format
-* [flux export alert-provider](/cmd/flux_export_alert-provider/)	 - Export Provider resources in YAML format
-* [flux export helmrelease](/cmd/flux_export_helmrelease/)	 - Export HelmRelease resources in YAML format
-* [flux export image](/cmd/flux_export_image/)	 - Export image automation objects
-* [flux export kustomization](/cmd/flux_export_kustomization/)	 - Export Kustomization resources in YAML format
-* [flux export receiver](/cmd/flux_export_receiver/)	 - Export Receiver resources in YAML format
-* [flux export source](/cmd/flux_export_source/)	 - Export sources
+* [flux](../flux/)	 - Command line utility for assembling Kubernetes CD pipelines
+* [flux export alert](../flux_export_alert/)	 - Export Alert resources in YAML format
+* [flux export alert-provider](../flux_export_alert-provider/)	 - Export Provider resources in YAML format
+* [flux export helmrelease](../flux_export_helmrelease/)	 - Export HelmRelease resources in YAML format
+* [flux export image](../flux_export_image/)	 - Export image automation objects
+* [flux export kustomization](../flux_export_kustomization/)	 - Export Kustomization resources in YAML format
+* [flux export receiver](../flux_export_receiver/)	 - Export Receiver resources in YAML format
+* [flux export source](../flux_export_source/)	 - Export sources
 

--- a/docs/cmd/flux_export_alert-provider.md
+++ b/docs/cmd/flux_export_alert-provider.md
@@ -42,5 +42,5 @@ flux export alert-provider [name] [flags]
 
 ### SEE ALSO
 
-* [flux export](/cmd/flux_export/)	 - Export resources in YAML format
+* [flux export](../flux_export/)	 - Export resources in YAML format
 

--- a/docs/cmd/flux_export_alert.md
+++ b/docs/cmd/flux_export_alert.md
@@ -42,5 +42,5 @@ flux export alert [name] [flags]
 
 ### SEE ALSO
 
-* [flux export](/cmd/flux_export/)	 - Export resources in YAML format
+* [flux export](../flux_export/)	 - Export resources in YAML format
 

--- a/docs/cmd/flux_export_helmrelease.md
+++ b/docs/cmd/flux_export_helmrelease.md
@@ -42,5 +42,5 @@ flux export helmrelease [name] [flags]
 
 ### SEE ALSO
 
-* [flux export](/cmd/flux_export/)	 - Export resources in YAML format
+* [flux export](../flux_export/)	 - Export resources in YAML format
 

--- a/docs/cmd/flux_export_image.md
+++ b/docs/cmd/flux_export_image.md
@@ -28,8 +28,8 @@ The export image sub-commands export image automation objects in YAML format.
 
 ### SEE ALSO
 
-* [flux export](/cmd/flux_export/)	 - Export resources in YAML format
-* [flux export image policy](/cmd/flux_export_image_policy/)	 - Export ImagePolicy resources in YAML format
-* [flux export image repository](/cmd/flux_export_image_repository/)	 - Export ImageRepository resources in YAML format
-* [flux export image update](/cmd/flux_export_image_update/)	 - Export ImageUpdateAutomation resources in YAML format
+* [flux export](../flux_export/)	 - Export resources in YAML format
+* [flux export image policy](../flux_export_image_policy/)	 - Export ImagePolicy resources in YAML format
+* [flux export image repository](../flux_export_image_repository/)	 - Export ImageRepository resources in YAML format
+* [flux export image update](../flux_export_image_update/)	 - Export ImageUpdateAutomation resources in YAML format
 

--- a/docs/cmd/flux_export_image_policy.md
+++ b/docs/cmd/flux_export_image_policy.md
@@ -42,5 +42,5 @@ flux export image policy [name] [flags]
 
 ### SEE ALSO
 
-* [flux export image](/cmd/flux_export_image/)	 - Export image automation objects
+* [flux export image](../flux_export_image/)	 - Export image automation objects
 

--- a/docs/cmd/flux_export_image_repository.md
+++ b/docs/cmd/flux_export_image_repository.md
@@ -42,5 +42,5 @@ flux export image repository [name] [flags]
 
 ### SEE ALSO
 
-* [flux export image](/cmd/flux_export_image/)	 - Export image automation objects
+* [flux export image](../flux_export_image/)	 - Export image automation objects
 

--- a/docs/cmd/flux_export_image_update.md
+++ b/docs/cmd/flux_export_image_update.md
@@ -42,5 +42,5 @@ flux export image update [name] [flags]
 
 ### SEE ALSO
 
-* [flux export image](/cmd/flux_export_image/)	 - Export image automation objects
+* [flux export image](../flux_export_image/)	 - Export image automation objects
 

--- a/docs/cmd/flux_export_kustomization.md
+++ b/docs/cmd/flux_export_kustomization.md
@@ -42,5 +42,5 @@ flux export kustomization [name] [flags]
 
 ### SEE ALSO
 
-* [flux export](/cmd/flux_export/)	 - Export resources in YAML format
+* [flux export](../flux_export/)	 - Export resources in YAML format
 

--- a/docs/cmd/flux_export_receiver.md
+++ b/docs/cmd/flux_export_receiver.md
@@ -42,5 +42,5 @@ flux export receiver [name] [flags]
 
 ### SEE ALSO
 
-* [flux export](/cmd/flux_export/)	 - Export resources in YAML format
+* [flux export](../flux_export/)	 - Export resources in YAML format
 

--- a/docs/cmd/flux_export_source.md
+++ b/docs/cmd/flux_export_source.md
@@ -29,8 +29,8 @@ The export source sub-commands export sources in YAML format.
 
 ### SEE ALSO
 
-* [flux export](/cmd/flux_export/)	 - Export resources in YAML format
-* [flux export source bucket](/cmd/flux_export_source_bucket/)	 - Export Bucket sources in YAML format
-* [flux export source git](/cmd/flux_export_source_git/)	 - Export GitRepository sources in YAML format
-* [flux export source helm](/cmd/flux_export_source_helm/)	 - Export HelmRepository sources in YAML format
+* [flux export](../flux_export/)	 - Export resources in YAML format
+* [flux export source bucket](../flux_export_source_bucket/)	 - Export Bucket sources in YAML format
+* [flux export source git](../flux_export_source_git/)	 - Export GitRepository sources in YAML format
+* [flux export source helm](../flux_export_source_helm/)	 - Export HelmRepository sources in YAML format
 

--- a/docs/cmd/flux_export_source_bucket.md
+++ b/docs/cmd/flux_export_source_bucket.md
@@ -43,5 +43,5 @@ flux export source bucket [name] [flags]
 
 ### SEE ALSO
 
-* [flux export source](/cmd/flux_export_source/)	 - Export sources
+* [flux export source](../flux_export_source/)	 - Export sources
 

--- a/docs/cmd/flux_export_source_git.md
+++ b/docs/cmd/flux_export_source_git.md
@@ -43,5 +43,5 @@ flux export source git [name] [flags]
 
 ### SEE ALSO
 
-* [flux export source](/cmd/flux_export_source/)	 - Export sources
+* [flux export source](../flux_export_source/)	 - Export sources
 

--- a/docs/cmd/flux_export_source_helm.md
+++ b/docs/cmd/flux_export_source_helm.md
@@ -43,5 +43,5 @@ flux export source helm [name] [flags]
 
 ### SEE ALSO
 
-* [flux export source](/cmd/flux_export_source/)	 - Export sources
+* [flux export source](../flux_export_source/)	 - Export sources
 

--- a/docs/cmd/flux_get.md
+++ b/docs/cmd/flux_get.md
@@ -28,12 +28,12 @@ The get sub-commands print the statuses of Flux resources.
 
 ### SEE ALSO
 
-* [flux](/cmd/flux/)	 - Command line utility for assembling Kubernetes CD pipelines
-* [flux get alert-providers](/cmd/flux_get_alert-providers/)	 - Get Provider statuses
-* [flux get alerts](/cmd/flux_get_alerts/)	 - Get Alert statuses
-* [flux get helmreleases](/cmd/flux_get_helmreleases/)	 - Get HelmRelease statuses
-* [flux get images](/cmd/flux_get_images/)	 - Get image automation object status
-* [flux get kustomizations](/cmd/flux_get_kustomizations/)	 - Get Kustomization statuses
-* [flux get receivers](/cmd/flux_get_receivers/)	 - Get Receiver statuses
-* [flux get sources](/cmd/flux_get_sources/)	 - Get source statuses
+* [flux](../flux/)	 - Command line utility for assembling Kubernetes CD pipelines
+* [flux get alert-providers](../flux_get_alert-providers/)	 - Get Provider statuses
+* [flux get alerts](../flux_get_alerts/)	 - Get Alert statuses
+* [flux get helmreleases](../flux_get_helmreleases/)	 - Get HelmRelease statuses
+* [flux get images](../flux_get_images/)	 - Get image automation object status
+* [flux get kustomizations](../flux_get_kustomizations/)	 - Get Kustomization statuses
+* [flux get receivers](../flux_get_receivers/)	 - Get Receiver statuses
+* [flux get sources](../flux_get_sources/)	 - Get source statuses
 

--- a/docs/cmd/flux_get_alert-providers.md
+++ b/docs/cmd/flux_get_alert-providers.md
@@ -39,5 +39,5 @@ flux get alert-providers [flags]
 
 ### SEE ALSO
 
-* [flux get](/cmd/flux_get/)	 - Get the resources and their status
+* [flux get](../flux_get/)	 - Get the resources and their status
 

--- a/docs/cmd/flux_get_alerts.md
+++ b/docs/cmd/flux_get_alerts.md
@@ -39,5 +39,5 @@ flux get alerts [flags]
 
 ### SEE ALSO
 
-* [flux get](/cmd/flux_get/)	 - Get the resources and their status
+* [flux get](../flux_get/)	 - Get the resources and their status
 

--- a/docs/cmd/flux_get_helmreleases.md
+++ b/docs/cmd/flux_get_helmreleases.md
@@ -39,5 +39,5 @@ flux get helmreleases [flags]
 
 ### SEE ALSO
 
-* [flux get](/cmd/flux_get/)	 - Get the resources and their status
+* [flux get](../flux_get/)	 - Get the resources and their status
 

--- a/docs/cmd/flux_get_images.md
+++ b/docs/cmd/flux_get_images.md
@@ -28,9 +28,9 @@ The get image sub-commands print the status of image automation objects.
 
 ### SEE ALSO
 
-* [flux get](/cmd/flux_get/)	 - Get the resources and their status
-* [flux get images all](/cmd/flux_get_images_all/)	 - Get all image statuses
-* [flux get images policy](/cmd/flux_get_images_policy/)	 - Get ImagePolicy status
-* [flux get images repository](/cmd/flux_get_images_repository/)	 - Get ImageRepository status
-* [flux get images update](/cmd/flux_get_images_update/)	 - Get ImageUpdateAutomation status
+* [flux get](../flux_get/)	 - Get the resources and their status
+* [flux get images all](../flux_get_images_all/)	 - Get all image statuses
+* [flux get images policy](../flux_get_images_policy/)	 - Get ImagePolicy status
+* [flux get images repository](../flux_get_images_repository/)	 - Get ImageRepository status
+* [flux get images update](../flux_get_images_update/)	 - Get ImageUpdateAutomation status
 

--- a/docs/cmd/flux_get_images_all.md
+++ b/docs/cmd/flux_get_images_all.md
@@ -42,5 +42,5 @@ flux get images all [flags]
 
 ### SEE ALSO
 
-* [flux get images](/cmd/flux_get_images/)	 - Get image automation object status
+* [flux get images](../flux_get_images/)	 - Get image automation object status
 

--- a/docs/cmd/flux_get_images_policy.md
+++ b/docs/cmd/flux_get_images_policy.md
@@ -42,5 +42,5 @@ flux get images policy [flags]
 
 ### SEE ALSO
 
-* [flux get images](/cmd/flux_get_images/)	 - Get image automation object status
+* [flux get images](../flux_get_images/)	 - Get image automation object status
 

--- a/docs/cmd/flux_get_images_repository.md
+++ b/docs/cmd/flux_get_images_repository.md
@@ -42,5 +42,5 @@ flux get images repository [flags]
 
 ### SEE ALSO
 
-* [flux get images](/cmd/flux_get_images/)	 - Get image automation object status
+* [flux get images](../flux_get_images/)	 - Get image automation object status
 

--- a/docs/cmd/flux_get_images_update.md
+++ b/docs/cmd/flux_get_images_update.md
@@ -42,5 +42,5 @@ flux get images update [flags]
 
 ### SEE ALSO
 
-* [flux get images](/cmd/flux_get_images/)	 - Get image automation object status
+* [flux get images](../flux_get_images/)	 - Get image automation object status
 

--- a/docs/cmd/flux_get_kustomizations.md
+++ b/docs/cmd/flux_get_kustomizations.md
@@ -39,5 +39,5 @@ flux get kustomizations [flags]
 
 ### SEE ALSO
 
-* [flux get](/cmd/flux_get/)	 - Get the resources and their status
+* [flux get](../flux_get/)	 - Get the resources and their status
 

--- a/docs/cmd/flux_get_receivers.md
+++ b/docs/cmd/flux_get_receivers.md
@@ -39,5 +39,5 @@ flux get receivers [flags]
 
 ### SEE ALSO
 
-* [flux get](/cmd/flux_get/)	 - Get the resources and their status
+* [flux get](../flux_get/)	 - Get the resources and their status
 

--- a/docs/cmd/flux_get_sources.md
+++ b/docs/cmd/flux_get_sources.md
@@ -28,10 +28,10 @@ The get source sub-commands print the statuses of the sources.
 
 ### SEE ALSO
 
-* [flux get](/cmd/flux_get/)	 - Get the resources and their status
-* [flux get sources all](/cmd/flux_get_sources_all/)	 - Get all source statuses
-* [flux get sources bucket](/cmd/flux_get_sources_bucket/)	 - Get Bucket source statuses
-* [flux get sources chart](/cmd/flux_get_sources_chart/)	 - Get HelmChart statuses
-* [flux get sources git](/cmd/flux_get_sources_git/)	 - Get GitRepository source statuses
-* [flux get sources helm](/cmd/flux_get_sources_helm/)	 - Get HelmRepository source statuses
+* [flux get](../flux_get/)	 - Get the resources and their status
+* [flux get sources all](../flux_get_sources_all/)	 - Get all source statuses
+* [flux get sources bucket](../flux_get_sources_bucket/)	 - Get Bucket source statuses
+* [flux get sources chart](../flux_get_sources_chart/)	 - Get HelmChart statuses
+* [flux get sources git](../flux_get_sources_git/)	 - Get GitRepository source statuses
+* [flux get sources helm](../flux_get_sources_helm/)	 - Get HelmRepository source statuses
 

--- a/docs/cmd/flux_get_sources_all.md
+++ b/docs/cmd/flux_get_sources_all.md
@@ -42,5 +42,5 @@ flux get sources all [flags]
 
 ### SEE ALSO
 
-* [flux get sources](/cmd/flux_get_sources/)	 - Get source statuses
+* [flux get sources](../flux_get_sources/)	 - Get source statuses
 

--- a/docs/cmd/flux_get_sources_bucket.md
+++ b/docs/cmd/flux_get_sources_bucket.md
@@ -42,5 +42,5 @@ flux get sources bucket [flags]
 
 ### SEE ALSO
 
-* [flux get sources](/cmd/flux_get_sources/)	 - Get source statuses
+* [flux get sources](../flux_get_sources/)	 - Get source statuses
 

--- a/docs/cmd/flux_get_sources_chart.md
+++ b/docs/cmd/flux_get_sources_chart.md
@@ -42,5 +42,5 @@ flux get sources chart [flags]
 
 ### SEE ALSO
 
-* [flux get sources](/cmd/flux_get_sources/)	 - Get source statuses
+* [flux get sources](../flux_get_sources/)	 - Get source statuses
 

--- a/docs/cmd/flux_get_sources_git.md
+++ b/docs/cmd/flux_get_sources_git.md
@@ -42,5 +42,5 @@ flux get sources git [flags]
 
 ### SEE ALSO
 
-* [flux get sources](/cmd/flux_get_sources/)	 - Get source statuses
+* [flux get sources](../flux_get_sources/)	 - Get source statuses
 

--- a/docs/cmd/flux_get_sources_helm.md
+++ b/docs/cmd/flux_get_sources_helm.md
@@ -42,5 +42,5 @@ flux get sources helm [flags]
 
 ### SEE ALSO
 
-* [flux get sources](/cmd/flux_get_sources/)	 - Get source statuses
+* [flux get sources](../flux_get_sources/)	 - Get source statuses
 

--- a/docs/cmd/flux_install.md
+++ b/docs/cmd/flux_install.md
@@ -63,5 +63,5 @@ flux install [flags]
 
 ### SEE ALSO
 
-* [flux](/cmd/flux/)	 - Command line utility for assembling Kubernetes CD pipelines
+* [flux](../flux/)	 - Command line utility for assembling Kubernetes CD pipelines
 

--- a/docs/cmd/flux_logs.md
+++ b/docs/cmd/flux_logs.md
@@ -55,5 +55,5 @@ flux logs [flags]
 
 ### SEE ALSO
 
-* [flux](/cmd/flux/)	 - Command line utility for assembling Kubernetes CD pipelines
+* [flux](../flux/)	 - Command line utility for assembling Kubernetes CD pipelines
 

--- a/docs/cmd/flux_reconcile.md
+++ b/docs/cmd/flux_reconcile.md
@@ -27,12 +27,12 @@ The reconcile sub-commands trigger a reconciliation of sources and resources.
 
 ### SEE ALSO
 
-* [flux](/cmd/flux/)	 - Command line utility for assembling Kubernetes CD pipelines
-* [flux reconcile alert](/cmd/flux_reconcile_alert/)	 - Reconcile an Alert
-* [flux reconcile alert-provider](/cmd/flux_reconcile_alert-provider/)	 - Reconcile a Provider
-* [flux reconcile helmrelease](/cmd/flux_reconcile_helmrelease/)	 - Reconcile a HelmRelease resource
-* [flux reconcile image](/cmd/flux_reconcile_image/)	 - Reconcile image automation objects
-* [flux reconcile kustomization](/cmd/flux_reconcile_kustomization/)	 - Reconcile a Kustomization resource
-* [flux reconcile receiver](/cmd/flux_reconcile_receiver/)	 - Reconcile a Receiver
-* [flux reconcile source](/cmd/flux_reconcile_source/)	 - Reconcile sources
+* [flux](../flux/)	 - Command line utility for assembling Kubernetes CD pipelines
+* [flux reconcile alert](../flux_reconcile_alert/)	 - Reconcile an Alert
+* [flux reconcile alert-provider](../flux_reconcile_alert-provider/)	 - Reconcile a Provider
+* [flux reconcile helmrelease](../flux_reconcile_helmrelease/)	 - Reconcile a HelmRelease resource
+* [flux reconcile image](../flux_reconcile_image/)	 - Reconcile image automation objects
+* [flux reconcile kustomization](../flux_reconcile_kustomization/)	 - Reconcile a Kustomization resource
+* [flux reconcile receiver](../flux_reconcile_receiver/)	 - Reconcile a Receiver
+* [flux reconcile source](../flux_reconcile_source/)	 - Reconcile sources
 

--- a/docs/cmd/flux_reconcile_alert-provider.md
+++ b/docs/cmd/flux_reconcile_alert-provider.md
@@ -38,5 +38,5 @@ flux reconcile alert-provider [name] [flags]
 
 ### SEE ALSO
 
-* [flux reconcile](/cmd/flux_reconcile/)	 - Reconcile sources and resources
+* [flux reconcile](../flux_reconcile/)	 - Reconcile sources and resources
 

--- a/docs/cmd/flux_reconcile_alert.md
+++ b/docs/cmd/flux_reconcile_alert.md
@@ -38,5 +38,5 @@ flux reconcile alert [name] [flags]
 
 ### SEE ALSO
 
-* [flux reconcile](/cmd/flux_reconcile/)	 - Reconcile sources and resources
+* [flux reconcile](../flux_reconcile/)	 - Reconcile sources and resources
 

--- a/docs/cmd/flux_reconcile_helmrelease.md
+++ b/docs/cmd/flux_reconcile_helmrelease.md
@@ -43,5 +43,5 @@ flux reconcile helmrelease [name] [flags]
 
 ### SEE ALSO
 
-* [flux reconcile](/cmd/flux_reconcile/)	 - Reconcile sources and resources
+* [flux reconcile](../flux_reconcile/)	 - Reconcile sources and resources
 

--- a/docs/cmd/flux_reconcile_image.md
+++ b/docs/cmd/flux_reconcile_image.md
@@ -27,7 +27,7 @@ The reconcile sub-commands trigger a reconciliation of image automation objects.
 
 ### SEE ALSO
 
-* [flux reconcile](/cmd/flux_reconcile/)	 - Reconcile sources and resources
-* [flux reconcile image repository](/cmd/flux_reconcile_image_repository/)	 - Reconcile an ImageRepository
-* [flux reconcile image update](/cmd/flux_reconcile_image_update/)	 - Reconcile an ImageUpdateAutomation
+* [flux reconcile](../flux_reconcile/)	 - Reconcile sources and resources
+* [flux reconcile image repository](../flux_reconcile_image_repository/)	 - Reconcile an ImageRepository
+* [flux reconcile image update](../flux_reconcile_image_update/)	 - Reconcile an ImageUpdateAutomation
 

--- a/docs/cmd/flux_reconcile_image_repository.md
+++ b/docs/cmd/flux_reconcile_image_repository.md
@@ -38,5 +38,5 @@ flux reconcile image repository [name] [flags]
 
 ### SEE ALSO
 
-* [flux reconcile image](/cmd/flux_reconcile_image/)	 - Reconcile image automation objects
+* [flux reconcile image](../flux_reconcile_image/)	 - Reconcile image automation objects
 

--- a/docs/cmd/flux_reconcile_image_update.md
+++ b/docs/cmd/flux_reconcile_image_update.md
@@ -38,5 +38,5 @@ flux reconcile image update [name] [flags]
 
 ### SEE ALSO
 
-* [flux reconcile image](/cmd/flux_reconcile_image/)	 - Reconcile image automation objects
+* [flux reconcile image](../flux_reconcile_image/)	 - Reconcile image automation objects
 

--- a/docs/cmd/flux_reconcile_kustomization.md
+++ b/docs/cmd/flux_reconcile_kustomization.md
@@ -43,5 +43,5 @@ flux reconcile kustomization [name] [flags]
 
 ### SEE ALSO
 
-* [flux reconcile](/cmd/flux_reconcile/)	 - Reconcile sources and resources
+* [flux reconcile](../flux_reconcile/)	 - Reconcile sources and resources
 

--- a/docs/cmd/flux_reconcile_receiver.md
+++ b/docs/cmd/flux_reconcile_receiver.md
@@ -38,5 +38,5 @@ flux reconcile receiver [name] [flags]
 
 ### SEE ALSO
 
-* [flux reconcile](/cmd/flux_reconcile/)	 - Reconcile sources and resources
+* [flux reconcile](../flux_reconcile/)	 - Reconcile sources and resources
 

--- a/docs/cmd/flux_reconcile_source.md
+++ b/docs/cmd/flux_reconcile_source.md
@@ -27,8 +27,8 @@ The reconcile source sub-commands trigger a reconciliation of sources.
 
 ### SEE ALSO
 
-* [flux reconcile](/cmd/flux_reconcile/)	 - Reconcile sources and resources
-* [flux reconcile source bucket](/cmd/flux_reconcile_source_bucket/)	 - Reconcile a Bucket source
-* [flux reconcile source git](/cmd/flux_reconcile_source_git/)	 - Reconcile a GitRepository source
-* [flux reconcile source helm](/cmd/flux_reconcile_source_helm/)	 - Reconcile a HelmRepository source
+* [flux reconcile](../flux_reconcile/)	 - Reconcile sources and resources
+* [flux reconcile source bucket](../flux_reconcile_source_bucket/)	 - Reconcile a Bucket source
+* [flux reconcile source git](../flux_reconcile_source_git/)	 - Reconcile a GitRepository source
+* [flux reconcile source helm](../flux_reconcile_source_helm/)	 - Reconcile a HelmRepository source
 

--- a/docs/cmd/flux_reconcile_source_bucket.md
+++ b/docs/cmd/flux_reconcile_source_bucket.md
@@ -38,5 +38,5 @@ flux reconcile source bucket [name] [flags]
 
 ### SEE ALSO
 
-* [flux reconcile source](/cmd/flux_reconcile_source/)	 - Reconcile sources
+* [flux reconcile source](../flux_reconcile_source/)	 - Reconcile sources
 

--- a/docs/cmd/flux_reconcile_source_git.md
+++ b/docs/cmd/flux_reconcile_source_git.md
@@ -38,5 +38,5 @@ flux reconcile source git [name] [flags]
 
 ### SEE ALSO
 
-* [flux reconcile source](/cmd/flux_reconcile_source/)	 - Reconcile sources
+* [flux reconcile source](../flux_reconcile_source/)	 - Reconcile sources
 

--- a/docs/cmd/flux_reconcile_source_helm.md
+++ b/docs/cmd/flux_reconcile_source_helm.md
@@ -38,5 +38,5 @@ flux reconcile source helm [name] [flags]
 
 ### SEE ALSO
 
-* [flux reconcile source](/cmd/flux_reconcile_source/)	 - Reconcile sources
+* [flux reconcile source](../flux_reconcile_source/)	 - Reconcile sources
 

--- a/docs/cmd/flux_resume.md
+++ b/docs/cmd/flux_resume.md
@@ -27,11 +27,11 @@ The resume sub-commands resume a suspended resource.
 
 ### SEE ALSO
 
-* [flux](/cmd/flux/)	 - Command line utility for assembling Kubernetes CD pipelines
-* [flux resume alert](/cmd/flux_resume_alert/)	 - Resume a suspended Alert
-* [flux resume helmrelease](/cmd/flux_resume_helmrelease/)	 - Resume a suspended HelmRelease
-* [flux resume image](/cmd/flux_resume_image/)	 - Resume image automation objects
-* [flux resume kustomization](/cmd/flux_resume_kustomization/)	 - Resume a suspended Kustomization
-* [flux resume receiver](/cmd/flux_resume_receiver/)	 - Resume a suspended Receiver
-* [flux resume source](/cmd/flux_resume_source/)	 - Resume sources
+* [flux](../flux/)	 - Command line utility for assembling Kubernetes CD pipelines
+* [flux resume alert](../flux_resume_alert/)	 - Resume a suspended Alert
+* [flux resume helmrelease](../flux_resume_helmrelease/)	 - Resume a suspended HelmRelease
+* [flux resume image](../flux_resume_image/)	 - Resume image automation objects
+* [flux resume kustomization](../flux_resume_kustomization/)	 - Resume a suspended Kustomization
+* [flux resume receiver](../flux_resume_receiver/)	 - Resume a suspended Receiver
+* [flux resume source](../flux_resume_source/)	 - Resume sources
 

--- a/docs/cmd/flux_resume_alert.md
+++ b/docs/cmd/flux_resume_alert.md
@@ -39,5 +39,5 @@ flux resume alert [name] [flags]
 
 ### SEE ALSO
 
-* [flux resume](/cmd/flux_resume/)	 - Resume suspended resources
+* [flux resume](../flux_resume/)	 - Resume suspended resources
 

--- a/docs/cmd/flux_resume_helmrelease.md
+++ b/docs/cmd/flux_resume_helmrelease.md
@@ -39,5 +39,5 @@ flux resume helmrelease [name] [flags]
 
 ### SEE ALSO
 
-* [flux resume](/cmd/flux_resume/)	 - Resume suspended resources
+* [flux resume](../flux_resume/)	 - Resume suspended resources
 

--- a/docs/cmd/flux_resume_image.md
+++ b/docs/cmd/flux_resume_image.md
@@ -27,7 +27,7 @@ The resume image sub-commands resume suspended image automation objects.
 
 ### SEE ALSO
 
-* [flux resume](/cmd/flux_resume/)	 - Resume suspended resources
-* [flux resume image repository](/cmd/flux_resume_image_repository/)	 - Resume a suspended ImageRepository
-* [flux resume image update](/cmd/flux_resume_image_update/)	 - Resume a suspended ImageUpdateAutomation
+* [flux resume](../flux_resume/)	 - Resume suspended resources
+* [flux resume image repository](../flux_resume_image_repository/)	 - Resume a suspended ImageRepository
+* [flux resume image update](../flux_resume_image_update/)	 - Resume a suspended ImageUpdateAutomation
 

--- a/docs/cmd/flux_resume_image_repository.md
+++ b/docs/cmd/flux_resume_image_repository.md
@@ -38,5 +38,5 @@ flux resume image repository [name] [flags]
 
 ### SEE ALSO
 
-* [flux resume image](/cmd/flux_resume_image/)	 - Resume image automation objects
+* [flux resume image](../flux_resume_image/)	 - Resume image automation objects
 

--- a/docs/cmd/flux_resume_image_update.md
+++ b/docs/cmd/flux_resume_image_update.md
@@ -38,5 +38,5 @@ flux resume image update [name] [flags]
 
 ### SEE ALSO
 
-* [flux resume image](/cmd/flux_resume_image/)	 - Resume image automation objects
+* [flux resume image](../flux_resume_image/)	 - Resume image automation objects
 

--- a/docs/cmd/flux_resume_kustomization.md
+++ b/docs/cmd/flux_resume_kustomization.md
@@ -39,5 +39,5 @@ flux resume kustomization [name] [flags]
 
 ### SEE ALSO
 
-* [flux resume](/cmd/flux_resume/)	 - Resume suspended resources
+* [flux resume](../flux_resume/)	 - Resume suspended resources
 

--- a/docs/cmd/flux_resume_receiver.md
+++ b/docs/cmd/flux_resume_receiver.md
@@ -39,5 +39,5 @@ flux resume receiver [name] [flags]
 
 ### SEE ALSO
 
-* [flux resume](/cmd/flux_resume/)	 - Resume suspended resources
+* [flux resume](../flux_resume/)	 - Resume suspended resources
 

--- a/docs/cmd/flux_resume_source.md
+++ b/docs/cmd/flux_resume_source.md
@@ -27,9 +27,9 @@ The resume sub-commands resume a suspended source.
 
 ### SEE ALSO
 
-* [flux resume](/cmd/flux_resume/)	 - Resume suspended resources
-* [flux resume source bucket](/cmd/flux_resume_source_bucket/)	 - Resume a suspended Bucket
-* [flux resume source chart](/cmd/flux_resume_source_chart/)	 - Resume a suspended HelmChart
-* [flux resume source git](/cmd/flux_resume_source_git/)	 - Resume a suspended GitRepository
-* [flux resume source helm](/cmd/flux_resume_source_helm/)	 - Resume a suspended HelmRepository
+* [flux resume](../flux_resume/)	 - Resume suspended resources
+* [flux resume source bucket](../flux_resume_source_bucket/)	 - Resume a suspended Bucket
+* [flux resume source chart](../flux_resume_source_chart/)	 - Resume a suspended HelmChart
+* [flux resume source git](../flux_resume_source_git/)	 - Resume a suspended GitRepository
+* [flux resume source helm](../flux_resume_source_helm/)	 - Resume a suspended HelmRepository
 

--- a/docs/cmd/flux_resume_source_bucket.md
+++ b/docs/cmd/flux_resume_source_bucket.md
@@ -38,5 +38,5 @@ flux resume source bucket [name] [flags]
 
 ### SEE ALSO
 
-* [flux resume source](/cmd/flux_resume_source/)	 - Resume sources
+* [flux resume source](../flux_resume_source/)	 - Resume sources
 

--- a/docs/cmd/flux_resume_source_chart.md
+++ b/docs/cmd/flux_resume_source_chart.md
@@ -38,5 +38,5 @@ flux resume source chart [name] [flags]
 
 ### SEE ALSO
 
-* [flux resume source](/cmd/flux_resume_source/)	 - Resume sources
+* [flux resume source](../flux_resume_source/)	 - Resume sources
 

--- a/docs/cmd/flux_resume_source_git.md
+++ b/docs/cmd/flux_resume_source_git.md
@@ -38,5 +38,5 @@ flux resume source git [name] [flags]
 
 ### SEE ALSO
 
-* [flux resume source](/cmd/flux_resume_source/)	 - Resume sources
+* [flux resume source](../flux_resume_source/)	 - Resume sources
 

--- a/docs/cmd/flux_resume_source_helm.md
+++ b/docs/cmd/flux_resume_source_helm.md
@@ -38,5 +38,5 @@ flux resume source helm [name] [flags]
 
 ### SEE ALSO
 
-* [flux resume source](/cmd/flux_resume_source/)	 - Resume sources
+* [flux resume source](../flux_resume_source/)	 - Resume sources
 

--- a/docs/cmd/flux_suspend.md
+++ b/docs/cmd/flux_suspend.md
@@ -27,11 +27,11 @@ The suspend sub-commands suspend the reconciliation of a resource.
 
 ### SEE ALSO
 
-* [flux](/cmd/flux/)	 - Command line utility for assembling Kubernetes CD pipelines
-* [flux suspend alert](/cmd/flux_suspend_alert/)	 - Suspend reconciliation of Alert
-* [flux suspend helmrelease](/cmd/flux_suspend_helmrelease/)	 - Suspend reconciliation of HelmRelease
-* [flux suspend image](/cmd/flux_suspend_image/)	 - Suspend image automation objects
-* [flux suspend kustomization](/cmd/flux_suspend_kustomization/)	 - Suspend reconciliation of Kustomization
-* [flux suspend receiver](/cmd/flux_suspend_receiver/)	 - Suspend reconciliation of Receiver
-* [flux suspend source](/cmd/flux_suspend_source/)	 - Suspend sources
+* [flux](../flux/)	 - Command line utility for assembling Kubernetes CD pipelines
+* [flux suspend alert](../flux_suspend_alert/)	 - Suspend reconciliation of Alert
+* [flux suspend helmrelease](../flux_suspend_helmrelease/)	 - Suspend reconciliation of HelmRelease
+* [flux suspend image](../flux_suspend_image/)	 - Suspend image automation objects
+* [flux suspend kustomization](../flux_suspend_kustomization/)	 - Suspend reconciliation of Kustomization
+* [flux suspend receiver](../flux_suspend_receiver/)	 - Suspend reconciliation of Receiver
+* [flux suspend source](../flux_suspend_source/)	 - Suspend sources
 

--- a/docs/cmd/flux_suspend_alert.md
+++ b/docs/cmd/flux_suspend_alert.md
@@ -38,5 +38,5 @@ flux suspend alert [name] [flags]
 
 ### SEE ALSO
 
-* [flux suspend](/cmd/flux_suspend/)	 - Suspend resources
+* [flux suspend](../flux_suspend/)	 - Suspend resources
 

--- a/docs/cmd/flux_suspend_helmrelease.md
+++ b/docs/cmd/flux_suspend_helmrelease.md
@@ -38,5 +38,5 @@ flux suspend helmrelease [name] [flags]
 
 ### SEE ALSO
 
-* [flux suspend](/cmd/flux_suspend/)	 - Suspend resources
+* [flux suspend](../flux_suspend/)	 - Suspend resources
 

--- a/docs/cmd/flux_suspend_image.md
+++ b/docs/cmd/flux_suspend_image.md
@@ -27,7 +27,7 @@ The suspend image sub-commands suspend the reconciliation of an image automation
 
 ### SEE ALSO
 
-* [flux suspend](/cmd/flux_suspend/)	 - Suspend resources
-* [flux suspend image repository](/cmd/flux_suspend_image_repository/)	 - Suspend reconciliation of an ImageRepository
-* [flux suspend image update](/cmd/flux_suspend_image_update/)	 - Suspend reconciliation of an ImageUpdateAutomation
+* [flux suspend](../flux_suspend/)	 - Suspend resources
+* [flux suspend image repository](../flux_suspend_image_repository/)	 - Suspend reconciliation of an ImageRepository
+* [flux suspend image update](../flux_suspend_image_update/)	 - Suspend reconciliation of an ImageUpdateAutomation
 

--- a/docs/cmd/flux_suspend_image_repository.md
+++ b/docs/cmd/flux_suspend_image_repository.md
@@ -38,5 +38,5 @@ flux suspend image repository [name] [flags]
 
 ### SEE ALSO
 
-* [flux suspend image](/cmd/flux_suspend_image/)	 - Suspend image automation objects
+* [flux suspend image](../flux_suspend_image/)	 - Suspend image automation objects
 

--- a/docs/cmd/flux_suspend_image_update.md
+++ b/docs/cmd/flux_suspend_image_update.md
@@ -38,5 +38,5 @@ flux suspend image update [name] [flags]
 
 ### SEE ALSO
 
-* [flux suspend image](/cmd/flux_suspend_image/)	 - Suspend image automation objects
+* [flux suspend image](../flux_suspend_image/)	 - Suspend image automation objects
 

--- a/docs/cmd/flux_suspend_kustomization.md
+++ b/docs/cmd/flux_suspend_kustomization.md
@@ -38,5 +38,5 @@ flux suspend kustomization [name] [flags]
 
 ### SEE ALSO
 
-* [flux suspend](/cmd/flux_suspend/)	 - Suspend resources
+* [flux suspend](../flux_suspend/)	 - Suspend resources
 

--- a/docs/cmd/flux_suspend_receiver.md
+++ b/docs/cmd/flux_suspend_receiver.md
@@ -38,5 +38,5 @@ flux suspend receiver [name] [flags]
 
 ### SEE ALSO
 
-* [flux suspend](/cmd/flux_suspend/)	 - Suspend resources
+* [flux suspend](../flux_suspend/)	 - Suspend resources
 

--- a/docs/cmd/flux_suspend_source.md
+++ b/docs/cmd/flux_suspend_source.md
@@ -27,9 +27,9 @@ The suspend sub-commands suspend the reconciliation of a source.
 
 ### SEE ALSO
 
-* [flux suspend](/cmd/flux_suspend/)	 - Suspend resources
-* [flux suspend source bucket](/cmd/flux_suspend_source_bucket/)	 - Suspend reconciliation of a Bucket
-* [flux suspend source chart](/cmd/flux_suspend_source_chart/)	 - Suspend reconciliation of a HelmChart
-* [flux suspend source git](/cmd/flux_suspend_source_git/)	 - Suspend reconciliation of a GitRepository
-* [flux suspend source helm](/cmd/flux_suspend_source_helm/)	 - Suspend reconciliation of a HelmRepository
+* [flux suspend](../flux_suspend/)	 - Suspend resources
+* [flux suspend source bucket](../flux_suspend_source_bucket/)	 - Suspend reconciliation of a Bucket
+* [flux suspend source chart](../flux_suspend_source_chart/)	 - Suspend reconciliation of a HelmChart
+* [flux suspend source git](../flux_suspend_source_git/)	 - Suspend reconciliation of a GitRepository
+* [flux suspend source helm](../flux_suspend_source_helm/)	 - Suspend reconciliation of a HelmRepository
 

--- a/docs/cmd/flux_suspend_source_bucket.md
+++ b/docs/cmd/flux_suspend_source_bucket.md
@@ -38,5 +38,5 @@ flux suspend source bucket [name] [flags]
 
 ### SEE ALSO
 
-* [flux suspend source](/cmd/flux_suspend_source/)	 - Suspend sources
+* [flux suspend source](../flux_suspend_source/)	 - Suspend sources
 

--- a/docs/cmd/flux_suspend_source_chart.md
+++ b/docs/cmd/flux_suspend_source_chart.md
@@ -38,5 +38,5 @@ flux suspend source chart [name] [flags]
 
 ### SEE ALSO
 
-* [flux suspend source](/cmd/flux_suspend_source/)	 - Suspend sources
+* [flux suspend source](../flux_suspend_source/)	 - Suspend sources
 

--- a/docs/cmd/flux_suspend_source_git.md
+++ b/docs/cmd/flux_suspend_source_git.md
@@ -38,5 +38,5 @@ flux suspend source git [name] [flags]
 
 ### SEE ALSO
 
-* [flux suspend source](/cmd/flux_suspend_source/)	 - Suspend sources
+* [flux suspend source](../flux_suspend_source/)	 - Suspend sources
 

--- a/docs/cmd/flux_suspend_source_helm.md
+++ b/docs/cmd/flux_suspend_source_helm.md
@@ -38,5 +38,5 @@ flux suspend source helm [name] [flags]
 
 ### SEE ALSO
 
-* [flux suspend source](/cmd/flux_suspend_source/)	 - Suspend sources
+* [flux suspend source](../flux_suspend_source/)	 - Suspend sources
 

--- a/docs/cmd/flux_uninstall.md
+++ b/docs/cmd/flux_uninstall.md
@@ -44,5 +44,5 @@ flux uninstall [flags]
 
 ### SEE ALSO
 
-* [flux](/cmd/flux/)	 - Command line utility for assembling Kubernetes CD pipelines
+* [flux](../flux/)	 - Command line utility for assembling Kubernetes CD pipelines
 

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -27,4 +27,4 @@ A reference for each component and API type is linked below.
 - [Image automation controllers](image/controller.md)
     - [ImageRepository CRD](image/imagerepositories.md)
     - [ImagePolicy CRD](image/imagepolicies.md)
-    - [ImageUpdateAutomation CRD](image/imageupdateautomation.md)
+    - [ImageUpdateAutomation CRD](image/imageupdateautomations.md)

--- a/docs/guides/image-update.md
+++ b/docs/guides/image-update.md
@@ -923,7 +923,7 @@ Verify that `kustomize build .` works, then commit the directory to you control 
 Flux will apply the Deployment and it will use the AAD managed identity for that Pod to regularly fetch ACR tokens into your configured `KUBE_SECRET` name.
 Reference the `KUBE_SECRET` value from any `ImageRepository` objects for that ACR registry.
 
-This example uses the `fluxcd/flux2` github archive as a remote base, but you may copy the [./manifests/integrations/registry-credentials-sync/azure](github.com/fluxcd/flux2/tree/main/manifests/integrations/registry-credentials-sync/azure)
+This example uses the `fluxcd/flux2` github archive as a remote base, but you may copy the [./manifests/integrations/registry-credentials-sync/azure](https://github.com/fluxcd/flux2/tree/main/manifests/integrations/registry-credentials-sync/azure)
 folder into your own repository or use a git submodule to vendor it if preferred.
 
 #### Using Static Credentials [long-lived]

--- a/docs/use-cases/azure.md
+++ b/docs/use-cases/azure.md
@@ -52,7 +52,7 @@ az aks create \
 
 ## Flux Installation with Azure DevOps Repos
 
-Ensure you can login to [https://dev.azure.com](dev.azure.com) for your proper organization, and create a new repo to hold your
+Ensure you can login to [dev.azure.com](https://dev.azure.com) for your proper organization, and create a new repo to hold your
 flux install and other necessary config.
 
 There is no bootstrap provider currently for Azure DevOps Repos,


### PR DESCRIPTION
For the move to the `hugo` site, I noticed that links in the CLI docs didn't quite work. This was due the new URL having an additional `/docs/` in there. To keep CLI docs working for both sites, moving to relative links.

Fixed a link in the components overview doc as well while I was at it.