### PR TITLE
fix: don't set 'Install' field by default in 'create hr'

### DIFF
--- a/cmd/flux/create_helmrelease.go
+++ b/cmd/flux/create_helmrelease.go
@@ -182,11 +182,14 @@ func createHelmReleaseCmdRun(cmd *cobra.Command, args []string) error {
 					},
 				},
 			},
-			Install: &helmv2.Install{
-				CreateNamespace: helmReleaseArgs.createNamespace,
-			},
 			Suspend: false,
 		},
+	}
+
+	if helmReleaseArgs.createNamespace {
+		helmRelease.Spec.Install = &helmv2.Install{
+			CreateNamespace: helmReleaseArgs.createNamespace,
+		}
 	}
 
 	if helmReleaseArgs.saName != "" {


### PR DESCRIPTION
This fixes the case where you create a HelmRelease with `--export` and
the `install: {}` field being there, adding no value to the manifest.

Context: https://cloud-native.slack.com/archives/CLAJ40HV3/p1631797885154100

Before:
```
$ ./bin/flux create hr podinfo --source HelmRepository/podinfo.flux-system --chart=podinfo --chart-version="4.0.x" --interval=1m --export
---
apiVersion: helm.toolkit.fluxcd.io/v2beta1
kind: HelmRelease
metadata:
  name: podinfo
  namespace: flux-system
spec:
  chart:
    spec:
      chart: podinfo
      sourceRef:
        kind: HelmRepository
        name: podinfo
        namespace: flux-system
      version: 4.0.x
  install: {}
  interval: 1m0s
```

After:
```
$ ./bin/flux create hr podinfo --source HelmRepository/podinfo.flux-system --chart=podinfo --chart-version="4.0.x" --interval=1m --export
---
apiVersion: helm.toolkit.fluxcd.io/v2beta1
kind: HelmRelease
metadata:
  name: podinfo
  namespace: flux-system
spec:
  chart:
    spec:
      chart: podinfo
      sourceRef:
        kind: HelmRepository
        name: podinfo
        namespace: flux-system
      version: 4.0.x
  interval: 1m0s
```
Signed-off-by: Max Jonas Werner <mail@makk.es>