### PR TITLE
Update more toolkit.fluxcd.io redirects

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,7 +47,7 @@ brews:
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     folder: Formula
-    homepage: "https://toolkit.fluxcd.io/"
+    homepage: "https://fluxcd.io/"
     description: "Flux CLI"
     dependencies:
       - name: kubectl

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ This project is composed of:
 ### Understanding the code
 
 To get started with developing controllers, you might want to review
-[our guide](https://toolkit.fluxcd.io/dev-guides/source-watcher/) which
+[our guide](https://fluxcd.io/docs/gitops-toolkit/source-watcher/) which
 walks you through writing a short and concise controller that watches out
 for source changes.
 

--- a/manifests/integrations/registry-credentials-sync/_cronjobs/aws/config-patches.yaml
+++ b/manifests/integrations/registry-credentials-sync/_cronjobs/aws/config-patches.yaml
@@ -34,8 +34,8 @@ spec:
 ## If not using IRSA, set the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables
 ## Store these values in a Secret and load them in the container using envFrom.
 ## For managing this secret via GitOps, consider using SOPS or SealedSecrets and add that manifest in a resource file for this kustomize build.
-##   https://toolkit.fluxcd.io/guides/mozilla-sops/
-##   https://toolkit.fluxcd.io/guides/sealed-secrets/
+##   https://fluxcd.io/docs/guides/mozilla-sops/
+##   https://fluxcd.io/docs/guides/sealed-secrets/
 # ---
 # apiVersion: apps/v1
 # kind: Deployment

--- a/manifests/integrations/registry-credentials-sync/aws/config-patches.yaml
+++ b/manifests/integrations/registry-credentials-sync/aws/config-patches.yaml
@@ -24,8 +24,8 @@ metadata:
 ## If not using IRSA, set the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables
 ## Store these values in a Secret and load them in the container using envFrom.
 ## For managing this secret via GitOps, consider using SOPS or SealedSecrets and add that manifest in a resource file for this kustomize build.
-##   https://toolkit.fluxcd.io/guides/mozilla-sops/
-##   https://toolkit.fluxcd.io/guides/sealed-secrets/
+##   https://fluxcd.io/docs/guides/mozilla-sops/
+##   https://fluxcd.io/docs/guides/sealed-secrets/
 # ---
 # apiVersion: apps/v1
 # kind: Deployment


### PR DESCRIPTION
Following up on #1380, updated some more docs links which now live under fluxcd.io itself.