### PR TITLE
Change createAlertCmdRun parsing to include namespace

### DIFF
--- a/cmd/flux/create_alert.go
+++ b/cmd/flux/create_alert.go
@@ -74,14 +74,15 @@ func createAlertCmdRun(cmd *cobra.Command, args []string) error {
 
 	eventSources := []notificationv1.CrossNamespaceObjectReference{}
 	for _, eventSource := range alertArgs.eventSources {
-		kind, name := utils.ParseObjectKindName(eventSource)
+		kind, name, namespace := utils.ParseObjectKindNameNamespace(eventSource)
 		if kind == "" {
 			return fmt.Errorf("invalid event source '%s', must be in format <kind>/<name>", eventSource)
 		}
 
 		eventSources = append(eventSources, notificationv1.CrossNamespaceObjectReference{
-			Kind: kind,
-			Name: name,
+			Kind:      kind,
+			Name:      name,
+			Namespace: namespace,
 		})
 	}
 


### PR DESCRIPTION
Previously I couldn't create the following yaml in the docs using the flux cli

https://github.com/fluxcd/flux2/blob/65d5cadf293663662a756cbbb34d2739508045ab/docs/guides/notifications.md#L209-L221 

Running the create alert command with the appropriate kind/name.namespace resulted in name: <name>.<namespace>

``` bash
$ flux create alert podinfo \ 
--provider-ref flux-system \
--event-severity info \
--event-source Kustomization/podinfo.flux-system \
--namespace flux-system \
--export
---
apiVersion: notification.toolkit.fluxcd.io/v1beta1
kind: Alert
metadata:
  name: podinfo
  namespace: flux-system
spec:
  eventSeverity: info
  eventSources:
  - kind: Kustomization
    name: podinfo.flux-system
  providerRef:
    name: flux-system
```

This fix changes it so the output of the command, matches what
s in the docs, and the alert api spec.

Signed-off-by: Alison Dowdney <alison@alisondowdney.com>