### PR TITLE
Updated automation migration guide filter tags crd

### DIFF
--- a/docs/guides/flux-v1-automation-migration.md
+++ b/docs/guides/flux-v1-automation-migration.md
@@ -541,13 +541,13 @@ spec:
       order: asc
 ```
 
-The `.spec.pattern` field gives a regular expression that a tag must match to be included. The
-`.spec.extract` field gives a replacement pattern that can refer back to capture groups in the
+The `.spec.filterTags.pattern` field gives a regular expression that a tag must match to be included. The
+`.spec.filterTags.extract` field gives a replacement pattern that can refer back to capture groups in the
 filter pattern. The extracted values are sorted to find the selected image tag. In this case, the
 timestamp part of the tag will be extracted and sorted numerically in ascending order. See [the
 reference docs][imagepolicy-ref] for more examples.
 
-Once you have made sure you have image tags and an `ImagePolicy` that works, jump ahead to [Checking
+Once you have made sure you have image tags and an `ImagePolicy`, jump ahead to [Checking
 the ImagePolicy works](#checking-that-the-image-policy-works).
 
 ### How to use SemVer image tags


### PR DESCRIPTION
The text description in the automation migration guide uses a wrong crd schema.