### PR TITLE
Put potentially destructive reconcile behind flag

### DIFF
--- a/cmd/flux/bootstrap_github.go
+++ b/cmd/flux/bootstrap_github.go
@@ -80,6 +80,7 @@ type githubFlags struct {
 	path         flags.SafeRelativePath
 	teams        []string
 	readWriteKey bool
+	reconcile    bool
 }
 
 const (
@@ -100,6 +101,7 @@ func init() {
 	bootstrapGitHubCmd.Flags().StringVar(&githubArgs.hostname, "hostname", ghDefaultDomain, "GitHub hostname")
 	bootstrapGitHubCmd.Flags().Var(&githubArgs.path, "path", "path relative to the repository root, when specified the cluster sync will be scoped to this path")
 	bootstrapGitHubCmd.Flags().BoolVar(&githubArgs.readWriteKey, "read-write-key", false, "if true, the deploy key is configured with read/write permissions")
+	bootstrapGitHubCmd.Flags().BoolVar(&githubArgs.reconcile, "reconcile", false, "if true, the configured options are also reconciled if the repository already exists")
 
 	bootstrapCmd.AddCommand(bootstrapGitHubCmd)
 }
@@ -234,6 +236,9 @@ func bootstrapGitHubCmdRun(cmd *cobra.Command, args []string) error {
 	}
 	if !githubArgs.private {
 		bootstrapOpts = append(bootstrapOpts, bootstrap.WithProviderRepositoryConfig("", "", "public"))
+	}
+	if githubArgs.reconcile {
+		bootstrapOpts = append(bootstrapOpts, bootstrap.WithReconcile())
 	}
 
 	// Setup bootstrapper with constructed configs

--- a/cmd/flux/bootstrap_gitlab.go
+++ b/cmd/flux/bootstrap_gitlab.go
@@ -86,6 +86,7 @@ type gitlabFlags struct {
 	path         flags.SafeRelativePath
 	teams        []string
 	readWriteKey bool
+	reconcile    bool
 }
 
 var gitlabArgs gitlabFlags
@@ -100,6 +101,7 @@ func init() {
 	bootstrapGitLabCmd.Flags().StringVar(&gitlabArgs.hostname, "hostname", glDefaultDomain, "GitLab hostname")
 	bootstrapGitLabCmd.Flags().Var(&gitlabArgs.path, "path", "path relative to the repository root, when specified the cluster sync will be scoped to this path")
 	bootstrapGitLabCmd.Flags().BoolVar(&gitlabArgs.readWriteKey, "read-write-key", false, "if true, the deploy key is configured with read/write permissions")
+	bootstrapGitLabCmd.Flags().BoolVar(&gitlabArgs.reconcile, "reconcile", false, "if true, the configured options are also reconciled if the repository already exists")
 
 	bootstrapCmd.AddCommand(bootstrapGitLabCmd)
 }
@@ -250,6 +252,9 @@ func bootstrapGitLabCmdRun(cmd *cobra.Command, args []string) error {
 	}
 	if !gitlabArgs.private {
 		bootstrapOpts = append(bootstrapOpts, bootstrap.WithProviderRepositoryConfig("", "", "public"))
+	}
+	if gitlabArgs.reconcile {
+		bootstrapOpts = append(bootstrapOpts, bootstrap.WithReconcile())
 	}
 
 	// Setup bootstrapper with constructed configs

--- a/docs/cmd/flux_bootstrap_github.md
+++ b/docs/cmd/flux_bootstrap_github.md
@@ -56,6 +56,7 @@ flux bootstrap github [flags]
       --personal                if true, the owner is assumed to be a GitHub user; otherwise an org
       --private                 if true, the repository is setup or configured as private (default true)
       --read-write-key          if true, the deploy key is configured with read/write permissions
+      --reconcile               if true, the configured options are also reconciled if the repository already exists
       --repository string       GitHub repository name
       --team stringArray        GitHub team to be given maintainer access
 ```

--- a/docs/cmd/flux_bootstrap_gitlab.md
+++ b/docs/cmd/flux_bootstrap_gitlab.md
@@ -53,6 +53,7 @@ flux bootstrap gitlab [flags]
       --personal                if true, the owner is assumed to be a GitLab user; otherwise a group
       --private                 if true, the repository is setup or configured as private (default true)
       --read-write-key          if true, the deploy key is configured with read/write permissions
+      --reconcile               if true, the configured options are also reconciled if the repository already exists
       --repository string       GitLab repository name
       --team stringArray        GitLab teams to be given maintainer access
 ```


### PR DESCRIPTION
The behavior introduced during the introduction of go-git-providers
was more strict, and has proven pretty quickly to not be useful to
all users. Therefore, the reconciliation behavior for repository
configuration has been put behind an opt-in flag, so that it does
not overwrite people their configs by accident.
