### PR TITLE
Use slash target path in Git bootstrap sync opts

### DIFF
--- a/cmd/flux/bootstrap_git.go
+++ b/cmd/flux/bootstrap_git.go
@@ -189,7 +189,7 @@ func bootstrapGitCmdRun(cmd *cobra.Command, args []string) error {
 		URL:               repositoryURL.String(),
 		Branch:            bootstrapArgs.branch,
 		Secret:            bootstrapArgs.secretName,
-		TargetPath:        gitArgs.path.String(),
+		TargetPath:        gitArgs.path.ToSlash(),
 		ManifestFile:      sync.MakeDefaultOptions().ManifestFile,
 		GitImplementation: sourceGitArgs.gitImplementation.String(),
 		RecurseSubmodules: bootstrapArgs.recurseSubmodules,


### PR DESCRIPTION
As otherwise (comparisons to) cluster configuration will fail due to
Separator differences. Was already fixed for provider implementations.

Follow up on #1240
Fixes #1303 