### PR TITLE
Request reconcile using patch instead of update

### DIFF
--- a/cmd/flux/alert.go
+++ b/cmd/flux/alert.go
@@ -37,6 +37,10 @@ func (a alertAdapter) asClientObject() client.Object {
 	return a.Alert
 }
 
+func (a alertAdapter) deepCopyClientObject() client.Object {
+	return a.Alert.DeepCopy()
+}
+
 // notificationv1.Alert
 
 type alertListAdapter struct {

--- a/cmd/flux/alert_provider.go
+++ b/cmd/flux/alert_provider.go
@@ -37,6 +37,10 @@ func (a alertProviderAdapter) asClientObject() client.Object {
 	return a.Provider
 }
 
+func (a alertProviderAdapter) deepCopyClientObject() client.Object {
+	return a.Provider.DeepCopy()
+}
+
 // notificationv1.Provider
 
 type alertProviderListAdapter struct {

--- a/cmd/flux/helmrelease.go
+++ b/cmd/flux/helmrelease.go
@@ -37,6 +37,10 @@ func (h helmReleaseAdapter) asClientObject() client.Object {
 	return h.HelmRelease
 }
 
+func (h helmReleaseAdapter) deepCopyClientObject() client.Object {
+	return h.HelmRelease.DeepCopy()
+}
+
 // helmv2.HelmReleaseList
 
 type helmReleaseListAdapter struct {

--- a/cmd/flux/image.go
+++ b/cmd/flux/image.go
@@ -42,6 +42,10 @@ func (a imageRepositoryAdapter) asClientObject() client.Object {
 	return a.ImageRepository
 }
 
+func (a imageRepositoryAdapter) deepCopyClientObject() client.Object {
+	return a.ImageRepository.DeepCopy()
+}
+
 // imagev1.ImageRepositoryList
 
 type imageRepositoryListAdapter struct {
@@ -98,6 +102,10 @@ type imageUpdateAutomationAdapter struct {
 
 func (a imageUpdateAutomationAdapter) asClientObject() client.Object {
 	return a.ImageUpdateAutomation
+}
+
+func (a imageUpdateAutomationAdapter) deepCopyClientObject() client.Object {
+	return a.ImageUpdateAutomation.DeepCopy()
 }
 
 // autov1.ImageUpdateAutomationList

--- a/cmd/flux/kustomization.go
+++ b/cmd/flux/kustomization.go
@@ -37,6 +37,10 @@ func (a kustomizationAdapter) asClientObject() client.Object {
 	return a.Kustomization
 }
 
+func (a kustomizationAdapter) deepCopyClientObject() client.Object {
+	return a.Kustomization.DeepCopy()
+}
+
 // kustomizev1.KustomizationList
 
 type kustomizationListAdapter struct {

--- a/cmd/flux/object.go
+++ b/cmd/flux/object.go
@@ -39,6 +39,13 @@ type adapter interface {
 	asClientObject() client.Object
 }
 
+// copyable is an interface for a wrapper or alias from which we can
+// get a deep copied client.Object, required when you e.g. want to
+// calculate a patch.
+type copyable interface {
+	deepCopyClientObject() client.Object
+}
+
 // listAdapater is the analogue to adapter, but for lists; the
 // controller runtime distinguishes between methods dealing with
 // objects and lists.

--- a/cmd/flux/receiver.go
+++ b/cmd/flux/receiver.go
@@ -37,6 +37,10 @@ func (a receiverAdapter) asClientObject() client.Object {
 	return a.Receiver
 }
 
+func (a receiverAdapter) deepCopyClientObject() client.Object {
+	return a.Receiver.DeepCopy()
+}
+
 // notificationv1.Receiver
 
 type receiverListAdapter struct {

--- a/cmd/flux/source.go
+++ b/cmd/flux/source.go
@@ -41,6 +41,10 @@ func (a bucketAdapter) asClientObject() client.Object {
 	return a.Bucket
 }
 
+func (a bucketAdapter) deepCopyClientObject() client.Object {
+	return a.Bucket.DeepCopy()
+}
+
 // sourcev1.BucketList
 
 type bucketListAdapter struct {
@@ -68,6 +72,10 @@ type helmChartAdapter struct {
 
 func (a helmChartAdapter) asClientObject() client.Object {
 	return a.HelmChart
+}
+
+func (a helmChartAdapter) deepCopyClientObject() client.Object {
+	return a.HelmChart.DeepCopy()
 }
 
 // sourcev1.HelmChartList
@@ -99,6 +107,10 @@ func (a gitRepositoryAdapter) asClientObject() client.Object {
 	return a.GitRepository
 }
 
+func (a gitRepositoryAdapter) deepCopyClientObject() client.Object {
+	return a.GitRepository.DeepCopy()
+}
+
 // sourcev1.GitRepositoryList
 
 type gitRepositoryListAdapter struct {
@@ -126,6 +138,10 @@ type helmRepositoryAdapter struct {
 
 func (a helmRepositoryAdapter) asClientObject() client.Object {
 	return a.HelmRepository
+}
+
+func (a helmRepositoryAdapter) deepCopyClientObject() client.Object {
+	return a.HelmRepository.DeepCopy()
 }
 
 // sourcev1.HelmRepositoryList


### PR DESCRIPTION
This should prevent the generation of the object getting bumped, as
observed on a GKE K8s 1.18 cluster using the  logic before this commit.

We only want to generation to increase when there are actual changes to
the `spec` of a resource, as some controllers use the `generation`
value to make assumptions about what they should do during a
reconciliation.

Ref: https://github.com/fluxcd/helm-controller/issues/295