### PR TITLE
add redirects file

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,17 @@
+# individual rules
+/core-concepts          https://fluxcd.io/docs/concepts                     301!
+/contributing           https://fluxcd.io/contributing                      301!
+
+# refer to https://github.com/fluxcd/flux2/discussions/367
+/dev-guides/*           https://fluxcd.io/docs/gitops-toolkit/:splat        301!
+
+
+# this is how things looked in the navbar anyway..?
+/guides/faq-migration                   https://fluxcd.io/docs/migration/faq-migration                  301!
+/guides/flux-v1-automation-migration    https://fluxcd.io/docs/migration/flux-v1-automation-migration   301!
+/guides/flux-v1-migration               https://fluxcd.io/docs/migration/flux-v1-migration              301!
+/guides/helm-operator-migration         https://fluxcd.io/docs/migration/helm-operator-migration        301!
+
+
+# catch all
+/*                      https://fluxcd.io/docs/:splat                       301!

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
-  command = "./copy-docs-assets.sh && mkdocs build"
+  command = "./copy-docs-assets.sh && mkdocs build && cp _redirects site/"
   publish = "site"


### PR DESCRIPTION
Add redirects from toolkit.fluxcd.io to fluxcd.io/docs - largely following https://github.com/fluxcd/flux2/discussions/367

One thing which was unfortunately overseen to date is:


User Guides | toolkit.fluxcd.io/guides | fluxcd.io/docs/flux
-- | -- | --
