### PR TITLE
Update gcr access token in place

### DIFF
--- a/docs/guides/image-update.md
+++ b/docs/guides/image-update.md
@@ -811,11 +811,13 @@ spec:
             - /bin/bash
             - -ce
             - |-
-              kubectl delete secret --ignore-not-found $SECRET_NAME
               kubectl create secret docker-registry $SECRET_NAME \
                 --docker-server="$GCR_REGISTRY" \
                 --docker-username=oauth2accesstoken \
-                --docker-password="$(gcloud auth print-access-token)" 
+                --docker-password="$(gcloud auth print-access-token)" \
+                --dry-run=client \
+                -o yaml \
+                | kubectl apply -f -
 ```
 
 Since the cronjob will not create a job right away, after applying the manifest,


### PR DESCRIPTION
It's possible to update secrets in place instead of removing and creating a new one.

But what's wrong with the old way of doing things you may ask.

If jobs for GCR synchronization and token refreshment lunch at the same time and they sometimes will we will get the following error:

`Secret "gcr-credentials" not found`

This happens because:
1. token was deleted by Token Refresh Job
2. GCR synchronization will begin and fail because there is no token
3. new token will be created.

Updating the token in place fixes this issue.