### PR TITLE
Use image API v1beta1

### DIFF
--- a/cmd/flux/create_image_policy.go
+++ b/cmd/flux/create_image_policy.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/fluxcd/pkg/apis/meta"
 
-	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1alpha2"
+	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1beta1"
 )
 
 var createImagePolicyCmd = &cobra.Command{

--- a/cmd/flux/create_image_repository.go
+++ b/cmd/flux/create_image_repository.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/fluxcd/pkg/apis/meta"
 
-	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1alpha2"
+	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1beta1"
 )
 
 var createImageRepositoryCmd = &cobra.Command{

--- a/cmd/flux/create_image_update.go
+++ b/cmd/flux/create_image_update.go
@@ -22,7 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	autov1 "github.com/fluxcd/image-automation-controller/api/v1alpha2"
+	autov1 "github.com/fluxcd/image-automation-controller/api/v1beta1"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
 )
 

--- a/cmd/flux/delete_image_policy.go
+++ b/cmd/flux/delete_image_policy.go
@@ -19,7 +19,7 @@ package main
 import (
 	"github.com/spf13/cobra"
 
-	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1alpha2"
+	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1beta1"
 )
 
 var deleteImagePolicyCmd = &cobra.Command{

--- a/cmd/flux/delete_image_repository.go
+++ b/cmd/flux/delete_image_repository.go
@@ -19,7 +19,7 @@ package main
 import (
 	"github.com/spf13/cobra"
 
-	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1alpha2"
+	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1beta1"
 )
 
 var deleteImageRepositoryCmd = &cobra.Command{

--- a/cmd/flux/delete_image_update.go
+++ b/cmd/flux/delete_image_update.go
@@ -19,7 +19,7 @@ package main
 import (
 	"github.com/spf13/cobra"
 
-	autov1 "github.com/fluxcd/image-automation-controller/api/v1alpha2"
+	autov1 "github.com/fluxcd/image-automation-controller/api/v1beta1"
 )
 
 var deleteImageUpdateCmd = &cobra.Command{

--- a/cmd/flux/export_image_policy.go
+++ b/cmd/flux/export_image_policy.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1alpha2"
+	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1beta1"
 )
 
 var exportImagePolicyCmd = &cobra.Command{

--- a/cmd/flux/export_image_repository.go
+++ b/cmd/flux/export_image_repository.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1alpha2"
+	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1beta1"
 )
 
 var exportImageRepositoryCmd = &cobra.Command{

--- a/cmd/flux/export_image_update.go
+++ b/cmd/flux/export_image_update.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	autov1 "github.com/fluxcd/image-automation-controller/api/v1alpha2"
+	autov1 "github.com/fluxcd/image-automation-controller/api/v1beta1"
 )
 
 var exportImageUpdateCmd = &cobra.Command{

--- a/cmd/flux/get_image_all.go
+++ b/cmd/flux/get_image_all.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	autov1 "github.com/fluxcd/image-automation-controller/api/v1alpha2"
-	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1alpha2"
+	autov1 "github.com/fluxcd/image-automation-controller/api/v1beta1"
+	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1beta1"
 )
 
 var getImageAllCmd = &cobra.Command{

--- a/cmd/flux/get_image_policy.go
+++ b/cmd/flux/get_image_policy.go
@@ -19,7 +19,7 @@ package main
 import (
 	"github.com/spf13/cobra"
 
-	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1alpha2"
+	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1beta1"
 )
 
 var getImagePolicyCmd = &cobra.Command{

--- a/cmd/flux/get_image_repository.go
+++ b/cmd/flux/get_image_repository.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1alpha2"
+	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1beta1"
 )
 
 var getImageRepositoryCmd = &cobra.Command{

--- a/cmd/flux/get_image_update.go
+++ b/cmd/flux/get_image_update.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	autov1 "github.com/fluxcd/image-automation-controller/api/v1alpha2"
+	autov1 "github.com/fluxcd/image-automation-controller/api/v1beta1"
 )
 
 var getImageUpdateCmd = &cobra.Command{

--- a/cmd/flux/image.go
+++ b/cmd/flux/image.go
@@ -19,8 +19,8 @@ package main
 import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	autov1 "github.com/fluxcd/image-automation-controller/api/v1alpha2"
-	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1alpha2"
+	autov1 "github.com/fluxcd/image-automation-controller/api/v1beta1"
+	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1beta1"
 )
 
 // These are general-purpose adapters for attaching methods to, for

--- a/cmd/flux/reconcile_image_repository.go
+++ b/cmd/flux/reconcile_image_repository.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1alpha2"
+	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1beta1"
 )
 
 var reconcileImageRepositoryCmd = &cobra.Command{

--- a/cmd/flux/reconcile_image_updateauto.go
+++ b/cmd/flux/reconcile_image_updateauto.go
@@ -22,7 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 
-	autov1 "github.com/fluxcd/image-automation-controller/api/v1alpha2"
+	autov1 "github.com/fluxcd/image-automation-controller/api/v1beta1"
 	meta "github.com/fluxcd/pkg/apis/meta"
 )
 

--- a/cmd/flux/resume_image_repository.go
+++ b/cmd/flux/resume_image_repository.go
@@ -19,7 +19,7 @@ package main
 import (
 	"github.com/spf13/cobra"
 
-	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1alpha2"
+	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1beta1"
 )
 
 var resumeImageRepositoryCmd = &cobra.Command{

--- a/cmd/flux/resume_image_updateauto.go
+++ b/cmd/flux/resume_image_updateauto.go
@@ -19,7 +19,7 @@ package main
 import (
 	"github.com/spf13/cobra"
 
-	autov1 "github.com/fluxcd/image-automation-controller/api/v1alpha2"
+	autov1 "github.com/fluxcd/image-automation-controller/api/v1beta1"
 )
 
 var resumeImageUpdateCmd = &cobra.Command{

--- a/cmd/flux/suspend_image_repository.go
+++ b/cmd/flux/suspend_image_repository.go
@@ -19,7 +19,7 @@ package main
 import (
 	"github.com/spf13/cobra"
 
-	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1alpha2"
+	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1beta1"
 )
 
 var suspendImageRepositoryCmd = &cobra.Command{

--- a/cmd/flux/suspend_image_updateauto.go
+++ b/cmd/flux/suspend_image_updateauto.go
@@ -19,7 +19,7 @@ package main
 import (
 	"github.com/spf13/cobra"
 
-	autov1 "github.com/fluxcd/image-automation-controller/api/v1alpha2"
+	autov1 "github.com/fluxcd/image-automation-controller/api/v1beta1"
 )
 
 var suspendImageUpdateCmd = &cobra.Command{

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -45,8 +45,8 @@ import (
 	"sigs.k8s.io/yaml"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
-	imageautov1 "github.com/fluxcd/image-automation-controller/api/v1alpha2"
-	imagereflectv1 "github.com/fluxcd/image-reflector-controller/api/v1alpha2"
+	imageautov1 "github.com/fluxcd/image-automation-controller/api/v1beta1"
+	imagereflectv1 "github.com/fluxcd/image-reflector-controller/api/v1beta1"
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta1"
 	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta1"
 	"github.com/fluxcd/pkg/runtime/dependency"


### PR DESCRIPTION
Makes all the image commands use the v1beta1 version of the API. Since v1beta1 is the same schema as v1alpha2, no changes to the handling of the values need to be made.