### PR TITLE
Fix ownership issue in bash install script

### DIFF
--- a/install/flux.sh
+++ b/install/flux.sh
@@ -207,7 +207,7 @@ verify_binary() {
 setup_binary() {
     chmod 755 "${TMP_BIN}"
     info "Installing flux to ${BIN_DIR}/flux"
-    tar -xzf "${TMP_BIN}" -C "${TMP_DIR}"
+    tar -xzof "${TMP_BIN}" -C "${TMP_DIR}"
 
     local CMD_MOVE="mv -f \"${TMP_DIR}/flux\" \"${BIN_DIR}\""
     if [[ -w "${BIN_DIR}" ]]; then


### PR DESCRIPTION
When using tar with sudo the extracted files will retain the ownership
of the files in the archive. When using the bash install script the flux
binary is owned by user ID 1001 and group docker after installation.

This commit fixes the ownership by appending the -o option to the tar
command which will extract files with the correct ownership, namely user
root and group root.

Signed-off-by: Julian Lengelsen <julian.lengelsen@th-koeln.de>