### PR TITLE
Update website via CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,8 @@ you can sign your commit automatically with `git commit -s`.
 
 For realtime communications we use Slack: To join the conversation, simply
 join the [CNCF](https://slack.cncf.io/) Slack workspace and use the
-[#flux-dev](https://cloud-native.slack.com/messages/flux-dev/) channel.
+[#flux-contributors](https://cloud-native.slack.com/messages/flux-contributors/)
+channel.
 
 To discuss ideas and specifications we use [Github
 Discussions](https://github.com/fluxcd/flux2/discussions).


### PR DESCRIPTION
We are directing folks to #flux-dev which is a channel for bots, and doesn't really host conversations.

For contributors, I think we want these folks to find us in #flux-contributors (rather than visiting #flux-dev)
