### PR TITLE
Provide suggestion for some fields in bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-description: Create a report to help us improve Flux v2
+description: Create a report to help us improve Flux
 body:
 - type: markdown
   attributes:
@@ -41,20 +41,21 @@ body:
     required: true
   attributes:
     label: OS / Distro
+    description: The OS / distro you are executing `flux` on. If not applicable, write `N/A`.
     placeholder: e.g. Windows 10, Ubuntu 20.04, Arch Linux, macOS 10.15...
 - type: input
   validations:
     required: true
   attributes:
     label: Flux version
-    description: Run `flux --version` to check.
+    description: Run `flux --version` to check. If not applicable, write `N/A`.
     placeholder: e.g. 0.16.1
 - type: textarea
   validations:
     required: true
   attributes:
     label: Flux check
-    description: Run `flux check` to check.
+    description: Run `flux check` to check. If not applicable, write `N/A`.
     placeholder: |
       For example:
       ► checking prerequisites


### PR DESCRIPTION
This commit adds suggestion for some of the required fields because
there can be a few exceptions in which these values can not be
provided. For example when the `flux` binary can not be installed, or
the set of controllers has been installed with just an `install.yaml`
file.

We use this approach instead of making the fields optional because it
guides people to provide the information whenever they can, which
should result in higher quality bug reports.

As a tiny addition, the reference to "Flux v2" has been renamed to just
"Flux" as we are slowly transitioning "Flux v1" into "Flux Legacy".