### PR TITLE
fix: install command flags logic bug

### DIFF
--- a/cmd/flux/install.go
+++ b/cmd/flux/install.go
@@ -176,15 +176,15 @@ func installCmdRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("install failed: %w", err)
 	}
 
-	if rootArgs.verbose {
-		fmt.Print(manifest.Content)
-	} else if installArgs.export {
+	if installArgs.export {
 		fmt.Println("---")
 		fmt.Println("# Flux version:", installArgs.version)
 		fmt.Println("# Components:", strings.Join(components, ","))
 		fmt.Print(manifest.Content)
 		fmt.Println("---")
 		return nil
+	} else if rootArgs.verbose {
+		fmt.Print(manifest.Content)
 	}
 
 	logger.Successf("manifests build completed")


### PR DESCRIPTION
Resolves https://github.com/fluxcd/flux2/issues/1204

If the `export` flag exists, print the generated manifest and return from the function; it should prevent any additional steps from being run. 
If the `verbose` flag exists, then print the generated manifest and continue with the function. 