### PR TITLE
Add `ValuesFiles` documentation

### DIFF
--- a/cmd/flux/create_helmrelease.go
+++ b/cmd/flux/create_helmrelease.go
@@ -113,7 +113,7 @@ type helmReleaseFlags struct {
 	chart           string
 	chartVersion    string
 	targetNamespace string
-	valuesFile      []string
+	valuesFiles     []string
 	valuesFrom      flags.HelmReleaseValuesFrom
 	saName          string
 }
@@ -128,7 +128,7 @@ func init() {
 	createHelmReleaseCmd.Flags().StringArrayVar(&helmReleaseArgs.dependsOn, "depends-on", nil, "HelmReleases that must be ready before this release can be installed, supported formats '<name>' and '<namespace>/<name>'")
 	createHelmReleaseCmd.Flags().StringVar(&helmReleaseArgs.targetNamespace, "target-namespace", "", "namespace to install this release, defaults to the HelmRelease namespace")
 	createHelmReleaseCmd.Flags().StringVar(&helmReleaseArgs.saName, "service-account", "", "the name of the service account to impersonate when reconciling this HelmRelease")
-	createHelmReleaseCmd.Flags().StringArrayVar(&helmReleaseArgs.valuesFile, "values", nil, "local path to values.yaml files")
+	createHelmReleaseCmd.Flags().StringArrayVar(&helmReleaseArgs.valuesFiles, "values", nil, "local path to values.yaml files")
 	createHelmReleaseCmd.Flags().Var(&helmReleaseArgs.valuesFrom, "values-from", helmReleaseArgs.valuesFrom.Description())
 	createCmd.AddCommand(createHelmReleaseCmd)
 }
@@ -184,9 +184,9 @@ func createHelmReleaseCmdRun(cmd *cobra.Command, args []string) error {
 		helmRelease.Spec.ServiceAccountName = helmReleaseArgs.saName
 	}
 
-	if len(helmReleaseArgs.valuesFile) > 0 {
-		var valuesMap map[string]interface{}
-		for _, v := range helmReleaseArgs.valuesFile {
+	if len(helmReleaseArgs.valuesFiles) > 0 {
+		valuesMap := make(map[string]interface{})
+		for _, v := range helmReleaseArgs.valuesFiles {
 			data, err := ioutil.ReadFile(v)
 			if err != nil {
 				return fmt.Errorf("reading values from %s failed: %w", v, err)
@@ -202,11 +202,7 @@ func createHelmReleaseCmdRun(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("unmarshaling values from %s failed: %w", v, err)
 			}
 
-			if valuesMap == nil {
-				valuesMap = jsonMap
-			} else {
-				valuesMap = transform.MergeMaps(valuesMap, jsonMap)
-			}
+			valuesMap = transform.MergeMaps(valuesMap, jsonMap)
 		}
 
 		jsonRaw, err := json.Marshal(valuesMap)

--- a/docs/guides/helm-operator-migration.md
+++ b/docs/guides/helm-operator-migration.md
@@ -58,7 +58,7 @@ Support for values references to `ConfigMap` and `Secret` resources in other nam
 
 We initially introduced this feature to support alternative (production focused) `values.yaml` files that sometimes come with charts. It was also used by users to use generic and/or dynamic `values.yaml` files in their `HelmRelease` resources.
 
-The former can now be achieved by defining a [`ValuesFile` overwrite in the `HelmChartTemplateSpec`](#chart-file-references), which will make the Source Controller look for the referenced file in the chart, and overwrite the default values with the contents from that file.
+The former can now be achieved by defining a [`ValuesFiles` overwrite in the `HelmChartTemplateSpec`](#chart-file-references), which will make the Source Controller look for the referenced file in the chart, and overwrite the default values with the contents from that file.
 
 Support for the latter use has been dropped, as it goes against the principles of GitOps and declarative configuration. You can not reliably restore the cluster state from a Git repository if the configuration of a service relies on some URL being available.
 
@@ -457,13 +457,15 @@ spec:
       version: 1.2.3
       # Alternative values file to use as the default values,
       # expected to be a relative path in the sourceRef
-      valuesFile: values-prod.yaml
+      valuesFiles:
+       - values.yaml
+       - values-prod.yaml
       sourceRef:
         kind: HelmRepository
         name: my-repository
 ```
 
-When the `valuesFile` is defined, the chart will be (re)packaged with the values from the referenced file as the default values. Note that this behavior is different from the Helm Operator and requires a full set of alternative values, as the referenced values are no longer merged with the default values.
+When `valuesFiles` is defined, the chart will be (re)packaged with the values from the referenced files as the default values, merged in the order they appear. Note that this behavior is different from the Helm Operator as the default values (values.yaml) are not merged by default and must be explicitly added to the list.
 
 ##### External source references
 

--- a/docs/guides/helmreleases.md
+++ b/docs/guides/helmreleases.md
@@ -9,7 +9,7 @@ The helm-controller is part of the default toolkit installation.
 
 ## Prerequisites
 
-To follow this guide you'll need a Kubernetes cluster with the GitOps 
+To follow this guide you'll need a Kubernetes cluster with the GitOps
 toolkit controllers installed on it.
 Please see the [get started guide](../get-started/index.md)
 or the [installation guide](installation.md).
@@ -54,7 +54,7 @@ The `url` can be any HTTP/S Helm repository URL.
     HTTP/S basic and TLS authentication can be configured for private
     Helm repositories. See the [`HelmRepository` CRD docs](../components/source/helmrepositories.md)
     for more details.
-    
+
 ### Git repository
 
 Charts from Git repositories can be released by declaring a
@@ -68,7 +68,7 @@ later on in the guide).
 **There is one caveat you should be aware of:** to make the
 source-controller produce a new chart artifact, the `version` in the
 `Chart.yaml` of the chart must be bumped.
-  
+
 An example `GitRepository`:
 
 ```yaml
@@ -378,12 +378,14 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: bitnami
-      valuesFile: values-production.yaml
+      valuesFiles:
+        - values.yaml
+        - values-production.yaml
   values:
     replicaCount: 5
 ```
 
-If the `spec.chart.spec.valuesFile` doesn't exists inside the chart, helm-controller will not be able to
+If the `spec.chart.spec.valuesFiles` doesn't exists inside the chart, helm-controller will not be able to
 fetch the chart. To determine why the `HelmChart` fails to produce an artifact, you can inspect the status with:
 
 ```console
@@ -439,7 +441,7 @@ First generate a random string and create a secret with a `token` field:
 TOKEN=$(head -c 12 /dev/urandom | shasum | cut -d ' ' -f1)
 echo $TOKEN
 
-kubectl -n flux-system create secret generic webhook-token \	
+kubectl -n flux-system create secret generic webhook-token \
 --from-literal=token=$TOKEN
 ```
 


### PR DESCRIPTION
- Changes `valuesFile` documentation to `valuesFiles`
- Purposely did not reference `valuesFile` as we would like to move people towards the non-deprecated option
- Updates source-controller/api to latest main (matching changes in helm-controller, source-controller)
- Renames `valuesFile` var to `valuesFiles`

Continuation of https://github.com/fluxcd/source-controller/issues/291, https://github.com/fluxcd/source-controller/pull/305