### PR TITLE
Publish OpenAPI schemas for Flux CRDs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,6 +53,17 @@ jobs:
           make cmd/flux/manifests
           ./manifests/scripts/bundle.sh "" ./output manifests.tar.gz
           kustomize build ./manifests/install > ./output/install.yaml
+      - name: Build CRDs
+        run: |
+          kustomize build manifests/crds > all-crds.yaml
+      - name: Generate OpenAPI JSON schemas from CRDs
+        uses: fluxcd/pkg//actions/crdjsonschema@main
+        with:
+          crd: all-crds.yaml
+          output: schemas
+      - name: Archive the OpenAPI JSON schemas
+        run: |
+          tar -czvf ./output/crd-schemas.tar.gz -C schemas .
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -72,6 +72,7 @@ publishers:
       .github/aur/flux-go/publish.sh {{ .Version }}
 release:
   extra_files:
+    - glob: ./output/crd-schemas.tar.gz
     - glob: ./output/manifests.tar.gz
     - glob: ./output/install.yaml
 dockers:

--- a/manifests/crds/kustomization.yaml
+++ b/manifests/crds/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- https://github.com/fluxcd/kustomize-controller/releases/download/v0.11.0/kustomize-controller.crds.yaml
+- https://github.com/fluxcd/source-controller/releases/download/v0.11.0/source-controller.crds.yaml
+- https://github.com/fluxcd/helm-controller/releases/download/v0.9.0/helm-controller.crds.yaml
+- https://github.com/fluxcd/notification-controller/releases/download/v0.12.0/notification-controller.crds.yaml
+- https://github.com/fluxcd/image-reflector-controller/releases/download/v0.8.0/image-reflector-controller.crds.yaml
+- https://github.com/fluxcd/image-automation-controller/releases/download/v0.8.0/image-automation-controller.crds.yaml


### PR DESCRIPTION
This PR generates OpenAPI schemas for all the GitOps Toolkit CRDs and adds the `crd-schemas.tar.gz` file to the release assets.

Ref: https://github.com/fluxcd/flux2/discussions/408