### PR TITLE
Use shared envTest for unit tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,16 @@ You can run the unit tests by simply doing
 make test
 ```
 
+The e2e test suite uses [kind](https://kind.sigs.k8s.io/) for running kubernetes cluster inside docker containers. You can run the e2e tests by simply doing
+
+```bash
+make setup-kind
+make e2e
+
+# When done
+make cleanup-kind
+```
+
 ## Acceptance policy
 
 These things will make a PR more likely to be accepted:

--- a/cmd/flux/check_test.go
+++ b/cmd/flux/check_test.go
@@ -27,8 +27,7 @@ func TestCheckPre(t *testing.T) {
 	serverVersion := strings.TrimPrefix(versions["serverVersion"].GitVersion, "v")
 
 	cmd := cmdTestCase{
-		args:            "check --pre",
-		testClusterMode: ExistingClusterMode,
+		args: "check --pre",
 		assert: assertGoldenTemplateFile("testdata/check/check_pre.golden", map[string]string{
 			"clientVersion": clientVersion,
 			"serverVersion": serverVersion,

--- a/cmd/flux/helmrelease_test.go
+++ b/cmd/flux/helmrelease_test.go
@@ -39,7 +39,7 @@ func TestHelmReleaseFromGit(t *testing.T) {
 		},
 	}
 
-	namespace := "thrfg"
+	namespace := allocateNamespace("thrfg")
 	del, err := setupTestNamespace(namespace)
 	if err != nil {
 		t.Fatal(err)
@@ -48,9 +48,8 @@ func TestHelmReleaseFromGit(t *testing.T) {
 
 	for _, tc := range cases {
 		cmd := cmdTestCase{
-			args:            tc.args + " -n=" + namespace,
-			assert:          assertGoldenFile(tc.goldenFile),
-			testClusterMode: ExistingClusterMode,
+			args:   tc.args + " -n=" + namespace,
+			assert: assertGoldenTemplateFile(tc.goldenFile, map[string]string{"ns": namespace}),
 		}
 		cmd.runTestCmd(t)
 	}

--- a/cmd/flux/image_test.go
+++ b/cmd/flux/image_test.go
@@ -31,7 +31,7 @@ func TestImageScanning(t *testing.T) {
 		},
 	}
 
-	namespace := "tis"
+	namespace := allocateNamespace("tis")
 	del, err := setupTestNamespace(namespace)
 	if err != nil {
 		t.Fatal(err)
@@ -40,9 +40,8 @@ func TestImageScanning(t *testing.T) {
 
 	for _, tc := range cases {
 		cmd := cmdTestCase{
-			args:            tc.args + " -n=" + namespace,
-			assert:          assertGoldenFile(tc.goldenFile),
-			testClusterMode: ExistingClusterMode,
+			args:   tc.args + " -n=" + namespace,
+			assert: assertGoldenFile(tc.goldenFile),
 		}
 		cmd.runTestCmd(t)
 	}

--- a/cmd/flux/kustomization_test.go
+++ b/cmd/flux/kustomization_test.go
@@ -39,7 +39,7 @@ func TestKustomizationFromGit(t *testing.T) {
 		},
 	}
 
-	namespace := "tkfg"
+	namespace := allocateNamespace("tkfg")
 	del, err := setupTestNamespace(namespace)
 	if err != nil {
 		t.Fatal(err)
@@ -48,9 +48,8 @@ func TestKustomizationFromGit(t *testing.T) {
 
 	for _, tc := range cases {
 		cmd := cmdTestCase{
-			args:            tc.args + " -n=" + namespace,
-			assert:          assertGoldenFile(tc.goldenFile),
-			testClusterMode: ExistingClusterMode,
+			args:   tc.args + " -n=" + namespace,
+			assert: assertGoldenTemplateFile(tc.goldenFile, map[string]string{"ns": namespace}),
 		}
 		cmd.runTestCmd(t)
 	}

--- a/cmd/flux/main_e2e_test.go
+++ b/cmd/flux/main_e2e_test.go
@@ -15,12 +15,13 @@ func TestMain(m *testing.M) {
 	// Ensure tests print consistent timestamps regardless of timezone
 	os.Setenv("TZ", "UTC")
 
-	// Install Flux.
-	// Creating the test env manager sets rootArgs client flags
-	_, err := NewTestEnvKubeManager(ExistingClusterMode)
+	testEnv, err := NewTestEnvKubeManager(ExistingClusterMode)
 	if err != nil {
 		panic(fmt.Errorf("error creating kube manager: '%w'", err))
 	}
+	rootArgs.kubeconfig = testEnv.kubeConfigPath
+
+	// Install Flux.
 	output, err := executeCommand("install --components-extra=image-reflector-controller,image-automation-controller")
 	if err != nil {
 		panic(fmt.Errorf("install falied: %s error:'%w'", output, err))
@@ -41,6 +42,8 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		panic(fmt.Errorf("delete namespace error:'%w'", err))
 	}
+
+	testEnv.Stop()
 
 	os.Exit(code)
 }

--- a/cmd/flux/main_unit_test.go
+++ b/cmd/flux/main_unit_test.go
@@ -3,12 +3,32 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"testing"
 )
 
+// The test environment is long running process shared between tests, initialized
+// by a `TestMain` function depending on how the test is involved and which tests
+// are a part of the build.
+var testEnv *testEnvKubeManager
+
 func TestMain(m *testing.M) {
 	// Ensure tests print consistent timestamps regardless of timezone
 	os.Setenv("TZ", "UTC")
-	os.Exit(m.Run())
+
+	// Creating the test env manager sets rootArgs client flags
+	km, err := NewTestEnvKubeManager(TestEnvClusterMode)
+	if err != nil {
+		panic(fmt.Errorf("error creating kube manager: '%w'", err))
+	}
+	testEnv = km
+	rootArgs.kubeconfig = testEnv.kubeConfigPath
+
+	// Run tests
+	code := m.Run()
+
+	km.Stop()
+
+	os.Exit(code)
 }

--- a/cmd/flux/testdata/helmrelease/delete_helmrelease_from_git.golden
+++ b/cmd/flux/testdata/helmrelease/delete_helmrelease_from_git.golden
@@ -1,2 +1,2 @@
-► deleting helmreleases thrfg in thrfg namespace
+► deleting helmreleases thrfg in {{ .ns }} namespace
 ✔ helmreleases deleted

--- a/cmd/flux/testdata/helmrelease/reconcile_helmrelease_from_git.golden
+++ b/cmd/flux/testdata/helmrelease/reconcile_helmrelease_from_git.golden
@@ -1,9 +1,9 @@
-► annotating GitRepository thrfg in thrfg namespace
+► annotating GitRepository thrfg in {{ .ns }} namespace
 ✔ GitRepository annotated
 ◎ waiting for GitRepository reconciliation
 ✔ GitRepository reconciliation completed
 ✔ fetched revision 6.0.0/627d5c4bb67b77185f37e31d734b085019ff2951
-► annotating HelmRelease thrfg in thrfg namespace
+► annotating HelmRelease thrfg in {{ .ns }} namespace
 ✔ HelmRelease annotated
 ◎ waiting for HelmRelease reconciliation
 ✔ HelmRelease reconciliation completed

--- a/cmd/flux/testdata/helmrelease/resume_helmrelease_from_git.golden
+++ b/cmd/flux/testdata/helmrelease/resume_helmrelease_from_git.golden
@@ -1,4 +1,4 @@
-► resuming helmreleases thrfg in thrfg namespace
+► resuming helmreleases thrfg in {{ .ns }} namespace
 ✔ helmreleases resumed
 ◎ waiting for HelmRelease reconciliation
 ✔ HelmRelease reconciliation completed

--- a/cmd/flux/testdata/helmrelease/suspend_helmrelease_from_git.golden
+++ b/cmd/flux/testdata/helmrelease/suspend_helmrelease_from_git.golden
@@ -1,2 +1,2 @@
-► suspending helmreleases thrfg in thrfg namespace
+► suspending helmreleases thrfg in {{ .ns }} namespace
 ✔ helmreleases suspended

--- a/cmd/flux/testdata/kustomization/delete_kustomization_from_git.golden
+++ b/cmd/flux/testdata/kustomization/delete_kustomization_from_git.golden
@@ -1,2 +1,2 @@
-► deleting kustomizations tkfg in tkfg namespace
+► deleting kustomizations tkfg in {{ .ns }} namespace
 ✔ kustomizations deleted

--- a/cmd/flux/testdata/kustomization/reconcile_kustomization_from_git.golden
+++ b/cmd/flux/testdata/kustomization/reconcile_kustomization_from_git.golden
@@ -1,9 +1,9 @@
-► annotating GitRepository tkfg in tkfg namespace
+► annotating GitRepository tkfg in {{ .ns }} namespace
 ✔ GitRepository annotated
 ◎ waiting for GitRepository reconciliation
 ✔ GitRepository reconciliation completed
 ✔ fetched revision 6.0.0/627d5c4bb67b77185f37e31d734b085019ff2951
-► annotating Kustomization tkfg in tkfg namespace
+► annotating Kustomization tkfg in {{ .ns }} namespace
 ✔ Kustomization annotated
 ◎ waiting for Kustomization reconciliation
 ✔ Kustomization reconciliation completed

--- a/cmd/flux/testdata/kustomization/resume_kustomization_from_git.golden
+++ b/cmd/flux/testdata/kustomization/resume_kustomization_from_git.golden
@@ -1,4 +1,4 @@
-► resuming kustomizations tkfg in tkfg namespace
+► resuming kustomizations tkfg in {{ .ns }} namespace
 ✔ kustomizations resumed
 ◎ waiting for Kustomization reconciliation
 ✔ Kustomization reconciliation completed

--- a/cmd/flux/testdata/kustomization/suspend_kustomization_from_git.golden
+++ b/cmd/flux/testdata/kustomization/suspend_kustomization_from_git.golden
@@ -1,2 +1,2 @@
-► suspending kustomizations tkfg in tkfg namespace
+► suspending kustomizations tkfg in {{ .ns }} namespace
 ✔ kustomizations suspended

--- a/cmd/flux/testdata/trace/deployment.golden
+++ b/cmd/flux/testdata/trace/deployment.golden
@@ -1,16 +1,16 @@
 
 Object:         deployment/podinfo
-Namespace:      podinfo
+Namespace:      {{ .ns }}
 Status:         Managed by Flux
 ---
 HelmRelease:    podinfo
-Namespace:      podinfo
+Namespace:      {{ .ns }}
 Revision:       6.0.0
 Status:         Last reconciled at 2021-07-16 15:42:20 +0000 UTC
 Message:        Release reconciliation succeeded
 ---
 HelmChart:      podinfo-podinfo
-Namespace:      flux-system
+Namespace:      {{ .fluxns }}
 Chart:          podinfo
 Version:        6.0.0
 Revision:       6.0.0
@@ -18,7 +18,7 @@ Status:         Last reconciled at 2021-07-16 15:32:09 +0000 UTC
 Message:        Fetched revision: 6.0.0
 ---
 HelmRepository: podinfo
-Namespace:      flux-system
+Namespace:      {{ .fluxns }}
 URL:            https://stefanprodan.github.io/podinfo
 Revision:       8411f23d07d3701f0e96e7d9e503b7936d7e1d56
 Status:         Last reconciled at 2021-07-11 00:25:46 +0000 UTC

--- a/cmd/flux/testdata/trace/deployment.yaml
+++ b/cmd/flux/testdata/trace/deployment.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: flux-system
+  name: {{ .fluxns }}
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: podinfo
+  name: {{ .ns }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -15,11 +15,10 @@ metadata:
   labels:
     app.kubernetes.io/name: podinfo
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: podinfo
     helm.toolkit.fluxcd.io/name: podinfo
-    helm.toolkit.fluxcd.io/namespace: podinfo
+    helm.toolkit.fluxcd.io/namespace: {{ .ns }}
   name: podinfo
-  namespace: podinfo
+  namespace: {{ .ns }}
 spec:
   replicas: 1
   selector:
@@ -40,9 +39,9 @@ kind: HelmRelease
 metadata:
   labels:
     kustomize.toolkit.fluxcd.io/name: infrastructure
-    kustomize.toolkit.fluxcd.io/namespace: flux-system
+    kustomize.toolkit.fluxcd.io/namespace: {{ .fluxns }}
   name: podinfo
-  namespace: podinfo
+  namespace: {{ .ns }}
 spec:
   chart:
     spec:
@@ -50,7 +49,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: podinfo
-        namespace: flux-system
+        namespace: {{ .fluxns }}
   interval: 5m
 status:
   conditions:
@@ -59,7 +58,7 @@ status:
     reason: ReconciliationSucceeded
     status: "True"
     type: Ready
-  helmChart: flux-system/podinfo-podinfo
+  helmChart: {{ .fluxns }}/podinfo-podinfo
   lastAppliedRevision: 6.0.0
   lastAttemptedRevision: 6.0.0
   lastAttemptedValuesChecksum: c31db75d05b7515eba2eef47bd71038c74b2e531
@@ -68,7 +67,7 @@ apiVersion: source.toolkit.fluxcd.io/v1beta1
 kind: HelmChart
 metadata:
   name: podinfo-podinfo
-  namespace: flux-system
+  namespace: {{ .fluxns }}
 spec:
   chart: podinfo
   sourceRef:
@@ -98,7 +97,7 @@ metadata:
     kustomize.toolkit.fluxcd.io/name: infrastructure
     kustomize.toolkit.fluxcd.io/namespace: flux-system
   name: podinfo
-  namespace: flux-system
+  namespace: {{ .fluxns }}
 spec:
   interval: 5m
   timeout: 1m0s
@@ -121,7 +120,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
 kind: Kustomization
 metadata:
   name: infrastructure
-  namespace: flux-system
+  namespace: {{ .fluxns }}
 spec:
   path: ./infrastructure/
   sourceRef:
@@ -143,9 +142,9 @@ kind: GitRepository
 metadata:
   labels:
     kustomize.toolkit.fluxcd.io/name: flux-system
-    kustomize.toolkit.fluxcd.io/namespace: flux-system
+    kustomize.toolkit.fluxcd.io/namespace: {{ .fluxns }}
   name: flux-system
-  namespace: flux-system
+  namespace: {{ .fluxns }}
 spec:
   gitImplementation: go-git
   ref:

--- a/cmd/flux/testdata/trace/helmrelease.golden
+++ b/cmd/flux/testdata/trace/helmrelease.golden
@@ -1,17 +1,17 @@
 
 Object:        HelmRelease/podinfo
-Namespace:     podinfo
+Namespace:     {{ .ns }}
 Status:        Managed by Flux
 ---
 Kustomization: infrastructure
-Namespace:     flux-system
+Namespace:     {{ .fluxns }}
 Path:          ./infrastructure
 Revision:      main/696f056df216eea4f9401adbee0ff744d4df390f
 Status:        Last reconciled at 2021-08-01 04:52:56 +0000 UTC
 Message:       Applied revision: main/696f056df216eea4f9401adbee0ff744d4df390f
 ---
 GitRepository: flux-system
-Namespace:     flux-system
+Namespace:     {{ .fluxns }}
 URL:           ssh://git@github.com/example/repo
 Branch:        main
 Revision:      main/696f056df216eea4f9401adbee0ff744d4df390f

--- a/cmd/flux/testdata/trace/helmrelease.yaml
+++ b/cmd/flux/testdata/trace/helmrelease.yaml
@@ -2,21 +2,21 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: flux-system
+  name: {{ .fluxns }}
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: podinfo
+  name: {{ .ns }}
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   labels:
     kustomize.toolkit.fluxcd.io/name: infrastructure
-    kustomize.toolkit.fluxcd.io/namespace: flux-system
+    kustomize.toolkit.fluxcd.io/namespace: {{ .fluxns }}
   name: podinfo
-  namespace: podinfo
+  namespace: {{ .ns }}
 spec:
   chart:
     spec:
@@ -24,7 +24,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: podinfo
-        namespace: flux-system
+        namespace: {{ .fluxns }}
   interval: 5m
 status:
   conditions:
@@ -33,7 +33,7 @@ status:
     reason: ReconciliationSucceeded
     status: "True"
     type: Ready
-  helmChart: flux-system/podinfo-podinfo
+  helmChart: {{ .fluxns }}/podinfo-podinfo
   lastAppliedRevision: 6.0.0
   lastAttemptedRevision: 6.0.0
   lastAttemptedValuesChecksum: c31db75d05b7515eba2eef47bd71038c74b2e531
@@ -42,7 +42,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
 kind: Kustomization
 metadata:
   name: infrastructure
-  namespace: flux-system
+  namespace: {{ .fluxns }}
 spec:
   path: ./infrastructure
   sourceRef:
@@ -65,9 +65,9 @@ kind: GitRepository
 metadata:
   labels:
     kustomize.toolkit.fluxcd.io/name: flux-system
-    kustomize.toolkit.fluxcd.io/namespace: flux-system
+    kustomize.toolkit.fluxcd.io/namespace: {{ .fluxns }}
   name: flux-system
-  namespace: flux-system
+  namespace: {{ .fluxns }}
 spec:
   gitImplementation: go-git
   ref:

--- a/cmd/flux/version_test.go
+++ b/cmd/flux/version_test.go
@@ -8,9 +8,8 @@ import (
 
 func TestVersion(t *testing.T) {
 	cmd := cmdTestCase{
-		args:            "--version",
-		testClusterMode: TestEnvClusterMode,
-		assert:          assertGoldenValue("flux version 0.0.0-dev.0\n"),
+		args:   "--version",
+		assert: assertGoldenValue("flux version 0.0.0-dev.0\n"),
 	}
 	cmd.runTestCmd(t)
 }


### PR DESCRIPTION
Speed up unit tests by using a shared envTest. This requires each
test to use its own namespace to avoid clobbering objects for
other tests. Tests previously took around 8 seconds each, and now
the initial test takes 2 seconds with follow up tests taking less
than a second each.

Share gold file template function with yaml files.

Remove the testClusterMode, and instead rely on MainTest to do
the appropriate test setup and rootArgs flag setup. Move the
rootArg flag setup out of NewTestEnvKubeManager to avoid
side effects.

A follow up change can be to push the individual setups
from NewTestEnvKubeManager() into their respective TestMain since
the harness share little code.