### PR TITLE
Update Kubernetes version minimum requirements

### DIFF
--- a/cmd/flux/testdata/check/check_pre.golden
+++ b/cmd/flux/testdata/check/check_pre.golden
@@ -1,3 +1,3 @@
 ► checking prerequisites
-✔ Kubernetes {{ .serverVersion }} >=1.16.0-0
+✔ Kubernetes {{ .serverVersion }} >=1.19.0-0
 ✔ prerequisites checks passed


### PR DESCRIPTION
Update the `flux check` command to the new minimum supported version of Kubernetes required by server-side apply:

| Kubernetes version | Minimum required |
| --- | --- |
| `v1.16` | `>= 1.16.11` |
| `v1.17` | `>= 1.17.7` |
| `v1.18` | `>= 1.18.4` |
| `v1.19` and later | `>= 1.19.0` |

Part of: #1889 

⚠️ This PR is made against the `ssa` branch which is used to collect all SSA related changes.