### PR TITLE
Update Makefile target in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,7 +50,7 @@ jobs:
         uses: fluxcd/pkg//actions/kustomize@main
       - name: Generate manifests
         run: |
-          make cmd/flux/manifests
+          make cmd/flux/.manifests.done
           ./manifests/scripts/bundle.sh "" ./output manifests.tar.gz
           kustomize build ./manifests/install > ./output/install.yaml
       - name: Build CRDs


### PR DESCRIPTION
There's another location which uses the "manifests directory" target directly, but isn't run when testing a PR: the release workflow.
