### PR TITLE
Remove redundant getCommand for image repository

### DIFF
--- a/cmd/flux/get_image_all.go
+++ b/cmd/flux/get_image_all.go
@@ -49,13 +49,6 @@ var getImageAllCmd = &cobra.Command{
 				list:    &imageUpdateAutomationListAdapter{&autov1.ImageUpdateAutomationList{}},
 			},
 		}
-		c := getCommand{
-			apiType: imageRepositoryType,
-			list:    imageRepositoryListAdapter{&imagev1.ImageRepositoryList{}},
-		}
-		if err := c.run(cmd, args); err != nil {
-			logger.Failuref(err.Error())
-		}
 
 		for _, c := range allImageCmd {
 			if err := c.run(cmd, args); err != nil {


### PR DESCRIPTION
Before this change, running `get all`:
```
NAME                    READY   MESSAGE                                                         REVISION                                        SUSPENDED 
helmrepository/podinfo  True    Fetched revision: 878b81372f19855d96af071ef089f91a6a323d3c      878b81372f19855d96af071ef089f91a6a323d3c        False           

NAME                            READY   MESSAGE                 REVISION        SUSPENDED 
helmchart/flux-system-podinfo   True    Fetched revision: 4.0.6 4.0.6           False           

✗ no matches for kind "ImageRepository" in version "image.toolkit.fluxcd.io/v1alpha2"
NAME                    READY   MESSAGE                                 REVISION        SUSPENDED 
helmrelease/podinfo     True    Release reconciliation succeeded        4.0.6           False
```

After this change:
```
NAME                    READY   MESSAGE                                                         REVISION                                        SUSPENDED 
helmrepository/podinfo  True    Fetched revision: 878b81372f19855d96af071ef089f91a6a323d3c      878b81372f19855d96af071ef089f91a6a323d3c        False           

NAME                            READY   MESSAGE                 REVISION        SUSPENDED 
helmchart/flux-system-podinfo   True    Fetched revision: 4.0.6 4.0.6           False           

NAME                    READY   MESSAGE                                 REVISION        SUSPENDED 
helmrelease/podinfo     True    Release reconciliation succeeded        4.0.6           False
```

Signed-off-by: Somtochi Onyekwere <somtochionyekwere@gmail.com>