### PR TITLE
feat: enable bootstrap with custom CA locally

### DIFF
--- a/cmd/flux/bootstrap_git.go
+++ b/cmd/flux/bootstrap_git.go
@@ -19,7 +19,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"strings"
@@ -203,7 +202,7 @@ func bootstrapGitCmdRun(cmd *cobra.Command, args []string) error {
 	var caBundle []byte
 	if bootstrapArgs.caFile != "" {
 		var err error
-		caBundle, err = ioutil.ReadFile(bootstrapArgs.caFile)
+		caBundle, err = os.ReadFile(bootstrapArgs.caFile)
 		if err != nil {
 			return fmt.Errorf("unable to read TLS CA file: %w", err)
 		}

--- a/cmd/flux/bootstrap_git.go
+++ b/cmd/flux/bootstrap_git.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"net/url"
 	"os"
 	"strings"
@@ -199,6 +200,15 @@ func bootstrapGitCmdRun(cmd *cobra.Command, args []string) error {
 		RecurseSubmodules: bootstrapArgs.recurseSubmodules,
 	}
 
+	var caBundle []byte
+	if bootstrapArgs.caFile != "" {
+		var err error
+		caBundle, err = ioutil.ReadFile(bootstrapArgs.caFile)
+		if err != nil {
+			return fmt.Errorf("unable to read TLS CA file: %w", err)
+		}
+	}
+
 	// Bootstrap config
 	bootstrapOpts := []bootstrap.GitOption{
 		bootstrap.WithRepositoryURL(gitArgs.url),
@@ -208,6 +218,7 @@ func bootstrapGitCmdRun(cmd *cobra.Command, args []string) error {
 		bootstrap.WithKubeconfig(rootArgs.kubeconfig, rootArgs.kubecontext),
 		bootstrap.WithPostGenerateSecretFunc(promptPublicKey),
 		bootstrap.WithLogger(logger),
+		bootstrap.WithCABundle(caBundle),
 	}
 
 	// Setup bootstrapper with constructed configs

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -47,7 +47,7 @@ type Reconciler interface {
 	// manifests with the provided values, committing them to Git and
 	// pushing to remote if there are any changes, and applying them
 	// to the cluster.
-	ReconcileComponents(ctx context.Context, manifestsBase string, options install.Options) error
+	ReconcileComponents(ctx context.Context, manifestsBase string, options install.Options, secretOpts sourcesecret.Options) error
 
 	// ReconcileSourceSecret reconciles the source secret by generating
 	// a new secret with the provided values if the secret does not
@@ -87,7 +87,7 @@ func Run(ctx context.Context, reconciler Reconciler, manifestsBase string,
 		}
 	}
 
-	if err := reconciler.ReconcileComponents(ctx, manifestsBase, installOpts); err != nil {
+	if err := reconciler.ReconcileComponents(ctx, manifestsBase, installOpts, secretOpts); err != nil {
 		return err
 	}
 	if err := reconciler.ReconcileSourceSecret(ctx, secretOpts); err != nil {

--- a/internal/bootstrap/git/git.go
+++ b/internal/bootstrap/git/git.go
@@ -42,10 +42,10 @@ type Commit struct {
 // remote repository.
 type Git interface {
 	Init(url, branch string) (bool, error)
-	Clone(ctx context.Context, url, branch string) (bool, error)
+	Clone(ctx context.Context, url, branch string, caBundle []byte) (bool, error)
 	Write(path string, reader io.Reader) error
 	Commit(message Commit) (string, error)
-	Push(ctx context.Context) error
+	Push(ctx context.Context, caBundle []byte) error
 	Status() (bool, error)
 	Head() (string, error)
 	Path() string

--- a/internal/bootstrap/git/gogit/gogit.go
+++ b/internal/bootstrap/git/gogit/gogit.go
@@ -82,7 +82,7 @@ func (g *GoGit) Init(url, branch string) (bool, error) {
 	return true, nil
 }
 
-func (g *GoGit) Clone(ctx context.Context, url, branch string) (bool, error) {
+func (g *GoGit) Clone(ctx context.Context, url, branch string, caBundle []byte) (bool, error) {
 	branchRef := plumbing.NewBranchReferenceName(branch)
 	r, err := gogit.PlainCloneContext(ctx, g.path, false, &gogit.CloneOptions{
 		URL:           url,
@@ -94,6 +94,7 @@ func (g *GoGit) Clone(ctx context.Context, url, branch string) (bool, error) {
 		NoCheckout: false,
 		Progress:   nil,
 		Tags:       gogit.NoTags,
+		CABundle:   caBundle,
 	})
 	if err != nil {
 		if err == transport.ErrEmptyRemoteRepository || isRemoteBranchNotFoundErr(err, branchRef.String()) {
@@ -185,7 +186,7 @@ func (g *GoGit) Commit(message git.Commit) (string, error) {
 	return commit.String(), nil
 }
 
-func (g *GoGit) Push(ctx context.Context) error {
+func (g *GoGit) Push(ctx context.Context, caBundle []byte) error {
 	if g.repository == nil {
 		return git.ErrNoGitRepository
 	}
@@ -194,6 +195,7 @@ func (g *GoGit) Push(ctx context.Context) error {
 		RemoteName: gogit.DefaultRemoteName,
 		Auth:       g.auth,
 		Progress:   nil,
+		CABundle:   caBundle,
 	})
 }
 


### PR DESCRIPTION
When a user provided the `--ca-file` flag to the `bootstrap` command,
the given CA file wasn't taken into account for cloning the repository
locally. It was just passed along to the CR that is created so Flux
can make use of it when cloning the repository in-cluster.

However, users may not want to add a custom CA to their local host's
trust chain and may expect the `--ca-file` flag to be respected also
for cloning the repository locally. This is what this commit
accomplishes.

closes #1775

Signed-off-by: Max Jonas Werner <mail@makk.es>