### PR TITLE
Adds a watch flag to the get command

### DIFF
--- a/cmd/flux/create_tenant.go
+++ b/cmd/flux/create_tenant.go
@@ -148,7 +148,7 @@ func createTenantCmdRun(cmd *cobra.Command, args []string) error {
 	}
 
 	if createArgs.export {
-		for i, _ := range tenantArgs.namespaces {
+		for i := range tenantArgs.namespaces {
 			if err := exportTenant(namespaces[i], accounts[i], roleBindings[i]); err != nil {
 				return err
 			}
@@ -164,7 +164,7 @@ func createTenantCmdRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	for i, _ := range tenantArgs.namespaces {
+	for i := range tenantArgs.namespaces {
 		logger.Actionf("applying namespace %s", namespaces[i].Name)
 		if err := upsertNamespace(ctx, kubeClient, namespaces[i]); err != nil {
 			return err

--- a/cmd/flux/get.go
+++ b/cmd/flux/get.go
@@ -25,12 +25,35 @@ import (
 	"github.com/spf13/cobra"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	watchtools "k8s.io/client-go/tools/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/fluxcd/pkg/apis/meta"
 
 	"github.com/fluxcd/flux2/internal/utils"
 )
+
+type deriveType func(runtime.Object) (summarisable, error)
+
+type typeMap map[string]deriveType
+
+func (m typeMap) registerCommand(t string, f deriveType) error {
+	if _, ok := m[t]; ok {
+		return fmt.Errorf("duplicate type function %s", t)
+	}
+	m[t] = f
+	return nil
+}
+
+func (m typeMap) execute(t string, obj runtime.Object) (summarisable, error) {
+	f, ok := m[t]
+	if !ok {
+		return nil, fmt.Errorf("unsupported type %s", t)
+	}
+	return f(obj)
+}
 
 var getCmd = &cobra.Command{
 	Use:   "get",
@@ -42,6 +65,7 @@ type GetFlags struct {
 	allNamespaces  bool
 	noHeader       bool
 	statusSelector string
+	watch          bool
 }
 
 var getArgs GetFlags
@@ -50,6 +74,7 @@ func init() {
 	getCmd.PersistentFlags().BoolVarP(&getArgs.allNamespaces, "all-namespaces", "A", false,
 		"list the requested object(s) across all namespaces")
 	getCmd.PersistentFlags().BoolVarP(&getArgs.noHeader, "no-header", "", false, "skip the header when printing the results")
+	getCmd.PersistentFlags().BoolVarP(&getArgs.watch, "watch", "w", false, "After listing/getting the requested object, watch for changes.")
 	getCmd.PersistentFlags().StringVar(&getArgs.statusSelector, "status-selector", "",
 		"specify the status condition name and the desired state to filter the get result, e.g. ready=false")
 	rootCmd.AddCommand(getCmd)
@@ -102,7 +127,8 @@ var namespaceHeader = []string{"Namespace"}
 
 type getCommand struct {
 	apiType
-	list summarisable
+	list    summarisable
+	funcMap typeMap
 }
 
 func (get getCommand) run(cmd *cobra.Command, args []string) error {
@@ -123,12 +149,16 @@ func (get getCommand) run(cmd *cobra.Command, args []string) error {
 		listOpts = append(listOpts, client.MatchingFields{"metadata.name": args[0]})
 	}
 
+	getAll := cmd.Use == "all"
+
+	if getArgs.watch {
+		return get.watch(ctx, kubeClient, cmd, args, listOpts)
+	}
+
 	err = kubeClient.List(ctx, get.list.asClientList(), listOpts...)
 	if err != nil {
 		return err
 	}
-
-	getAll := cmd.Use == "all"
 
 	if get.list.len() == 0 {
 		if !getAll {
@@ -141,28 +171,93 @@ func (get getCommand) run(cmd *cobra.Command, args []string) error {
 	if !getArgs.noHeader {
 		header = get.list.headers(getArgs.allNamespaces)
 	}
+
+	rows, err := getRowsToPrint(getAll, get.list)
+	if err != nil {
+		return err
+	}
+
+	utils.PrintTable(os.Stdout, header, rows)
+
+	if getAll {
+		fmt.Println()
+	}
+
+	return nil
+}
+
+func getRowsToPrint(getAll bool, list summarisable) ([][]string, error) {
 	noFilter := true
 	var conditionType, conditionStatus string
 	if getArgs.statusSelector != "" {
 		parts := strings.SplitN(getArgs.statusSelector, "=", 2)
 		if len(parts) != 2 {
-			return fmt.Errorf("expected status selector in type=status format, but found: %s", getArgs.statusSelector)
+			return nil, fmt.Errorf("expected status selector in type=status format, but found: %s", getArgs.statusSelector)
 		}
 		conditionType = parts[0]
 		conditionStatus = parts[1]
 		noFilter = false
 	}
 	var rows [][]string
-	for i := 0; i < get.list.len(); i++ {
-		if noFilter || get.list.statusSelectorMatches(i, conditionType, conditionStatus) {
-			row := get.list.summariseItem(i, getArgs.allNamespaces, getAll)
+	for i := 0; i < list.len(); i++ {
+		if noFilter || list.statusSelectorMatches(i, conditionType, conditionStatus) {
+			row := list.summariseItem(i, getArgs.allNamespaces, getAll)
 			rows = append(rows, row)
 		}
 	}
-	utils.PrintTable(os.Stdout, header, rows)
+	return rows, nil
+}
 
-	if getAll {
-		fmt.Println()
+//
+// watch starts a client-side watch of one or more resources.
+func (get *getCommand) watch(ctx context.Context, kubeClient client.WithWatch, cmd *cobra.Command, args []string, listOpts []client.ListOption) error {
+	w, err := kubeClient.Watch(ctx, get.list.asClientList(), listOpts...)
+	if err != nil {
+		return err
+	}
+
+	_, err = watchUntil(ctx, w, get)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func watchUntil(ctx context.Context, w watch.Interface, get *getCommand) (bool, error) {
+	firstIteration := true
+	_, error := watchtools.UntilWithoutRetry(ctx, w, func(e watch.Event) (bool, error) {
+		objToPrint := e.Object
+		sink, err := get.funcMap.execute(get.apiType.kind, objToPrint)
+		if err != nil {
+			return false, err
+		}
+
+		var header []string
+		if !getArgs.noHeader {
+			header = sink.headers(getArgs.allNamespaces)
+		}
+		rows, err := getRowsToPrint(false, sink)
+		if err != nil {
+			return false, err
+		}
+		if firstIteration {
+			utils.PrintTable(os.Stdout, header, rows)
+			firstIteration = false
+		} else {
+			utils.PrintTable(os.Stdout, []string{}, rows)
+		}
+
+		return false, nil
+	})
+
+	return false, error
+}
+
+func validateWatchOption(cmd *cobra.Command, toMatch string) error {
+	w, _ := cmd.Flags().GetBool("watch")
+	if cmd.Use == toMatch && w {
+		return fmt.Errorf("expected a single resource type, but found %s", cmd.Use)
 	}
 	return nil
 }

--- a/cmd/flux/get_all.go
+++ b/cmd/flux/get_all.go
@@ -36,7 +36,12 @@ var getAllCmd = &cobra.Command{
   # List all resources in all namespaces
   flux get all --all-namespaces`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		err := getSourceAllCmd.RunE(cmd, args)
+		err := validateWatchOption(cmd, "all")
+		if err != nil {
+			return err
+		}
+
+		err = getSourceAllCmd.RunE(cmd, args)
 		if err != nil {
 			logError(err)
 		}

--- a/cmd/flux/get_image.go
+++ b/cmd/flux/get_image.go
@@ -25,6 +25,9 @@ var getImageCmd = &cobra.Command{
 	Aliases: []string{"image"},
 	Short:   "Get image automation object status",
 	Long:    "The get image sub-commands print the status of image automation objects.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return validateWatchOption(cmd, "images")
+	},
 }
 
 func init() {

--- a/cmd/flux/get_image_all.go
+++ b/cmd/flux/get_image_all.go
@@ -35,6 +35,11 @@ var getImageAllCmd = &cobra.Command{
   # List all image objects in all namespaces
   flux get images all --all-namespaces`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		err := validateWatchOption(cmd, "all")
+		if err != nil {
+			return err
+		}
+
 		var allImageCmd = []getCommand{
 			{
 				apiType: imageRepositoryType,

--- a/cmd/flux/get_kustomization.go
+++ b/cmd/flux/get_kustomization.go
@@ -17,10 +17,12 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta1"
 )
@@ -32,10 +34,39 @@ var getKsCmd = &cobra.Command{
 	Long:    "The get kustomizations command prints the statuses of the resources.",
 	Example: `  # List all kustomizations and their status
   flux get kustomizations`,
-	RunE: getCommand{
-		apiType: kustomizationType,
-		list:    &kustomizationListAdapter{&kustomizev1.KustomizationList{}},
-	}.run,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		get := getCommand{
+			apiType: kustomizationType,
+			list:    &kustomizationListAdapter{&kustomizev1.KustomizationList{}},
+			funcMap: make(typeMap),
+		}
+
+		err := get.funcMap.registerCommand(get.apiType.kind, func(obj runtime.Object) (summarisable, error) {
+			o, ok := obj.(*kustomizev1.Kustomization)
+			if !ok {
+				return nil, fmt.Errorf("Impossible to cast type %#v kustomization", obj)
+			}
+
+			sink := kustomizationListAdapter{
+				&kustomizev1.KustomizationList{
+					Items: []kustomizev1.Kustomization{
+						*o,
+					},
+				},
+			}
+			return sink, nil
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if err := get.run(cmd, args); err != nil {
+			return err
+		}
+
+		return nil
+	},
 }
 
 func init() {

--- a/cmd/flux/get_source.go
+++ b/cmd/flux/get_source.go
@@ -25,6 +25,10 @@ var getSourceCmd = &cobra.Command{
 	Aliases: []string{"source"},
 	Short:   "Get source statuses",
 	Long:    "The get source sub-commands print the statuses of the sources.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		return validateWatchOption(cmd, "sources")
+	},
 }
 
 func init() {

--- a/cmd/flux/get_source_all.go
+++ b/cmd/flux/get_source_all.go
@@ -34,6 +34,11 @@ var getSourceAllCmd = &cobra.Command{
   # List all sources in all namespaces
   flux get sources all --all-namespaces`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		err := validateWatchOption(cmd, "all")
+		if err != nil {
+			return err
+		}
+
 		var allSourceCmd = []getCommand{
 			{
 				apiType: bucketType,

--- a/cmd/flux/get_source_bucket.go
+++ b/cmd/flux/get_source_bucket.go
@@ -17,10 +17,12 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
 )
@@ -34,10 +36,36 @@ var getSourceBucketCmd = &cobra.Command{
 
  # List buckets from all namespaces
   flux get sources helm --all-namespaces`,
-	RunE: getCommand{
-		apiType: bucketType,
-		list:    &bucketListAdapter{&sourcev1.BucketList{}},
-	}.run,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		get := getCommand{
+			apiType: bucketType,
+			list:    &bucketListAdapter{&sourcev1.BucketList{}},
+			funcMap: make(typeMap),
+		}
+
+		err := get.funcMap.registerCommand(get.apiType.kind, func(obj runtime.Object) (summarisable, error) {
+			o, ok := obj.(*sourcev1.Bucket)
+			if !ok {
+				return nil, fmt.Errorf("Impossible to cast type %#v bucket", obj)
+			}
+
+			sink := &bucketListAdapter{&sourcev1.BucketList{
+				Items: []sourcev1.Bucket{
+					*o,
+				}}}
+			return sink, nil
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if err := get.run(cmd, args); err != nil {
+			return err
+		}
+
+		return nil
+	},
 }
 
 func init() {

--- a/cmd/flux/get_source_git.go
+++ b/cmd/flux/get_source_git.go
@@ -17,10 +17,12 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
 )
@@ -34,10 +36,36 @@ var getSourceGitCmd = &cobra.Command{
 
  # List Git repositories from all namespaces
   flux get sources git --all-namespaces`,
-	RunE: getCommand{
-		apiType: gitRepositoryType,
-		list:    &gitRepositoryListAdapter{&sourcev1.GitRepositoryList{}},
-	}.run,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		get := getCommand{
+			apiType: gitRepositoryType,
+			list:    &gitRepositoryListAdapter{&sourcev1.GitRepositoryList{}},
+			funcMap: make(typeMap),
+		}
+
+		err := get.funcMap.registerCommand(get.apiType.kind, func(obj runtime.Object) (summarisable, error) {
+			o, ok := obj.(*sourcev1.GitRepository)
+			if !ok {
+				return nil, fmt.Errorf("Impossible to cast type %#v git", obj)
+			}
+
+			sink := &gitRepositoryListAdapter{&sourcev1.GitRepositoryList{
+				Items: []sourcev1.GitRepository{
+					*o,
+				}}}
+			return sink, nil
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if err := get.run(cmd, args); err != nil {
+			return err
+		}
+
+		return nil
+	},
 }
 
 func init() {

--- a/cmd/flux/main_test.go
+++ b/cmd/flux/main_test.go
@@ -50,10 +50,10 @@ func readYamlObjects(objectFile string) ([]client.Object, error) {
 
 // A KubeManager that can create objects that are subject to a test.
 type fakeKubeManager struct {
-	fakeClient client.Client
+	fakeClient client.WithWatch
 }
 
-func (m *fakeKubeManager) NewClient(kubeconfig string, kubecontext string) (client.Client, error) {
+func (m *fakeKubeManager) NewClient(kubeconfig string, kubecontext string) (client.WithWatch, error) {
 	return m.fakeClient, nil
 }
 

--- a/go.sum
+++ b/go.sum
@@ -336,6 +336,7 @@ github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4er
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e h1:1r7pUrabqp18hOBcwBwiTsbnFeTZHV9eER/QT5JVZxY=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -398,6 +399,7 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
@@ -449,6 +451,7 @@ github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -134,7 +134,7 @@ func KubeConfig(kubeConfigPath string, kubeContext string) (*rest.Config, error)
 // KubeManger creates a Kubernetes client.Client. This interface exists to
 // facilitate unit testing and provide a fake client.
 type KubeManager interface {
-	NewClient(string, string) (client.Client, error)
+	NewClient(string, string) (client.WithWatch, error)
 }
 
 type defaultKubeManager struct{}
@@ -144,14 +144,14 @@ func DefaultKubeManager() KubeManager {
 	return manager
 }
 
-func (m defaultKubeManager) NewClient(kubeConfigPath string, kubeContext string) (client.Client, error) {
+func (m defaultKubeManager) NewClient(kubeConfigPath string, kubeContext string) (client.WithWatch, error) {
 	cfg, err := KubeConfig(kubeConfigPath, kubeContext)
 	if err != nil {
 		return nil, fmt.Errorf("kubernetes client initialization failed: %w", err)
 	}
 
 	scheme := NewScheme()
-	kubeClient, err := client.New(cfg, client.Options{
+	kubeClient, err := client.NewWithWatch(cfg, client.Options{
 		Scheme: scheme,
 	})
 	if err != nil {
@@ -179,7 +179,7 @@ func NewScheme() *apiruntime.Scheme {
 	return scheme
 }
 
-func KubeClient(kubeConfigPath string, kubeContext string) (client.Client, error) {
+func KubeClient(kubeConfigPath string, kubeContext string) (client.WithWatch, error) {
 	m := DefaultKubeManager()
 	kubeClient, err := m.NewClient(kubeConfigPath, kubeContext)
 	return kubeClient, err


### PR DESCRIPTION
Fix: #1586 

The new flag fetch and display the request ressource and then continue
watching the ressource until timeout or cancellation.

A single ressource/ressource type is supported.

Signed-off-by: Soule BA <soule@weave.works>