### PR TITLE
Add e2e test case fo check --pre

### DIFF
--- a/cmd/flux/check_test.go
+++ b/cmd/flux/check_test.go
@@ -1,0 +1,40 @@
+// +build e2e
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/fluxcd/flux2/internal/utils"
+	"k8s.io/apimachinery/pkg/version"
+)
+
+func TestCheckPre(t *testing.T) {
+	jsonOutput, err := utils.ExecKubectlCommand(context.TODO(), utils.ModeCapture, rootArgs.kubeconfig, rootArgs.kubecontext, "version", "--output", "json")
+	if err != nil {
+		t.Fatalf("Error running utils.ExecKubectlCommand: %v", err.Error())
+	}
+
+	var versions map[string]version.Info
+	if err := json.Unmarshal([]byte(jsonOutput), &versions); err != nil {
+		t.Fatalf("Error unmarshalling: %v", err.Error())
+	}
+
+	clientVersion := strings.TrimPrefix(versions["clientVersion"].GitVersion, "v")
+	serverVersion := strings.TrimPrefix(versions["serverVersion"].GitVersion, "v")
+
+	cmd := cmdTestCase{
+		args:            "check --pre",
+		wantError:       false,
+		testClusterMode: ExistingClusterMode,
+		templateValues: map[string]string{
+			"clientVersion": clientVersion,
+			"serverVersion": serverVersion,
+		},
+		goldenFile: "testdata/check/check_pre.golden",
+	}
+	cmd.runTestCmd(t)
+}

--- a/cmd/flux/testdata/check/check_pre.golden
+++ b/cmd/flux/testdata/check/check_pre.golden
@@ -1,0 +1,4 @@
+► checking prerequisites
+✔ kubectl {{ .clientVersion }} >=1.18.0-0
+✔ Kubernetes {{ .serverVersion }} >=1.16.0-0
+✔ prerequisites checks passed


### PR DESCRIPTION
This PR implements an e2e test case for the `flux check --pre` happy path.

To this end, this PR adds a templating mechanism for golden files.