### PR TITLE
Use a file to record successful manifests build

### DIFF
--- a/.github/workflows/bootstrap.yaml
+++ b/.github/workflows/bootstrap.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: fluxcd/pkg//actions/kustomize@main
       - name: Build
         run: |
-          make cmd/flux/manifests
+          make cmd/flux/.manifests.done
           go build -o /tmp/flux ./cmd/flux
       - name: Set outputs
         id: vars

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: fluxcd/pkg//actions/kustomize@main
       - name: Build manifests
         run: |
-          make cmd/flux/manifests
+          make cmd/flux/.manifests.done
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/golang@master
         continue-on-error: true

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ dist/
 bin/
 output/
 cmd/flux/manifests/
+cmd/flux/.manifests.done
 
 # Docs
 site/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION?=$(shell grep 'VERSION' cmd/flux/main.go | awk '{ print $$4 }' | head -n 1 | tr -d '"')
-EMBEDDED_MANIFESTS_TARGET=cmd/flux/manifests
+EMBEDDED_MANIFESTS_TARGET=cmd/flux/.manifests.done
 TEST_KUBECONFIG?=/tmp/flux-e2e-test-kubeconfig
 ENVTEST_BIN_VERSION?=latest
 KUBEBUILDER_ASSETS?="$(shell $(SETUP_ENVTEST) use -i $(ENVTEST_BIN_VERSION) -p path)"
@@ -46,6 +46,7 @@ test-with-kind: setup-envtest
 
 $(EMBEDDED_MANIFESTS_TARGET): $(call rwildcard,manifests/,*.yaml *.json)
 	./manifests/scripts/bundle.sh
+	touch $@
 
 build: $(EMBEDDED_MANIFESTS_TARGET)
 	CGO_ENABLED=0 go build -ldflags="-s -w -X main.VERSION=$(VERSION)" -o ./bin/flux ./cmd/flux


### PR DESCRIPTION
Using the directory cmd/flux/manifests as a prerequisite causes a problem: if the script that creates the files within fails, the next invocation of make will see the directory and assume it succeeded. Since the executable expects certain files to be present, but they are not explicit prerequisites of the recipe for building the binary, this results in a successful build but a broken `flux` executable.

Instead, depend on a file that's explicitly updated when the script has succeeded, and which itself depends on the inputs.
