### PR TITLE
Fix Bucket SecretRef mapping

### DIFF
--- a/cmd/flux/create_source_bucket.go
+++ b/cmd/flux/create_source_bucket.go
@@ -134,7 +134,7 @@ func createSourceBucketCmdRun(cmd *cobra.Command, args []string) error {
 			},
 		},
 	}
-	if sourceHelmArgs.secretRef != "" {
+	if sourceBucketArgs.secretRef != "" {
 		bucket.Spec.SecretRef = &meta.LocalObjectReference{
 			Name: sourceBucketArgs.secretRef,
 		}


### PR DESCRIPTION
Found a bug while creating a bucket source with the ```--secret-ref``` Flag.

Signed-off-by: Fynn Späker <spaeker@23technologies.cloud>