### PR TITLE
Update the APIs docs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -57,12 +57,12 @@ jobs:
             # image-*-controller CRDs; these use the same API group
             IMG_REFL_VER=$(controller_version image-reflector-controller)
             curl -# -Lf "https://raw.githubusercontent.com/fluxcd/image-reflector-controller/$IMG_REFL_VER/docs/api/image-reflector.md" > docs/components/image/reflector-api.md
-            curl -# -Lf "https://raw.githubusercontent.com/fluxcd/image-reflector-controller/$IMG_REFL_VER/docs/spec/v1alpha1/imagerepositories.md" > docs/components/image/imagerepositories.md
-            curl -# -Lf "https://raw.githubusercontent.com/fluxcd/image-reflector-controller/$IMG_REFL_VER/docs/spec/v1alpha1/imagepolicies.md" > docs/components/image/imagepolicies.md
+            curl -# -Lf "https://raw.githubusercontent.com/fluxcd/image-reflector-controller/$IMG_REFL_VER/docs/spec/v1alpha2/imagerepositories.md" > docs/components/image/imagerepositories.md
+            curl -# -Lf "https://raw.githubusercontent.com/fluxcd/image-reflector-controller/$IMG_REFL_VER/docs/spec/v1alpha2/imagepolicies.md" > docs/components/image/imagepolicies.md
 
             IMG_AUTO_VER=$(controller_version image-automation-controller)
             curl -# -Lf "https://raw.githubusercontent.com/fluxcd/image-automation-controller/$IMG_AUTO_VER/docs/api/image-automation.md" > docs/components/image/automation-api.md
-            curl -# -Lf "https://raw.githubusercontent.com/fluxcd/image-automation-controller/$IMG_AUTO_VER/docs/spec/v1alpha1/imageupdateautomations.md" > docs/components/image/imageupdateautomations.md
+            curl -# -Lf "https://raw.githubusercontent.com/fluxcd/image-automation-controller/$IMG_AUTO_VER/docs/spec/v1alpha2/imageupdateautomations.md" > docs/components/image/imageupdateautomations.md
           }
 
           {

--- a/manifests/crds/kustomization.yaml
+++ b/manifests/crds/kustomization.yaml
@@ -1,8 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/fluxcd/kustomize-controller/releases/download/v0.11.1/kustomize-controller.crds.yaml
-- https://github.com/fluxcd/source-controller/releases/download/v0.12.0/source-controller.crds.yaml
+- https://github.com/fluxcd/source-controller/releases/download/v0.12.1/source-controller.crds.yaml
+- https://github.com/fluxcd/kustomize-controller/releases/download/v0.12.1/kustomize-controller.crds.yaml
 - https://github.com/fluxcd/helm-controller/releases/download/v0.10.0/helm-controller.crds.yaml
 - https://github.com/fluxcd/notification-controller/releases/download/v0.13.0/notification-controller.crds.yaml
 - https://github.com/fluxcd/image-reflector-controller/releases/download/v0.9.0/image-reflector-controller.crds.yaml


### PR DESCRIPTION
Changes:
- bump the CRD versions for the OpenAPI schema generation 
- switch the image automation docs to v1alpha2