### PR TITLE
Change permission grant error print conditons

### DIFF
--- a/internal/bootstrap/bootstrap_provider.go
+++ b/internal/bootstrap/bootstrap_provider.go
@@ -321,9 +321,8 @@ func (b *GitProviderBootstrapper) reconcileOrgRepository(ctx context.Context) (g
 			_, changed, err = repo.TeamAccess().Reconcile(ctx, i)
 			if err != nil {
 				warning = fmt.Errorf("failed to grant permissions to team: %w", ErrReconciledWithWarning)
-				b.logger.Failuref("failed to grant %q permissions to %q: %w", *i.Permission, i.Name, err)
-			}
-			if changed {
+				b.logger.Failuref("failed to grant %q permissions to %q: %s", *i.Permission, i.Name, err.Error())
+			} else if changed {
 				b.logger.Successf("granted %q permissions to %q", *i.Permission, i.Name)
 			}
 		}


### PR DESCRIPTION
Based on observations in
https://github.com/fluxcd/flux2/runs/2410633975:

1. Print error correctly by switching from `%w` to `%s`
2. Only print the change messsage if there has not been an error.
