### PR TITLE
Avoid throttling when some Flux CRDs are not registered

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -156,6 +156,10 @@ func KubeConfig(kubeConfigPath string, kubeContext string) (*rest.Config, error)
 		return nil, fmt.Errorf("kubernetes configuration load failed: %w", err)
 	}
 
+	// avoid throttling request when some Flux CRDs are not registered
+	cfg.QPS = 50
+	cfg.Burst = 100
+
 	return cfg, nil
 }
 


### PR DESCRIPTION
When running `flux get all` users that haven't installed the image automation will see:
```
I0426 13:38:52.372570    1374 request.go:655] Throttling request took 1.000968421s, request: GET:https://35.228.232.234/apis/helm.toolkit.fluxcd.io/v2beta1?timeout=32s
✗ no matches for kind "ImageRepository" in version "image.toolkit.fluxcd.io/v1alpha2"
```

This PR increases the client-side rate limits to avoid the above. fix: #1346