### PR TITLE
Update podmonitor example

### DIFF
--- a/manifests/monitoring/monitoring-config/podmonitor.yaml
+++ b/manifests/monitoring/monitoring-config/podmonitor.yaml
@@ -21,4 +21,4 @@ spec:
           - image-automation-controller
           - image-reflector-controller
   podMetricsEndpoints:
-    - targetPort: http-prom
+    - port: http-prom


### PR DESCRIPTION
`targetPort` is deprecated since prometheus-operator 0.38.0 (changelog: https://github.com/prometheus-operator/prometheus-operator/blob/master/CHANGELOG.md#0380--2020-03-20).