### PR TITLE
Make test harness more flexible with functions

### DIFF
--- a/cmd/flux/check_test.go
+++ b/cmd/flux/check_test.go
@@ -28,13 +28,11 @@ func TestCheckPre(t *testing.T) {
 
 	cmd := cmdTestCase{
 		args:            "check --pre",
-		wantError:       false,
 		testClusterMode: ExistingClusterMode,
-		templateValues: map[string]string{
+		assert: assertGoldenTemplateFile("testdata/check/check_pre.golden", map[string]string{
 			"clientVersion": clientVersion,
 			"serverVersion": serverVersion,
-		},
-		goldenFile: "testdata/check/check_pre.golden",
+		}),
 	}
 	cmd.runTestCmd(t)
 }

--- a/cmd/flux/helmrelease_test.go
+++ b/cmd/flux/helmrelease_test.go
@@ -49,7 +49,7 @@ func TestHelmReleaseFromGit(t *testing.T) {
 	for _, tc := range cases {
 		cmd := cmdTestCase{
 			args:            tc.args + " -n=" + namespace,
-			goldenFile:      tc.goldenFile,
+			assert:          assertGoldenFile(tc.goldenFile),
 			testClusterMode: ExistingClusterMode,
 		}
 		cmd.runTestCmd(t)

--- a/cmd/flux/image_test.go
+++ b/cmd/flux/image_test.go
@@ -41,7 +41,7 @@ func TestImageScanning(t *testing.T) {
 	for _, tc := range cases {
 		cmd := cmdTestCase{
 			args:            tc.args + " -n=" + namespace,
-			goldenFile:      tc.goldenFile,
+			assert:          assertGoldenFile(tc.goldenFile),
 			testClusterMode: ExistingClusterMode,
 		}
 		cmd.runTestCmd(t)

--- a/cmd/flux/kustomization_test.go
+++ b/cmd/flux/kustomization_test.go
@@ -49,7 +49,7 @@ func TestKustomizationFromGit(t *testing.T) {
 	for _, tc := range cases {
 		cmd := cmdTestCase{
 			args:            tc.args + " -n=" + namespace,
-			goldenFile:      tc.goldenFile,
+			assert:          assertGoldenFile(tc.goldenFile),
 			testClusterMode: ExistingClusterMode,
 		}
 		cmd.runTestCmd(t)

--- a/cmd/flux/trace_test.go
+++ b/cmd/flux/trace_test.go
@@ -10,8 +10,7 @@ func TestTraceNoArgs(t *testing.T) {
 	cmd := cmdTestCase{
 		args:            "trace",
 		testClusterMode: TestEnvClusterMode,
-		wantError:       true,
-		goldenValue:     "object name is required",
+		assert:          assertError("object name is required"),
 	}
 	cmd.runTestCmd(t)
 }
@@ -20,8 +19,7 @@ func TestTraceDeployment(t *testing.T) {
 	cmd := cmdTestCase{
 		args:            "trace podinfo -n podinfo --kind deployment --api-version=apps/v1",
 		testClusterMode: TestEnvClusterMode,
-		wantError:       false,
-		goldenFile:      "testdata/trace/deployment.txt",
+		assert:          assertGoldenFile("testdata/trace/deployment.txt"),
 		objectFile:      "testdata/trace/deployment.yaml",
 	}
 	cmd.runTestCmd(t)
@@ -31,8 +29,7 @@ func TestTraceHelmRelease(t *testing.T) {
 	cmd := cmdTestCase{
 		args:            "trace podinfo -n podinfo --kind HelmRelease --api-version=helm.toolkit.fluxcd.io/v2beta1",
 		testClusterMode: TestEnvClusterMode,
-		wantError:       false,
-		goldenFile:      "testdata/trace/helmrelease.txt",
+		assert:          assertGoldenFile("testdata/trace/helmrelease.txt"),
 		objectFile:      "testdata/trace/helmrelease.yaml",
 	}
 	cmd.runTestCmd(t)

--- a/cmd/flux/version_test.go
+++ b/cmd/flux/version_test.go
@@ -10,7 +10,7 @@ func TestVersion(t *testing.T) {
 	cmd := cmdTestCase{
 		args:            "--version",
 		testClusterMode: TestEnvClusterMode,
-		goldenValue:     "flux version 0.0.0-dev.0\n",
+		assert:          assertGoldenValue("flux version 0.0.0-dev.0\n"),
 	}
 	cmd.runTestCmd(t)
 }


### PR DESCRIPTION
Replace the 4 arguments to cmdTestCase with a function that
can let tests run arbitrary logic if it is more complex than
what is provided by the test harness. Move the existing logic
into functions that the test can use for common checks on
golden files and golden values.

These changes were pulled out of PR #1696 to make a smaller review.