### PR TITLE
Use Case Docs: Image automation Auto-PR with GitHub Actions

### DIFF
--- a/docs/guides/image-update.md
+++ b/docs/guides/image-update.md
@@ -408,7 +408,7 @@ spec:
 ```
 
 You can use CI automation e.g. GitHub Actions such as
-[create-pull-request](https://github.com/peter-evans/create-pull-request)
+Flux's [GitHub Actions Auto PR](/use-cases/gh-actions-auto-pr) example
 to open a pull request against the checkout branch.
 
 This way you can manually approve the image updates before they are applied on your clusters.

--- a/docs/use-cases/gh-actions-auto-pr.md
+++ b/docs/use-cases/gh-actions-auto-pr.md
@@ -2,7 +2,7 @@
 
 In the [Image Update Guide] we saw we can [Push updates to a different branch] by using `.spec.git.push.branch` to push image updates to a different branch than the one used for checkout.
 
-In this example, we configure an `ImageUpdateAutomation` resource to push to a `staging` branch, which we could set up separately as a preview environment to deploy automatic updates in a staging cluster or namespace.
+In this example, we configure an `ImageUpdateAutomation` resource to push to a `staging` branch, (which we could set up separately as a preview environment to deploy automatic updates in a staging cluster or namespace.)
 
 ```yaml
 kind: ImageUpdateAutomation
@@ -16,6 +16,8 @@ spec:
     push:
       branch: staging
 ```
+
+For this use case, we are only interested in showing that once the change is approved and merged, it gets deployed into production. The image automation is gated behind a pull request approval workflow, according to any policy you have in place for your repository.
 
 In your manifest repository, add a GitHub Action workflow as below. This workflow watches for commits on the `staging` branch and opens a pull request with any labels, title, or body that you configure.
 
@@ -45,9 +47,9 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-You can use the [github-pull-request-action] workflow to automatically open a pull request against a destination branch. In this case, when a pull request is merged into the main changes are deployed in production.
+You can use the [github-pull-request-action] workflow to automatically open a pull request against a destination branch. In this case, when `staging` is merged into the `main` branch, changes are deployed in production.
 
-This way you can manually approve automatic image updates before they are applied on your production clusters.
+This way you can automatically push changes to a `staging` branch and require manual approval of any automatic image updates before they are applied on your production clusters.
 
 [Image Update Guide]: /guides/image-update/
 [Push updates to a different branch]: /guides/image-update/#push-updates-to-a-different-branch

--- a/docs/use-cases/gh-actions-auto-pr.md
+++ b/docs/use-cases/gh-actions-auto-pr.md
@@ -1,8 +1,10 @@
 # GitHub Actions Auto PR
 
-In the [Image Update Guide] we saw we can [Push updates to a different branch] by using `.spec.git.push.branch` to push image updates to a different branch than the one used for checkout.
+This guide shows how to configure GitHub Actions to open a pull request whenever a selected branch is pushed.
 
-In this example, we configure an `ImageUpdateAutomation` resource to push to a `staging` branch, (which we could set up separately as a preview environment to deploy automatic updates in a staging cluster or namespace.)
+In the [Image Update Guide] we saw that Flux's automation can [Push updates to a different branch] by using `.spec.git.push.branch` to push automated image updates to a different branch than the one used for checkout.
+
+In this example, we configure an `ImageUpdateAutomation` resource to push to a `staging` branch, where we can imagine some policy dictates that updates must be staged and approved before they are deployed in production.
 
 ```yaml
 kind: ImageUpdateAutomation

--- a/docs/use-cases/gh-actions-auto-pr.md
+++ b/docs/use-cases/gh-actions-auto-pr.md
@@ -1,0 +1,54 @@
+# GitHub Actions Auto PR
+
+In the [Image Update Guide] we saw we can [Push updates to a different branch] by using `.spec.git.push.branch` to push image updates to a different branch than the one used for checkout.
+
+In this example, we configure an `ImageUpdateAutomation` resource to push to a `staging` branch, which we could set up separately as a preview environment to deploy automatic updates in a staging cluster or namespace.
+
+```yaml
+kind: ImageUpdateAutomation
+metadata:
+  name: flux-system
+spec:
+  git:
+    checkout:
+      ref:
+        branch: main
+    push:
+      branch: staging
+```
+
+In your manifest repository, add a GitHub Action workflow as below. This workflow watches for commits on the `staging` branch and opens a pull request with any labels, title, or body that you configure.
+
+```yaml
+# ./.github/workflows/staging-auto-pr.yaml
+name: Staging Auto-PR
+on:
+  push:
+    branches: ['staging']
+
+jobs:
+  pull-request:
+    name: Open PR to main
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      name: checkout
+
+    - uses: repo-sync/pull-request@v2
+      name: pull-request
+      with:
+        destination_branch: "main"
+        pr_title: "Pulling ${{ github.ref }} into main"
+        pr_body: ":crown: *An automated PR*"
+        pr_reviewer: "kingdonb"
+        pr_draft: true
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+You can use the [github-pull-request-action] workflow to automatically open a pull request against a destination branch. In this case, when a pull request is merged into the main changes are deployed in production.
+
+This way you can manually approve automatic image updates before they are applied on your production clusters.
+
+[Image Update Guide]: /guides/image-update/
+[Push updates to a different branch]: /guides/image-update/#push-updates-to-a-different-branch
+[github-pull-request-action]: https://github.com/marketplace/actions/github-pull-request-action

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
   - Use Cases:
       - Azure: use-cases/azure.md
       - GitHub Actions Manifest Generation: use-cases/gh-actions-manifest-generation.md
+      - GitHub Actions Auto Pull Request: use-cases/gh-actions-auto-pr.md
       - Helm: use-cases/helm.md
   - Toolkit Components:
     - Overview: components/index.md


### PR DESCRIPTION
The linked github actions workflow (from the original note in the Image Update guide) does not actually do what you need, I believe I have found a better one and effectively demonstrated how to use it in this example.

The "GitHub Actions Auto PR" use case could be expanded upon, but I think maybe this short version already says everything it needs to say!