### PR TITLE
Normalize paths to forward slashes

### DIFF
--- a/cmd/flux/bootstrap_git.go
+++ b/cmd/flux/bootstrap_git.go
@@ -134,7 +134,7 @@ func bootstrapGitCmdRun(cmd *cobra.Command, args []string) error {
 		NotificationController: rootArgs.defaults.NotificationController,
 		ManifestFile:           rootArgs.defaults.ManifestFile,
 		Timeout:                rootArgs.timeout,
-		TargetPath:             gitArgs.path.String(),
+		TargetPath:             gitArgs.path.ToSlash(),
 		ClusterDomain:          bootstrapArgs.clusterDomain,
 		TolerationKeys:         bootstrapArgs.tolerationKeys,
 	}

--- a/cmd/flux/bootstrap_github.go
+++ b/cmd/flux/bootstrap_github.go
@@ -168,7 +168,7 @@ func bootstrapGitHubCmdRun(cmd *cobra.Command, args []string) error {
 		NotificationController: rootArgs.defaults.NotificationController,
 		ManifestFile:           rootArgs.defaults.ManifestFile,
 		Timeout:                rootArgs.timeout,
-		TargetPath:             githubArgs.path.String(),
+		TargetPath:             githubArgs.path.ToSlash(),
 		ClusterDomain:          bootstrapArgs.clusterDomain,
 		TolerationKeys:         bootstrapArgs.tolerationKeys,
 	}
@@ -180,7 +180,7 @@ func bootstrapGitHubCmdRun(cmd *cobra.Command, args []string) error {
 	secretOpts := sourcesecret.Options{
 		Name:         bootstrapArgs.secretName,
 		Namespace:    rootArgs.namespace,
-		TargetPath:   githubArgs.path.String(),
+		TargetPath:   githubArgs.path.ToSlash(),
 		ManifestFile: sourcesecret.MakeDefaultOptions().ManifestFile,
 	}
 	if bootstrapArgs.tokenAuth {
@@ -208,7 +208,7 @@ func bootstrapGitHubCmdRun(cmd *cobra.Command, args []string) error {
 		Namespace:         rootArgs.namespace,
 		Branch:            bootstrapArgs.branch,
 		Secret:            bootstrapArgs.secretName,
-		TargetPath:        githubArgs.path.String(),
+		TargetPath:        githubArgs.path.ToSlash(),
 		ManifestFile:      sync.MakeDefaultOptions().ManifestFile,
 		GitImplementation: sourceGitArgs.gitImplementation.String(),
 		RecurseSubmodules: bootstrapArgs.recurseSubmodules,

--- a/cmd/flux/bootstrap_gitlab.go
+++ b/cmd/flux/bootstrap_gitlab.go
@@ -181,7 +181,7 @@ func bootstrapGitLabCmdRun(cmd *cobra.Command, args []string) error {
 		NotificationController: rootArgs.defaults.NotificationController,
 		ManifestFile:           rootArgs.defaults.ManifestFile,
 		Timeout:                rootArgs.timeout,
-		TargetPath:             gitlabArgs.path.String(),
+		TargetPath:             gitlabArgs.path.ToSlash(),
 		ClusterDomain:          bootstrapArgs.clusterDomain,
 		TolerationKeys:         bootstrapArgs.tolerationKeys,
 	}
@@ -224,7 +224,7 @@ func bootstrapGitLabCmdRun(cmd *cobra.Command, args []string) error {
 		Namespace:         rootArgs.namespace,
 		Branch:            bootstrapArgs.branch,
 		Secret:            bootstrapArgs.secretName,
-		TargetPath:        gitlabArgs.path.String(),
+		TargetPath:        gitlabArgs.path.ToSlash(),
 		ManifestFile:      sync.MakeDefaultOptions().ManifestFile,
 		GitImplementation: sourceGitArgs.gitImplementation.String(),
 		RecurseSubmodules: bootstrapArgs.recurseSubmodules,

--- a/cmd/flux/create_kustomization.go
+++ b/cmd/flux/create_kustomization.go
@@ -19,7 +19,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -151,7 +150,7 @@ func createKsCmdRun(cmd *cobra.Command, args []string) error {
 			Interval: metav1.Duration{
 				Duration: createArgs.interval,
 			},
-			Path:  filepath.ToSlash(kustomizationArgs.path.String()),
+			Path:  kustomizationArgs.path.ToSlash(),
 			Prune: kustomizationArgs.prune,
 			SourceRef: kustomizev1.CrossNamespaceSourceReference{
 				Kind:      kustomizationArgs.source.Kind,

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -160,6 +160,11 @@ func kustomizationReconciled(ctx context.Context, kube client.Client, objKey cli
 			return false, err
 		}
 
+		// Detect suspended Kustomization, as this would result in an endless wait
+		if kustomization.Spec.Suspend {
+			return false, fmt.Errorf("Kustomization is suspended")
+		}
+
 		// Confirm the state we are observing is for the current generation
 		if kustomization.Generation != kustomization.Status.ObservedGeneration {
 			return false, nil

--- a/internal/flags/safe_relative_path.go
+++ b/internal/flags/safe_relative_path.go
@@ -18,6 +18,7 @@ package flags
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	securejoin "github.com/cyphar/filepath-securejoin"
@@ -27,6 +28,10 @@ type SafeRelativePath string
 
 func (p *SafeRelativePath) String() string {
 	return string(*p)
+}
+
+func (p *SafeRelativePath) ToSlash() string {
+	return filepath.ToSlash(p.String())
 }
 
 func (p *SafeRelativePath) Set(str string) error {


### PR DESCRIPTION
Fixes #1235

```console
C:\Users\IEUser>flux bootstrap github --owner=hiddeco --repository=staple.huge.horse --personal --path=clusters/cozy
► connecting to github.com
► cloning branch "main" from Git repository "https://github.com/hiddeco/staple.huge.horse.git"
✔ cloned repository
► generating component manifests
✔ generated component manifests
✔ component manifests are up to date
✔ reconciled components
► determining if source secret "flux-system/flux-system" exists
✔ source secret up to date
► generating sync manifests
✔ generated sync manifests
✔ sync manifests are up to date
► applying sync manifests
✔ applied sync manifests
✔ reconciled sync configuration
► confirming components are healthy
✔ helm-controller: deployment ready
✔ notification-controller: deployment ready
✔ source-controller: deployment ready
✔ kustomize-controller: deployment ready
✔ all components are healthy
```