### PR TITLE
Drop AutoInit from Org repository create

### DIFF
--- a/internal/bootstrap/bootstrap_provider.go
+++ b/internal/bootstrap/bootstrap_provider.go
@@ -280,11 +280,8 @@ func (b *GitProviderBootstrapper) reconcileOrgRepository(ctx context.Context) (g
 		}
 		// go-git-providers has at present some issues with the idempotency
 		// of the available Reconcile methods, and setting e.g. the default
-		// branch correctly. Resort to Create with AutoInit until this has
-		// been resolved.
-		repo, err = b.provider.OrgRepositories().Create(ctx, repoRef, repoInfo, &gitprovider.RepositoryCreateOptions{
-			AutoInit: gitprovider.BoolVar(true),
-		})
+		// branch correctly. Resort to Create until this has been resolved.
+		repo, err = b.provider.OrgRepositories().Create(ctx, repoRef, repoInfo)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create new Git repository %q: %w", repoRef.String(), err)
 		}
@@ -348,6 +345,7 @@ func (b *GitProviderBootstrapper) reconcileUserRepository(ctx context.Context) (
 	repoRef := newUserRepositoryRef(userRef, repoName)
 	repoInfo := newRepositoryInfo(b.description, b.defaultBranch, b.visibility)
 
+	// Reconcile the user repository
 	repo, err := b.provider.UserRepositories().Get(ctx, repoRef)
 	if err != nil {
 		if !errors.Is(err, gitprovider.ErrNotFound) {
@@ -355,9 +353,8 @@ func (b *GitProviderBootstrapper) reconcileUserRepository(ctx context.Context) (
 		}
 		// go-git-providers has at present some issues with the idempotency
 		// of the available Reconcile methods, and setting e.g. the default
-		// branch correctly. Resort to Create with AutoInit until this has
-		// been resolved.
-		repo, err = b.provider.UserRepositories().Create(ctx, repoRef, repoInfo, &gitprovider.RepositoryCreateOptions{})
+		// branch correctly. Resort to Create until this has been resolved.
+		repo, err = b.provider.UserRepositories().Create(ctx, repoRef, repoInfo)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create new Git repository %q: %w", repoRef.String(), err)
 		}


### PR DESCRIPTION
Pushing the first branch is sufficient to set a default, and
README.md (and/or LICENSE) can better be pushed elsewhere so commit
author and templates be configured.