### PR TITLE
fix Control Plane dashboard legend

### DIFF
--- a/manifests/monitoring/grafana/dashboards/control-plane.json
+++ b/manifests/monitoring/grafana/dashboards/control-plane.json
@@ -547,7 +547,7 @@
         {
           "expr": "rate(process_cpu_seconds_total{namespace=\"$namespace\",pod=~\".*-controller-.*\"}[1m])",
           "interval": "",
-          "legendFormat": "{{kubernetes_pod_name}}",
+          "legendFormat": "{{pod}}",
           "refId": "A"
         }
       ],
@@ -643,7 +643,7 @@
           "expr": "rate(go_memstats_alloc_bytes_total{namespace=\"$namespace\",pod=~\".*-controller-.*\"}[1m])",
           "hide": false,
           "interval": "",
-          "legendFormat": "{{kubernetes_pod_name}}",
+          "legendFormat": "{{pod}}",
           "refId": "A"
         }
       ],


### PR DESCRIPTION
The legend was not showing the Pod name, instead the whole resource in
the dashboard

As a result, use the correct Prometheus label

For example, this was displayed previously
![image](https://user-images.githubusercontent.com/5355219/123976083-286a4980-d9be-11eb-9036-597983d960ed.png)

With this PR, it'll look like this
![image](https://user-images.githubusercontent.com/5355219/123976209-433cbe00-d9be-11eb-9cf1-0163904694a2.png)


Resolves:
Related: