### PR TITLE
Fix service account name in registry-credentials-sync deployment kustomization

### DIFF
--- a/manifests/integrations/registry-credentials-sync/_base/sync.yaml
+++ b/manifests/integrations/registry-credentials-sync/_base/sync.yaml
@@ -24,7 +24,7 @@ spec:
     type: Recreate
   template:
     spec:
-      serviceAccount: credentials-sync
+      serviceAccountName: credentials-sync
       containers:
       - image: busybox  # override this with a cloud-specific image
         name: sync


### PR DESCRIPTION
The Kustomization uses a name prefix of `acr-`. The sync deployment uses the `serviceAccount` property in the template. This field is deprecated (Deployments should use `serviceAccountName`) and therefore doesn't get the name prefix during kustomization, resulting in the deploy failing with:

``` 
Error creating: pods "acr-credentials-sync-78c56d4876-" is forbidden: error looking up service account flux-system/credentials-sync: serviceaccount "credentials-sync" not found
```

This is similar to [this issue](https://github.com/kubernetes-sigs/kustomize/issues/505).