### PR TITLE
Remove resourceNames in integration secrets

### DIFF
--- a/manifests/integrations/eventhub-credentials-sync/_base/sync.yaml
+++ b/manifests/integrations/eventhub-credentials-sync/_base/sync.yaml
@@ -110,8 +110,8 @@ rules:
       - update
       - patch
     # Lock this down to the specific Secret name  (Optional)
-    resourceNames:
-     - $(KUBE_SECRET) # templated from kustomize vars referencing ConfigMap, also see kustomizeconfig.yaml
+    #resourceNames:
+    # - $(KUBE_SECRET) # templated from kustomize vars referencing ConfigMap, also see kustomizeconfig.yaml
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/integrations/registry-credentials-sync/_base/sync.yaml
+++ b/manifests/integrations/registry-credentials-sync/_base/sync.yaml
@@ -102,8 +102,8 @@ rules:
   - update
   - patch
   # # Lock this down to the specific Secret name  (Optional)
-  resourceNames:
-  - $(KUBE_SECRET)  # templated from kustomize vars referencing ConfigMap, also see kustomizeconfig.yaml
+  #resourceNames:
+  #- $(KUBE_SECRET)  # templated from kustomize vars referencing ConfigMap, also see kustomizeconfig.yaml
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/integrations/registry-credentials-sync/_cronjobs/_base/sync.yaml
+++ b/manifests/integrations/registry-credentials-sync/_cronjobs/_base/sync.yaml
@@ -49,7 +49,7 @@ spec:
 
               apply-secret() {
                 /kbin/kubectl create secret docker-registry "${1}" \
-                  --docker-passwrod="${2}" \
+                  --docker-password="${2}" \
                   --docker-username="${3}" \
                   --docker-server="${4}" \
                   --dry-run=client -o=yaml \


### PR DESCRIPTION
* Fixes: #1524
* We remove resourceName due to the following:
  Note: You cannot restrict create or deletecollection requests by resourceName.
  For create, this limitation is because the object name is not known at authorization time.
* Fix typo in azure-registry cronjob
Signed-off-by: Edvin Norling <edvin.norling@xenit.se>