### PR TITLE
add gitImplementation as a bootstrap flag

### DIFF
--- a/cmd/flux/bootstrap.go
+++ b/cmd/flux/bootstrap.go
@@ -41,6 +41,7 @@ type bootstrapFlags struct {
 
 	branch            string
 	recurseSubmodules bool
+	gitImplementation flags.GitImplementation
 	manifestsPath     string
 
 	defaultComponents  []string
@@ -93,6 +94,7 @@ func init() {
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapArgs.branch, "branch", bootstrapDefaultBranch, "Git branch")
 	bootstrapCmd.PersistentFlags().BoolVar(&bootstrapArgs.recurseSubmodules, "recurse-submodules", false,
 		"when enabled, configures the GitRepository source to initialize and include Git submodules in the artifact it produces")
+	bootstrapCmd.PersistentFlags().Var(&bootstrapArgs.gitImplementation, "git-implementation", bootstrapArgs.gitImplementation.Description())
 
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapArgs.manifestsPath, "manifests", "", "path to the manifest directory")
 

--- a/cmd/flux/bootstrap_git.go
+++ b/cmd/flux/bootstrap_git.go
@@ -194,7 +194,7 @@ func bootstrapGitCmdRun(cmd *cobra.Command, args []string) error {
 		Secret:            bootstrapArgs.secretName,
 		TargetPath:        gitArgs.path.ToSlash(),
 		ManifestFile:      sync.MakeDefaultOptions().ManifestFile,
-		GitImplementation: sourceGitArgs.gitImplementation.String(),
+		GitImplementation: bootstrapArgs.gitImplementation.String(),
 		RecurseSubmodules: bootstrapArgs.recurseSubmodules,
 	}
 

--- a/cmd/flux/bootstrap_github.go
+++ b/cmd/flux/bootstrap_github.go
@@ -212,7 +212,7 @@ func bootstrapGitHubCmdRun(cmd *cobra.Command, args []string) error {
 		Secret:            bootstrapArgs.secretName,
 		TargetPath:        githubArgs.path.ToSlash(),
 		ManifestFile:      sync.MakeDefaultOptions().ManifestFile,
-		GitImplementation: sourceGitArgs.gitImplementation.String(),
+		GitImplementation: bootstrapArgs.gitImplementation.String(),
 		RecurseSubmodules: bootstrapArgs.recurseSubmodules,
 	}
 

--- a/cmd/flux/bootstrap_gitlab.go
+++ b/cmd/flux/bootstrap_gitlab.go
@@ -228,7 +228,7 @@ func bootstrapGitLabCmdRun(cmd *cobra.Command, args []string) error {
 		Secret:            bootstrapArgs.secretName,
 		TargetPath:        gitlabArgs.path.ToSlash(),
 		ManifestFile:      sync.MakeDefaultOptions().ManifestFile,
-		GitImplementation: sourceGitArgs.gitImplementation.String(),
+		GitImplementation: bootstrapArgs.gitImplementation.String(),
 		RecurseSubmodules: bootstrapArgs.recurseSubmodules,
 	}
 


### PR DESCRIPTION
The gitImplementation flag is needed as a bootstrap flag to be able to
clone using libgit2 for example when bootstraping in a azure devops repo.

Signed-off-by: Edvin Norling <edvin.norling@xenit.se>