### PR TITLE
Extend `--team` flag to include access level

### DIFF
--- a/cmd/flux/bootstrap.go
+++ b/cmd/flux/bootstrap.go
@@ -20,6 +20,7 @@ import (
 	"crypto/elliptic"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -174,6 +175,10 @@ func mapTeamSlice(s []string, defaultPermission string) map[string]string {
 	m := make(map[string]string, len(s))
 	for _, v := range s {
 		m[v] = defaultPermission
+		if s := strings.Split(v, ":"); len(s) == 2 {
+			m[s[0]] = s[1]
+		}
 	}
+
 	return m
 }

--- a/cmd/flux/bootstrap_github.go
+++ b/cmd/flux/bootstrap_github.go
@@ -52,6 +52,9 @@ the bootstrap command will perform an upgrade if needed.`,
   # Run bootstrap for a private repository and assign organization teams to it
   flux bootstrap github --owner=<organization> --repository=<repository name> --team=<team1 slug> --team=<team2 slug>
 
+  # Run bootstrap for a private repository and assign organization teams with their access level(e.g maintain, admin) to it
+  flux bootstrap github --owner=<organization> --repository=<repository name> --team=<team1 slug>:<access-level>
+
   # Run bootstrap for a repository path
   flux bootstrap github --owner=<organization> --repository=<repository name> --path=dev-cluster
 
@@ -93,7 +96,7 @@ var githubArgs githubFlags
 func init() {
 	bootstrapGitHubCmd.Flags().StringVar(&githubArgs.owner, "owner", "", "GitHub user or organization name")
 	bootstrapGitHubCmd.Flags().StringVar(&githubArgs.repository, "repository", "", "GitHub repository name")
-	bootstrapGitHubCmd.Flags().StringSliceVar(&githubArgs.teams, "team", []string{}, "GitHub team to be given maintainer access (also accepts comma-separated values)")
+	bootstrapGitHubCmd.Flags().StringSliceVar(&githubArgs.teams, "team", []string{}, "GitHub team and the access to be given to it(team:maintain). Defaults to maintainer access if no access level is specified (also accepts comma-separated values)")
 	bootstrapGitHubCmd.Flags().BoolVar(&githubArgs.personal, "personal", false, "if true, the owner is assumed to be a GitHub user; otherwise an org")
 	bootstrapGitHubCmd.Flags().BoolVar(&githubArgs.private, "private", true, "if true, the repository is setup or configured as private")
 	bootstrapGitHubCmd.Flags().DurationVar(&githubArgs.interval, "interval", time.Minute, "sync interval")

--- a/internal/bootstrap/bootstrap_provider.go
+++ b/internal/bootstrap/bootstrap_provider.go
@@ -318,6 +318,10 @@ func (b *GitProviderBootstrapper) reconcileOrgRepository(ctx context.Context) (g
 		b.logger.Actionf("reconciling repository permissions")
 		for _, i := range teamAccessInfo {
 			var err error
+			// Don't reconcile team if team already exists and b.reconcile is false
+			if team, err := repo.TeamAccess().Get(ctx, i.Name); err == nil && !b.reconcile && team != nil {
+				continue
+			}
 			_, changed, err = repo.TeamAccess().Reconcile(ctx, i)
 			if err != nil {
 				warning = fmt.Errorf("failed to grant permissions to team: %w", ErrReconciledWithWarning)


### PR DESCRIPTION
Fixes #1452 
This pull request doesn't reconcile a team if the team already exists and the reconcile flag wasn't passed in. 
It also adds a feature where a user can specify the level of access that can be given to a team through the `--team` flag. It maintains backwards compatibility by defaulting to maintainer access if no access level is specified.

Example
`flux bootstrap github --team=eng:admin` -> Gives eng team admin access
`flux bootstrap github --team=eng` -> Gives eng team maintainer access