### PR TITLE
Update source-controller to v0.15.1

### DIFF
--- a/cmd/flux/create_source_helm.go
+++ b/cmd/flux/create_source_helm.go
@@ -66,13 +66,14 @@ For private Helm repositories, the basic authentication credentials are stored i
 }
 
 type sourceHelmFlags struct {
-	url       string
-	username  string
-	password  string
-	certFile  string
-	keyFile   string
-	caFile    string
-	secretRef string
+	url             string
+	username        string
+	password        string
+	certFile        string
+	keyFile         string
+	caFile          string
+	secretRef       string
+	passCredentials bool
 }
 
 var sourceHelmArgs sourceHelmFlags
@@ -85,6 +86,7 @@ func init() {
 	createSourceHelmCmd.Flags().StringVar(&sourceHelmArgs.keyFile, "key-file", "", "TLS authentication key file path")
 	createSourceHelmCmd.Flags().StringVar(&sourceHelmArgs.caFile, "ca-file", "", "TLS authentication CA file path")
 	createSourceHelmCmd.Flags().StringVarP(&sourceHelmArgs.secretRef, "secret-ref", "", "", "the name of an existing secret containing TLS or basic auth credentials")
+	createSourceHelmCmd.Flags().BoolVarP(&sourceHelmArgs.passCredentials, "pass-credentials", "", false, "pass credentials to all domains")
 
 	createSourceCmd.AddCommand(createSourceHelmCmd)
 }
@@ -132,6 +134,7 @@ func createSourceHelmCmdRun(cmd *cobra.Command, args []string) error {
 		helmRepository.Spec.SecretRef = &meta.LocalObjectReference{
 			Name: sourceHelmArgs.secretRef,
 		}
+		helmRepository.Spec.PassCredentials = sourceHelmArgs.passCredentials
 	}
 
 	if createArgs.export {
@@ -175,6 +178,7 @@ func createSourceHelmCmdRun(cmd *cobra.Command, args []string) error {
 			helmRepository.Spec.SecretRef = &meta.LocalObjectReference{
 				Name: secretName,
 			}
+			helmRepository.Spec.PassCredentials = sourceHelmArgs.passCredentials
 			logger.Successf("authentication configured")
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/fluxcd/pkg/ssh v0.0.5
 	github.com/fluxcd/pkg/untar v0.0.5
 	github.com/fluxcd/pkg/version v0.0.1
-	github.com/fluxcd/source-controller/api v0.15.0
+	github.com/fluxcd/source-controller/api v0.15.1
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/google/go-containerregistry v0.2.0
 	github.com/manifoldco/promptui v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -225,8 +225,8 @@ github.com/fluxcd/pkg/untar v0.0.5/go.mod h1:O6V9+rtl8c1mHBafgqFlJN6zkF1HS5SSYn7
 github.com/fluxcd/pkg/version v0.0.1 h1:/8asQoDXSThz3csiwi4Qo8Zb6blAxLXbtxNgeMJ9bCg=
 github.com/fluxcd/pkg/version v0.0.1/go.mod h1:WAF4FEEA9xyhngF8TDxg3UPu5fA1qhEYV8Pmi2Il01Q=
 github.com/fluxcd/source-controller/api v0.14.0/go.mod h1:P1pIkaoIsiCJ/NLC7IBXPb9XEime9NvA1WN4hZu2Of4=
-github.com/fluxcd/source-controller/api v0.15.0 h1:EhuBZb+gLFbOWxX+UQzXqnAO0wUSViJEDcuVscmRoHc=
-github.com/fluxcd/source-controller/api v0.15.0/go.mod h1:P1pIkaoIsiCJ/NLC7IBXPb9XEime9NvA1WN4hZu2Of4=
+github.com/fluxcd/source-controller/api v0.15.1 h1:ajJHCP3e3AST13nOJrM2ax2mqTS2vSjj7jkedhbMds0=
+github.com/fluxcd/source-controller/api v0.15.1/go.mod h1:P1pIkaoIsiCJ/NLC7IBXPb9XEime9NvA1WN4hZu2Of4=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=


### PR DESCRIPTION
This includes an introduction of a `--pass-credentials` flag for the
`flux create source helm` command to allow configuring the new
option introduced.
