### PR TITLE
Fix trace for optional GitRepository.Spec.Reference

### DIFF
--- a/cmd/flux/trace.go
+++ b/cmd/flux/trace.go
@@ -191,12 +191,14 @@ Status:        Unknown
 GitRepository: {{.GitRepository.Name}}
 Namespace:     {{.GitRepository.Namespace}}
 URL:           {{.GitRepository.Spec.URL}}
+{{- if .GitRepository.Spec.Reference }}
 {{- if .GitRepository.Spec.Reference.Tag }}
 Tag:           {{.GitRepository.Spec.Reference.Tag}}
 {{- else if .GitRepository.Spec.Reference.SemVer }}
 Tag:           {{.GitRepository.Spec.Reference.SemVer}}
 {{- else if .GitRepository.Spec.Reference.Branch }}
 Branch:        {{.GitRepository.Spec.Reference.Branch}}
+{{- end }}
 {{- end }}
 {{- if .GitRepository.Status.Artifact }}
 Revision:      {{.GitRepository.Status.Artifact.Revision}}

--- a/cmd/flux/trace.go
+++ b/cmd/flux/trace.go
@@ -363,12 +363,14 @@ Status:         Unknown
 GitRepository: {{.GitRepository.Name}}
 Namespace:     {{.GitRepository.Namespace}}
 URL:           {{.GitRepository.Spec.URL}}
+{{- if .GitRepository.Spec.Reference }}
 {{- if .GitRepository.Spec.Reference.Tag }}
 Tag:           {{.GitRepository.Spec.Reference.Tag}}
 {{- else if .GitRepository.Spec.Reference.SemVer }}
 Tag:           {{.GitRepository.Spec.Reference.SemVer}}
 {{- else if .GitRepository.Spec.Reference.Branch }}
 Branch:        {{.GitRepository.Spec.Reference.Branch}}
+{{- end }}
 {{- end }}
 {{- if .GitRepository.Status.Artifact }}
 Revision:      {{.GitRepository.Status.Artifact.Revision}}


### PR DESCRIPTION
Check for existence of GitRepository.Spec.Reference when displaying a trace to
avoid error:

✗ template: tmpl:28:21: executing "tmpl" at <.GitRepository.Spec.Reference.Tag>: nil pointer evaluating *v1beta1.GitRepositoryRef.Tag

Fixes issue #1621
Manually tested using the use cases highlighted in the issue.

Signed-off-by: Allen Porter <allen@thebends.org>