### PR TITLE
Keep network policy order as defined

### DIFF
--- a/manifests/policies/allow-egress.yaml
+++ b/manifests/policies/allow-egress.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: deny-ingress
+  name: allow-egress
 spec:
   policyTypes:
     - Ingress

--- a/manifests/policies/kustomization.yaml
+++ b/manifests/policies/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - deny-ingress.yaml
+  - allow-egress.yaml
   - allow-scraping.yaml
   - allow-webhooks.yaml


### PR DESCRIPTION
Kustomize by default reorders resources in "legacy" mode. This is harmful for the network policies, as the order of how they are defined in yaml (and applied) matters. At least for Azure Network policy. Different order leads to different resulting iptables.

This is a simple fix to suppress the default Kustomize reordering for network policies while building the manifests.

Fixes #703 