### PR TITLE
Add provisioning script for ARM64 GitHub runners

### DIFF
--- a/.github/runners/README.md
+++ b/.github/runners/README.md
@@ -1,0 +1,42 @@
+# Flux GitHub runners
+
+How to provision GitHub Actions self-hosted runners for Flux conformance testing.
+
+## ARM64 Instance specs
+
+In order to add a new runner to the GitHub Actions pool,
+first create an instance on Oracle Cloud with the following configuration:
+- OS: Canonical Ubuntu 20.04
+- Shape: VM.Standard.A1.Flex
+- OCPU Count: 2 
+- Memory (GB): 12
+- Network Bandwidth (Gbps): 2
+- Local Disk: Block Storage Only  
+
+Note that the instance image source must be **Canonical Ubuntu** instead of the default Oracle Linux.
+
+## ARM64 Instance setup
+
+- SSH into a newly created instance
+```shell
+ssh ubuntu@<instance-public-IP>
+``` 
+- Create the action runner dir
+```shell
+mkdir -p actions-runner && cd actions-runner
+```
+- Download the provisioning script
+```shell
+curl -sL https://raw.githubusercontent.com/fluxcd/flux2/main/.github/runners/arm64.sh > arm64.sh \
+  && chmod +x ./arm64.sh
+```
+- Retrieve the GitHub runner token from the repository [settings page](https://github.com/fluxcd/flux2/settings/actions/runners/new?arch=arm64&os=linux)
+- Run the provisioning script passing the token as the first argument
+```shell
+sudo ./arm64.sh <TOKEN>
+```
+- Reboot the instance
+```shell
+sudo reboot
+```  
+- Navigate to the GitHub repository [runners page](https://github.com/fluxcd/flux2/settings/actions/runners) and check the runner status

--- a/.github/workflows/e2e-arm64.yaml
+++ b/.github/workflows/e2e-arm64.yaml
@@ -9,9 +9,7 @@ jobs:
   ampere:
     # Runner info
     # Owner: Stefan Prodan
-    # VM: Oracle Cloud VM.Standard.A1.Flex 4CPU 24GB RAM
-    # OS: Linux 5.4.0-1045-oracle #49-Ubuntu SMP aarch64
-    # Packages: docker, kind, kubectl, kustomize
+    # Docs: https://github.com/fluxcd/flux2/tree/main/.github/runners
     runs-on: [self-hosted, Linux, ARM64]
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR adds the script used to provision the GitHub Actions self-hosted runners for Flux conformance testing on ARM64. The script is accompanied by documentation on how to add an Oracle Cloud Ampere instance to the runners pool.

The ARM64 pool is currently made of two Ampere instances (created on my personal Oracle Cloud account) with 2CPU and 12GB RAM each:
- arm64-runner-1 (test run https://github.com/fluxcd/flux2/runs/2864585134)
- arm64-runner-2 (test run https://github.com/fluxcd/flux2/runs/2864586435)

Followup: #1540