### PR TITLE
Make the Git ref required

### DIFF
--- a/cmd/flux/create_source_git.go
+++ b/cmd/flux/create_source_git.go
@@ -122,7 +122,7 @@ var sourceGitArgs = newSourceGitFlags()
 
 func init() {
 	createSourceGitCmd.Flags().StringVar(&sourceGitArgs.url, "url", "", "git address, e.g. ssh://git@host/org/repository")
-	createSourceGitCmd.Flags().StringVar(&sourceGitArgs.branch, "branch", "master", "git branch")
+	createSourceGitCmd.Flags().StringVar(&sourceGitArgs.branch, "branch", "", "git branch")
 	createSourceGitCmd.Flags().StringVar(&sourceGitArgs.tag, "tag", "", "git tag")
 	createSourceGitCmd.Flags().StringVar(&sourceGitArgs.semver, "tag-semver", "", "git tag semver range")
 	createSourceGitCmd.Flags().StringVarP(&sourceGitArgs.username, "username", "u", "", "basic authentication username")
@@ -164,6 +164,10 @@ func createSourceGitCmdRun(cmd *cobra.Command, args []string) error {
 	}
 	if u.Scheme != "ssh" && u.Scheme != "http" && u.Scheme != "https" {
 		return fmt.Errorf("git URL scheme '%s' not supported, can be: ssh, http and https", u.Scheme)
+	}
+
+	if sourceGitArgs.branch == "" && sourceGitArgs.tag == "" && sourceGitArgs.semver == "" {
+		return fmt.Errorf("a Git ref is required, use one of the following: --branch, --tag or --tag-semver")
 	}
 
 	if sourceGitArgs.caFile != "" && u.Scheme == "ssh" {


### PR DESCRIPTION
Remove the default branch value from `flux create source git` and validate that one of the ref options are specified.

Fix: #1387