### PR TITLE
Avoid substitution issue in kustomize for azure credentials sync

### DIFF
--- a/manifests/integrations/registry-credentials-sync/azure/reconcile-patch.yaml
+++ b/manifests/integrations/registry-credentials-sync/azure/reconcile-patch.yaml
@@ -17,13 +17,13 @@ spec:
               echo "Starting ACR token sync -- $(date)"
               echo "Logging into Azure"
               az login --identity
-              echo "Logging into ACR: ${ACR_NAME}"
-              output="$(az acr login --expose-token -o=tsv -n "${ACR_NAME}")"
-              read token server <<< "${output}"
+              echo "Logging into ACR: $ACR_NAME"
+              output="$(az acr login --expose-token -o=tsv -n "$ACR_NAME")"
+              read token server <<< "$output"
               user="00000000-0000-0000-0000-000000000000"
 
-              echo "Creating secret: ${KUBE_SECRET}"
-              apply-secret "${KUBE_SECRET}" "${token}" "${user}" "${server}"
+              echo "Creating secret: $KUBE_SECRET"
+              apply-secret "$KUBE_SECRET" "$token" "$user" "$server"
 
               echo "Finished ACR token sync -- $(date)"
               echo


### PR DESCRIPTION
https://fluxcd.io/docs/components/kustomize/kustomization/#variable-substitution

> Note that if you want to avoid var substitutions in scripts embedded in ConfigMaps or container commands, you must use the format $var instead of ${var}. All the undefined variables in the format ${var} will be substituted with string empty, unless a default is provided e.g. ${var:=default}.

https://cloud-native.slack.com/archives/CLAJ40HV3/p1629301869218600?thread_ts=1629215863.169600&cid=CLAJ40HV3