### PR TITLE
Add recurse submodules arg to create source git and bootstrap cmd

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -188,7 +188,8 @@ jobs:
         run: |
           /tmp/flux create source git flux-system \
           --url=https://github.com/fluxcd/flux2-kustomize-helm-example \
-          --branch=main
+          --branch=main \
+          --recurse-submodules
           /tmp/flux create kustomization flux-system \
           --source=flux-system \
           --path=./clusters/staging

--- a/cmd/flux/bootstrap.go
+++ b/cmd/flux/bootstrap.go
@@ -39,8 +39,9 @@ type bootstrapFlags struct {
 	arch     flags.Arch
 	logLevel flags.LogLevel
 
-	branch        string
-	manifestsPath string
+	branch            string
+	recurseSubmodules bool
+	manifestsPath     string
 
 	defaultComponents  []string
 	extraComponents    []string
@@ -89,8 +90,10 @@ func init() {
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapArgs.imagePullSecret, "image-pull-secret", "",
 		"Kubernetes secret name used for pulling the toolkit images from a private registry")
 
-	bootstrapCmd.PersistentFlags().StringVar(&bootstrapArgs.branch, "branch", bootstrapDefaultBranch,
-		"default branch (for GitHub this must match the default branch setting for the organization)")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapArgs.branch, "branch", bootstrapDefaultBranch, "Git branch")
+	bootstrapCmd.PersistentFlags().BoolVar(&bootstrapArgs.recurseSubmodules, "recurse-submodules", false,
+		"when enabled, configures the GitRepository source to initialize and include Git submodules in the artifact it produces")
+
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapArgs.manifestsPath, "manifests", "", "path to the manifest directory")
 
 	bootstrapCmd.PersistentFlags().BoolVar(&bootstrapArgs.watchAllNamespaces, "watch-all-namespaces", true,

--- a/cmd/flux/bootstrap_git.go
+++ b/cmd/flux/bootstrap_git.go
@@ -189,6 +189,7 @@ func bootstrapGitCmdRun(cmd *cobra.Command, args []string) error {
 		TargetPath:        gitArgs.path.String(),
 		ManifestFile:      sync.MakeDefaultOptions().ManifestFile,
 		GitImplementation: sourceGitArgs.gitImplementation.String(),
+		RecurseSubmodules: bootstrapArgs.recurseSubmodules,
 	}
 
 	// Bootstrap config

--- a/cmd/flux/bootstrap_github.go
+++ b/cmd/flux/bootstrap_github.go
@@ -211,6 +211,7 @@ func bootstrapGitHubCmdRun(cmd *cobra.Command, args []string) error {
 		TargetPath:        githubArgs.path.String(),
 		ManifestFile:      sync.MakeDefaultOptions().ManifestFile,
 		GitImplementation: sourceGitArgs.gitImplementation.String(),
+		RecurseSubmodules: bootstrapArgs.recurseSubmodules,
 	}
 
 	// Bootstrap config

--- a/cmd/flux/bootstrap_gitlab.go
+++ b/cmd/flux/bootstrap_gitlab.go
@@ -227,6 +227,7 @@ func bootstrapGitLabCmdRun(cmd *cobra.Command, args []string) error {
 		TargetPath:        gitlabArgs.path.String(),
 		ManifestFile:      sync.MakeDefaultOptions().ManifestFile,
 		GitImplementation: sourceGitArgs.gitImplementation.String(),
+		RecurseSubmodules: bootstrapArgs.recurseSubmodules,
 	}
 
 	// Bootstrap config

--- a/cmd/flux/create_source_git.go
+++ b/cmd/flux/create_source_git.go
@@ -125,7 +125,8 @@ func init() {
 	createSourceGitCmd.Flags().Var(&sourceGitArgs.gitImplementation, "git-implementation", sourceGitArgs.gitImplementation.Description())
 	createSourceGitCmd.Flags().StringVar(&sourceGitArgs.caFile, "ca-file", "", "path to TLS CA file used for validating self-signed certificates")
 	createSourceGitCmd.Flags().StringVar(&sourceGitArgs.privateKeyFile, "private-key-file", "", "path to a passwordless private key file used for authenticating to the Git SSH server")
-	createSourceGitCmd.Flags().BoolVar(&sourceGitArgs.recurseSubmodules, "recurse-submodules", false, "when enabled, after the clone is created, initializes all Git submodules within")
+	createSourceGitCmd.Flags().BoolVar(&sourceGitArgs.recurseSubmodules, "recurse-submodules", false,
+		"when enabled, configures the GitRepository source to initialize and include Git submodules in the artifact it produces")
 
 	createSourceCmd.AddCommand(createSourceGitCmd)
 }

--- a/docs/cmd/flux_bootstrap.md
+++ b/docs/cmd/flux_bootstrap.md
@@ -14,7 +14,7 @@ The bootstrap sub-commands bootstrap the toolkit components on the targeted Git 
 ```
       --author-email string                    author email for Git commits
       --author-name string                     author name for Git commits (default "Flux")
-      --branch string                          default branch (for GitHub this must match the default branch setting for the organization) (default "main")
+      --branch string                          Git branch (default "main")
       --ca-file string                         path to TLS CA file used for validating self-signed certificates
       --cluster-domain string                  internal cluster domain (default "cluster.local")
       --commit-message-appendix string         string to add to the commit messages, e.g. '[ci skip]'
@@ -25,6 +25,7 @@ The bootstrap sub-commands bootstrap the toolkit components on the targeted Git 
       --log-level logLevel                     log level, available options are: (debug, info, error) (default info)
       --network-policy                         deny ingress access to the toolkit controllers from other namespaces using network policies (default true)
       --private-key-file string                path to a private key file used for authenticating to the Git SSH server
+      --recurse-submodules                     when enabled, configures the GitRepository source to initialize and include Git submodules in the artifact it produces
       --registry string                        container registry where the toolkit images are published (default "ghcr.io/fluxcd")
       --secret-name string                     name of the secret the sync credentials can be found in or stored to (default "flux-system")
       --ssh-ecdsa-curve ecdsaCurve             SSH ECDSA public key curve (p256, p384, p521) (default p384)

--- a/docs/cmd/flux_bootstrap_git.md
+++ b/docs/cmd/flux_bootstrap_git.md
@@ -46,7 +46,7 @@ flux bootstrap git [flags]
 ```
       --author-email string                    author email for Git commits
       --author-name string                     author name for Git commits (default "Flux")
-      --branch string                          default branch (for GitHub this must match the default branch setting for the organization) (default "main")
+      --branch string                          Git branch (default "main")
       --ca-file string                         path to TLS CA file used for validating self-signed certificates
       --cluster-domain string                  internal cluster domain (default "cluster.local")
       --commit-message-appendix string         string to add to the commit messages, e.g. '[ci skip]'
@@ -59,6 +59,7 @@ flux bootstrap git [flags]
   -n, --namespace string                       the namespace scope for this operation (default "flux-system")
       --network-policy                         deny ingress access to the toolkit controllers from other namespaces using network policies (default true)
       --private-key-file string                path to a private key file used for authenticating to the Git SSH server
+      --recurse-submodules                     when enabled, configures the GitRepository source to initialize and include Git submodules in the artifact it produces
       --registry string                        container registry where the toolkit images are published (default "ghcr.io/fluxcd")
       --secret-name string                     name of the secret the sync credentials can be found in or stored to (default "flux-system")
       --ssh-ecdsa-curve ecdsaCurve             SSH ECDSA public key curve (p256, p384, p521) (default p384)

--- a/docs/cmd/flux_bootstrap_github.md
+++ b/docs/cmd/flux_bootstrap_github.md
@@ -65,7 +65,7 @@ flux bootstrap github [flags]
 ```
       --author-email string                    author email for Git commits
       --author-name string                     author name for Git commits (default "Flux")
-      --branch string                          default branch (for GitHub this must match the default branch setting for the organization) (default "main")
+      --branch string                          Git branch (default "main")
       --ca-file string                         path to TLS CA file used for validating self-signed certificates
       --cluster-domain string                  internal cluster domain (default "cluster.local")
       --commit-message-appendix string         string to add to the commit messages, e.g. '[ci skip]'
@@ -78,6 +78,7 @@ flux bootstrap github [flags]
   -n, --namespace string                       the namespace scope for this operation (default "flux-system")
       --network-policy                         deny ingress access to the toolkit controllers from other namespaces using network policies (default true)
       --private-key-file string                path to a private key file used for authenticating to the Git SSH server
+      --recurse-submodules                     when enabled, configures the GitRepository source to initialize and include Git submodules in the artifact it produces
       --registry string                        container registry where the toolkit images are published (default "ghcr.io/fluxcd")
       --secret-name string                     name of the secret the sync credentials can be found in or stored to (default "flux-system")
       --ssh-ecdsa-curve ecdsaCurve             SSH ECDSA public key curve (p256, p384, p521) (default p384)

--- a/docs/cmd/flux_bootstrap_gitlab.md
+++ b/docs/cmd/flux_bootstrap_gitlab.md
@@ -62,7 +62,7 @@ flux bootstrap gitlab [flags]
 ```
       --author-email string                    author email for Git commits
       --author-name string                     author name for Git commits (default "Flux")
-      --branch string                          default branch (for GitHub this must match the default branch setting for the organization) (default "main")
+      --branch string                          Git branch (default "main")
       --ca-file string                         path to TLS CA file used for validating self-signed certificates
       --cluster-domain string                  internal cluster domain (default "cluster.local")
       --commit-message-appendix string         string to add to the commit messages, e.g. '[ci skip]'
@@ -75,6 +75,7 @@ flux bootstrap gitlab [flags]
   -n, --namespace string                       the namespace scope for this operation (default "flux-system")
       --network-policy                         deny ingress access to the toolkit controllers from other namespaces using network policies (default true)
       --private-key-file string                path to a private key file used for authenticating to the Git SSH server
+      --recurse-submodules                     when enabled, configures the GitRepository source to initialize and include Git submodules in the artifact it produces
       --registry string                        container registry where the toolkit images are published (default "ghcr.io/fluxcd")
       --secret-name string                     name of the secret the sync credentials can be found in or stored to (default "flux-system")
       --ssh-ecdsa-curve ecdsaCurve             SSH ECDSA public key curve (p256, p384, p521) (default p384)

--- a/docs/cmd/flux_create_source_git.md
+++ b/docs/cmd/flux_create_source_git.md
@@ -65,7 +65,7 @@ flux create source git [name] [flags]
 
 ```
       --branch string                          git branch (default "master")
-      --ca-file string                         path to TLS CA file used for validating self-signed certificates, requires libgit2
+      --ca-file string                         path to TLS CA file used for validating self-signed certificates
       --git-implementation gitImplementation   the Git implementation to use, available options are: (go-git, libgit2)
   -h, --help                                   help for git
   -p, --password string                        basic authentication password

--- a/docs/cmd/flux_create_source_git.md
+++ b/docs/cmd/flux_create_source_git.md
@@ -70,6 +70,7 @@ flux create source git [name] [flags]
   -h, --help                                   help for git
   -p, --password string                        basic authentication password
       --private-key-file string                path to a passwordless private key file used for authenticating to the Git SSH server
+      --recurse-submodules                     when enabled, after the clone is created, initializes all Git submodules within
       --secret-ref string                      the name of an existing secret containing SSH or basic credentials
       --ssh-ecdsa-curve ecdsaCurve             SSH ECDSA public key curve (p256, p384, p521) (default p384)
       --ssh-key-algorithm publicKeyAlgorithm   SSH public key algorithm (rsa, ecdsa, ed25519) (default rsa)

--- a/docs/cmd/flux_create_source_git.md
+++ b/docs/cmd/flux_create_source_git.md
@@ -70,7 +70,7 @@ flux create source git [name] [flags]
   -h, --help                                   help for git
   -p, --password string                        basic authentication password
       --private-key-file string                path to a passwordless private key file used for authenticating to the Git SSH server
-      --recurse-submodules                     when enabled, after the clone is created, initializes all Git submodules within
+      --recurse-submodules                     when enabled, configures the GitRepository source to initialize and include Git submodules in the artifact it produces
       --secret-ref string                      the name of an existing secret containing SSH or basic credentials
       --ssh-ecdsa-curve ecdsaCurve             SSH ECDSA public key curve (p256, p384, p521) (default p384)
       --ssh-key-algorithm publicKeyAlgorithm   SSH public key algorithm (rsa, ecdsa, ed25519) (default rsa)

--- a/pkg/manifestgen/sync/options.go
+++ b/pkg/manifestgen/sync/options.go
@@ -30,6 +30,7 @@ type Options struct {
 	TargetPath        string
 	ManifestFile      string
 	GitImplementation string
+	RecurseSubmodules bool
 }
 
 func MakeDefaultOptions() Options {

--- a/pkg/manifestgen/sync/sync.go
+++ b/pkg/manifestgen/sync/sync.go
@@ -56,6 +56,7 @@ func Generate(options Options) (*manifestgen.Manifest, error) {
 				Name: options.Secret,
 			},
 			GitImplementation: options.GitImplementation,
+			RecurseSubmodules: options.RecurseSubmodules,
 		},
 	}
 


### PR DESCRIPTION
Changes to `flux create source git` command:
- Add `--recurse-submodules` boolean arg 
- Allow recurse submodules only when `--git-implementation=go-git`
- Allow self-signed certs for both `go-git` and `libgit2`

Changes to `flux bootstrap` commands:
- Add `--recurse-submodules` boolean arg 