### PR TITLE
Run conformance tests on ARM64 Kubernetes clusters

### DIFF
--- a/.github/workflows/e2e-arm64.yaml
+++ b/.github/workflows/e2e-arm64.yaml
@@ -1,0 +1,109 @@
+name: e2e-arm64
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main, update-components ]
+
+jobs:
+  ampere:
+    # Runner info
+    # Owner: Stefan Prodan
+    # VM: Oracle Cloud VM.Standard.A1.Flex 4CPU 24GB RAM
+    # OS: Linux 5.4.0-1045-oracle #49-Ubuntu SMP aarch64
+    # Packages: docker, kind, kubectl, kustomize
+    runs-on: [self-hosted, Linux, ARM64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
+      - name: Prepare
+        id: prep
+        run: |
+          echo ::set-output name=CLUSTER::arm64-${GITHUB_SHA:0:7}-$(date +%s)
+          echo ::set-output name=CONTEXT::kind-arm64-${GITHUB_SHA:0:7}-$(date +%s)
+      - name: Run unit tests
+        run: make test
+      - name: Check if working tree is dirty
+        run: |
+          if [[ $(git diff --stat) != '' ]]; then
+            git diff
+            echo 'run make test and commit changes'
+            exit 1
+          fi
+      - name: Build
+        run: |
+          go build -o /tmp/flux ./cmd/flux
+      - name: Setup Kubernetes Kind
+        run: |
+          kind create cluster --name ${{ steps.prep.outputs.CLUSTER }}
+      - name: flux check --pre
+        run: |
+          /tmp/flux check --pre \
+          --context ${{ steps.prep.outputs.CONTEXT }}
+      - name: flux install
+        run: |
+          /tmp/flux install \
+          --components-extra=image-reflector-controller,image-automation-controller \
+          --context ${{ steps.prep.outputs.CONTEXT }}
+      - name: flux create source git
+        run: |
+          /tmp/flux create source git podinfo-gogit \
+            --git-implementation=go-git \
+            --url https://github.com/stefanprodan/podinfo  \
+            --tag-semver=">1.0.0" \
+            --context ${{ steps.prep.outputs.CONTEXT }}
+          /tmp/flux create source git podinfo-libgit2 \
+            --git-implementation=libgit2 \
+            --url https://github.com/stefanprodan/podinfo  \
+            --branch="master" \
+            --context ${{ steps.prep.outputs.CONTEXT }}
+      - name: flux create kustomization
+        run: |
+          /tmp/flux create kustomization podinfo \
+            --source=podinfo-gogit \
+            --path="./deploy/overlays/dev" \
+            --prune=true \
+            --interval=5m \
+            --validation=client \
+            --health-check="Deployment/frontend.dev" \
+            --health-check="Deployment/backend.dev" \
+            --health-check-timeout=3m \
+            --context ${{ steps.prep.outputs.CONTEXT }}
+      - name: flux create tenant
+        run: |
+          /tmp/flux create tenant dev-team \
+            --with-namespace=apps \
+            --context ${{ steps.prep.outputs.CONTEXT }}
+      - name: flux create helmrelease
+        run: |
+          /tmp/flux -n apps create source helm podinfo \
+            --url https://stefanprodan.github.io/podinfo \
+            --context ${{ steps.prep.outputs.CONTEXT }}
+
+          /tmp/flux -n apps create hr podinfo-helm \
+            --source=HelmRepository/podinfo \
+            --chart=podinfo \
+            --chart-version="6.0.x" \
+            --service-account=dev-team \
+            --context ${{ steps.prep.outputs.CONTEXT }}
+      - name: flux get all
+        run: |
+          /tmp/flux get all --all-namespaces \
+            --context ${{ steps.prep.outputs.CONTEXT }}
+      - name: flux uninstall
+        run: |
+          /tmp/flux uninstall -s \
+            --context ${{ steps.prep.outputs.CONTEXT }}
+      - name: Debug failure
+        if: failure()
+        run: |
+          kubectl --context ${{ steps.prep.outputs.CONTEXT }} -n flux-system get all
+          /tmp/flux logs --all-namespaces
+      - name: Cleanup
+        if: always()
+        run: |
+          kind delete cluster --name ${{ steps.prep.outputs.CLUSTER }}


### PR DESCRIPTION
Until now, we've been running conformance testing of Flux release candidates only on AMD64 Kubernetes clusters (provided by GitHub hosted runners). While GitHub offers no ARM64 runners, we really need to make sure Flux does work on ARM64 as many users have deployed Flux on ARM64 clusters in production.

In order to ensure Flux releases can be run on ARM64, I've created a GitHub self-hosted runner on my personal account in Oracle Could with the following specs:
- VM: Oracle Cloud VM.Standard.A1.Flex 4CPU 24GB RAM
- OS: Linux 5.4.0-1045-oracle 49-Ubuntu SMP aarch64
- Packages: docker, kind, kubectl, kustomize

The ARM64 conformance test suite covers the following:
- Flux CLI can be build on aarch64 and all unit tests are passing
- The Flux controllers can be successfully installed on Kubernetes Kind ARM64 clusters
- Flux source controller can clone repositories using go-git and libgit2
- Flux can reconcile Kustomize overlays and Helm releases
- Flux can create tenants in-cluster and impersonate accounts with restricted access
- Flux can be successfully uninstalled on clusters with ARM64 nodes
