### PR TITLE
Use proper Host configuration for SSH

### DIFF
--- a/cmd/flux/bootstrap_git.go
+++ b/cmd/flux/bootstrap_git.go
@@ -173,7 +173,6 @@ func bootstrapGitCmdRun(cmd *cobra.Command, args []string) error {
 		// Configure repository URL to match auth config for sync.
 		repositoryURL.User = url.User(gitArgs.username)
 		repositoryURL.Scheme = "ssh"
-		repositoryURL.Host = repositoryURL.Hostname()
 		if bootstrapArgs.sshHostname != "" {
 			repositoryURL.Host = bootstrapArgs.sshHostname
 		}


### PR DESCRIPTION
This removes the usage of Hostname() which does not honor configured SSH
port to be used.

Resolves: #1377
See also: #1101, #1102

Signed-off-by: Tobias Jakobsson <jakobsson.tobias@gmail.com>