### PR TITLE
Ensure kustomization/helmrelease is reconciled when source is in a different namespace

### DIFF
--- a/cmd/flux/reconcile_helmrelease.go
+++ b/cmd/flux/reconcile_helmrelease.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/types"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
@@ -60,7 +61,7 @@ func (obj helmReleaseAdapter) reconcileSource() bool {
 	return rhrArgs.syncHrWithSource
 }
 
-func (obj helmReleaseAdapter) getSource() (reconcileCommand, string) {
+func (obj helmReleaseAdapter) getSource() (reconcileCommand, types.NamespacedName) {
 	var cmd reconcileCommand
 	switch obj.Spec.Chart.Spec.SourceRef.Kind {
 	case sourcev1.HelmRepositoryKind:
@@ -80,5 +81,8 @@ func (obj helmReleaseAdapter) getSource() (reconcileCommand, string) {
 		}
 	}
 
-	return cmd, obj.Spec.Chart.Spec.SourceRef.Name
+	return cmd, types.NamespacedName{
+		Name:      obj.Spec.Chart.Spec.SourceRef.Name,
+		Namespace: obj.Spec.Chart.Spec.SourceRef.Namespace,
+	}
 }

--- a/cmd/flux/reconcile_kustomization.go
+++ b/cmd/flux/reconcile_kustomization.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/types"
 
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta1"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
@@ -60,7 +61,7 @@ func (obj kustomizationAdapter) reconcileSource() bool {
 	return rksArgs.syncKsWithSource
 }
 
-func (obj kustomizationAdapter) getSource() (reconcileCommand, string) {
+func (obj kustomizationAdapter) getSource() (reconcileCommand, types.NamespacedName) {
 	var cmd reconcileCommand
 	switch obj.Spec.SourceRef.Kind {
 	case sourcev1.GitRepositoryKind:
@@ -75,5 +76,8 @@ func (obj kustomizationAdapter) getSource() (reconcileCommand, string) {
 		}
 	}
 
-	return cmd, obj.Spec.SourceRef.Name
+	return cmd, types.NamespacedName{
+		Name:      obj.Spec.SourceRef.Name,
+		Namespace: obj.Spec.SourceRef.Namespace,
+	}
 }

--- a/cmd/flux/reconcile_with_source.go
+++ b/cmd/flux/reconcile_with_source.go
@@ -18,7 +18,7 @@ type reconcileWithSource interface {
 	adapter
 	reconcilable
 	reconcileSource() bool
-	getSource() (reconcileCommand, string)
+	getSource() (reconcileCommand, types.NamespacedName)
 }
 
 type reconcileWithSourceCommand struct {
@@ -55,14 +55,13 @@ func (reconcile reconcileWithSourceCommand) run(cmd *cobra.Command, args []strin
 	}
 
 	if reconcile.object.reconcileSource() {
+		reconcileCmd, nsName := reconcile.object.getSource()
 		nsCopy := rootArgs.namespace
-		objectNs := reconcile.object.asClientObject().GetNamespace()
-		if objectNs != "" {
-			rootArgs.namespace = reconcile.object.asClientObject().GetNamespace()
+		if nsName.Namespace != "" {
+			rootArgs.namespace = nsName.Namespace
 		}
 
-		reconcileCmd, sourceName := reconcile.object.getSource()
-		err := reconcileCmd.run(nil, []string{sourceName})
+		err := reconcileCmd.run(nil, []string{nsName.Name})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes #1283

I tested these changes and I confirm that I fixed the regression bug introduced in #1224 that prevented users from reconciling a Kustomization or helmrelease when the source is in a different namespace.

Signed-off-by: Somtochi Onyekwere <somtochionyekwere@gmail.com>