### PR TITLE
Publish AMD64, ARM64, ARMv7 images for binary

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,26 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.16.x
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+      - name: Setup Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          buildkitd-flags: "--debug"
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: fluxcdbot
+          password: ${{ secrets.GHCR_TOKEN }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: fluxcdbot
+          password: ${{ secrets.DOCKER_FLUXCD_PASSWORD }}
       - name: Download release notes utility
         env:
           GH_REL_URL: https://github.com/buchanae/github-release-notes/releases/download/0.2.0/github-release-notes-linux-amd64-0.2.0.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# Release
+dist/
+
 # Dependency directories (remove the comment below to include it)
 # vendor/
 bin/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -74,3 +74,64 @@ release:
   extra_files:
     - glob: ./output/manifests.tar.gz
     - glob: ./output/install.yaml
+dockers:
+- image_templates:
+    - 'fluxcd/flux-cli:{{ .Tag }}-amd64'
+    - 'ghcr.io/fluxcd/flux-cli:{{ .Tag }}-amd64'
+  dockerfile: Dockerfile
+  use_buildx: true
+  goos: linux
+  goarch: amd64
+  build_flag_templates:
+   - "--pull"
+   - "--build-arg=ARCH=linux/amd64"
+   - "--label=org.opencontainers.image.created={{ .Date }}"
+   - "--label=org.opencontainers.image.name={{ .ProjectName }}"
+   - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+   - "--label=org.opencontainers.image.version={{ .Version }}"
+   - "--label=org.opencontainers.image.source={{ .GitURL }}"
+   - "--platform=linux/amd64"
+- image_templates:
+    - 'fluxcd/flux-cli:{{ .Tag }}-arm64'
+    - 'ghcr.io/fluxcd/flux-cli:{{ .Tag }}-arm64'
+  dockerfile: Dockerfile
+  use_buildx: true
+  goos: linux
+  goarch: arm64
+  build_flag_templates:
+    - "--pull"
+    - "--build-arg=ARCH=linux/arm64"
+    - "--label=org.opencontainers.image.created={{ .Date }}"
+    - "--label=org.opencontainers.image.name={{ .ProjectName }}"
+    - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+    - "--label=org.opencontainers.image.version={{ .Version }}"
+    - "--label=org.opencontainers.image.source={{ .GitURL }}"
+    - "--platform=linux/arm64"
+- image_templates:
+    - 'fluxcd/flux-cli:{{ .Tag }}-arm'
+    - 'ghcr.io/fluxcd/flux-cli:{{ .Tag }}-arm'
+  dockerfile: Dockerfile
+  use_buildx: true
+  goos: linux
+  goarch: arm
+  goarm: 7
+  build_flag_templates:
+    - "--pull"
+    - "--build-arg=ARCH=linux/arm"
+    - "--label=org.opencontainers.image.created={{ .Date }}"
+    - "--label=org.opencontainers.image.name={{ .ProjectName }}"
+    - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+    - "--label=org.opencontainers.image.version={{ .Version }}"
+    - "--label=org.opencontainers.image.source={{ .GitURL }}"
+    - "--platform=linux/arm/v7"
+docker_manifests:
+- name_template: 'fluxcd/flux-cli:{{ .Tag }}'
+  image_templates:
+    - 'fluxcd/flux-cli:{{ .Tag }}-amd64'
+    - 'fluxcd/flux-cli:{{ .Tag }}-arm64'
+    - 'fluxcd/flux-cli:{{ .Tag }}-arm'
+- name_template: 'ghcr.io/fluxcd/flux-cli:{{ .Tag }}'
+  image_templates:
+    - 'ghcr.io/fluxcd/flux-cli:{{ .Tag }}-amd64'
+    - 'ghcr.io/fluxcd/flux-cli:{{ .Tag }}-arm64'
+    - 'ghcr.io/fluxcd/flux-cli:{{ .Tag }}-arm'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM alpine:3.13 as builder
+
+RUN apk add --no-cache ca-certificates curl
+
+ARG ARCH=linux/amd64
+ARG KUBECTL_VER=1.20.4
+
+RUN curl -sL https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VER}/bin/${ARCH}/kubectl \
+    -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl && \
+    kubectl version --client=true
+
+FROM alpine:3.13 as flux-cli
+
+# Create minimal nsswitch.conf file to prioritize the usage of /etc/hosts over DNS queries.
+# https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-354316460
+RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+
+RUN apk add --no-cache ca-certificates
+
+COPY --from=builder /usr/local/bin/kubectl /usr/local/bin/
+COPY --chmod=755 flux /usr/local/bin/
+
+ENTRYPOINT [ "flux" ]


### PR DESCRIPTION
This PR adds the bits and pieces to enable the build of Docker images (and a multi-arch) image for goreleaser, publishing them to both Docker Hub and GHCR.

It offers a workaround for #1125 as described in https://github.com/fluxcd/flux2/issues/1125#issuecomment-806482915.

Release process was tested locally against a fork, see:

- https://hub.docker.com/r/hiddeco/flux-cli/tags
- https://github.com/users/hiddeco/packages/container/package/flux-cli