### PR TITLE
Update kustomize-controller API to v1beta2

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -93,7 +93,6 @@ jobs:
             --path="./deploy/overlays/dev" \
             --prune=true \
             --interval=5m \
-            --validation=client \
             --health-check="Deployment/frontend.dev" \
             --health-check="Deployment/backend.dev" \
             --health-check-timeout=3m

--- a/cmd/flux/create_kustomization.go
+++ b/cmd/flux/create_kustomization.go
@@ -49,7 +49,6 @@ var createKsCmd = &cobra.Command{
     --path="./examples/contour/" \
     --prune=true \
     --interval=10m \
-    --validation=client \
     --health-check="Deployment/contour.projectcontour" \
     --health-check="DaemonSet/envoy.projectcontour" \
     --health-check-timeout=3m
@@ -60,8 +59,7 @@ var createKsCmd = &cobra.Command{
     --source=GitRepository/webapp \
     --path="./deploy/overlays/dev" \
     --prune=true \
-    --interval=5m \
-    --validation=client
+    --interval=5m
 
   # Create a Kustomization using a source from a different namespace
   flux create kustomization podinfo \
@@ -69,8 +67,7 @@ var createKsCmd = &cobra.Command{
     --source=GitRepository/podinfo.flux-system \
     --path="./deploy/overlays/dev" \
     --prune=true \
-    --interval=5m \
-    --validation=client
+    --interval=5m
 
   # Create a Kustomization resource that references a Bucket
   flux create kustomization secrets \
@@ -108,6 +105,8 @@ func init() {
 	createKsCmd.Flags().Var(&kustomizationArgs.decryptionProvider, "decryption-provider", kustomizationArgs.decryptionProvider.Description())
 	createKsCmd.Flags().StringVar(&kustomizationArgs.decryptionSecret, "decryption-secret", "", "set the Kubernetes secret name that contains the OpenPGP private keys used for sops decryption")
 	createKsCmd.Flags().StringVar(&kustomizationArgs.targetNamespace, "target-namespace", "", "overrides the namespace of all Kustomization objects reconciled by this Kustomization")
+	createKsCmd.Flags().MarkDeprecated("validation", "this arg is no longer used, all resources are validated using server-side apply dry-run")
+
 	createCmd.AddCommand(createKsCmd)
 }
 

--- a/cmd/flux/create_kustomization.go
+++ b/cmd/flux/create_kustomization.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
-	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta1"
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
 	"github.com/fluxcd/pkg/apis/meta"
 
 	"github.com/fluxcd/flux2/internal/flags"
@@ -158,7 +158,6 @@ func createKsCmdRun(cmd *cobra.Command, args []string) error {
 				Namespace: kustomizationArgs.source.Namespace,
 			},
 			Suspend:         false,
-			Validation:      kustomizationArgs.validation,
 			TargetNamespace: kustomizationArgs.targetNamespace,
 		},
 	}

--- a/cmd/flux/delete_kustomization.go
+++ b/cmd/flux/delete_kustomization.go
@@ -19,7 +19,7 @@ package main
 import (
 	"github.com/spf13/cobra"
 
-	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta1"
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
 )
 
 var deleteKsCmd = &cobra.Command{

--- a/cmd/flux/export_kustomization.go
+++ b/cmd/flux/export_kustomization.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta1"
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
 )
 
 var exportKsCmd = &cobra.Command{

--- a/cmd/flux/get_all.go
+++ b/cmd/flux/get_all.go
@@ -22,7 +22,7 @@ import (
 	"github.com/spf13/cobra"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
-	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta1"
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
 	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta1"
 )
 

--- a/cmd/flux/get_kustomization.go
+++ b/cmd/flux/get_kustomization.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta1"
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
 )
 
 var getKsCmd = &cobra.Command{

--- a/cmd/flux/kustomization.go
+++ b/cmd/flux/kustomization.go
@@ -19,7 +19,7 @@ package main
 import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta1"
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
 )
 
 // kustomizev1.Kustomization

--- a/cmd/flux/kustomization_test.go
+++ b/cmd/flux/kustomization_test.go
@@ -14,7 +14,7 @@ func TestKustomizationFromGit(t *testing.T) {
 			"testdata/kustomization/create_source_git.golden",
 		},
 		{
-			"create kustomization tkfg --source=tkfg --path=./deploy/overlays/dev --prune=true --interval=5m --validation=client --health-check=Deployment/frontend.dev --health-check=Deployment/backend.dev --health-check-timeout=3m",
+			"create kustomization tkfg --source=tkfg --path=./deploy/overlays/dev --prune=true --interval=5m --health-check=Deployment/frontend.dev --health-check=Deployment/backend.dev --health-check-timeout=3m",
 			"testdata/kustomization/create_kustomization_from_git.golden",
 		},
 		{

--- a/cmd/flux/main.go
+++ b/cmd/flux/main.go
@@ -43,7 +43,7 @@ Command line utility for assembling Kubernetes CD pipelines the GitOps way.`,
   flux check --pre
 
   # Install the latest version of Flux
-  flux install --version=master
+  flux install
 
   # Create a source for a public Git repository
   flux create source git webapp-latest \
@@ -66,7 +66,6 @@ Command line utility for assembling Kubernetes CD pipelines the GitOps way.`,
     --path="./deploy/webapp/" \
     --prune=true \
     --interval=5m \
-    --validation=client \
     --health-check="Deployment/backend.webapp" \
     --health-check="Deployment/frontend.webapp" \
     --health-check-timeout=2m

--- a/cmd/flux/reconcile_kustomization.go
+++ b/cmd/flux/reconcile_kustomization.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/types"
 
-	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta1"
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
 )
 

--- a/cmd/flux/resume_kustomization.go
+++ b/cmd/flux/resume_kustomization.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta1"
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
 )
 
 var resumeKsCmd = &cobra.Command{

--- a/cmd/flux/suspend_kustomization.go
+++ b/cmd/flux/suspend_kustomization.go
@@ -19,7 +19,7 @@ package main
 import (
 	"github.com/spf13/cobra"
 
-	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta1"
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
 )
 
 var suspendKsCmd = &cobra.Command{

--- a/cmd/flux/trace.go
+++ b/cmd/flux/trace.go
@@ -33,7 +33,7 @@ import (
 
 	"github.com/fluxcd/flux2/internal/utils"
 	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
-	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta1"
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
 	fluxmeta "github.com/fluxcd/pkg/apis/meta"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
 )

--- a/cmd/flux/uninstall.go
+++ b/cmd/flux/uninstall.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/fluxcd/flux2/internal/utils"
 	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
-	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta1"
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/fluxcd/helm-controller/api v0.11.2
 	github.com/fluxcd/image-automation-controller/api v0.14.1
 	github.com/fluxcd/image-reflector-controller/api v0.11.1
-	github.com/fluxcd/kustomize-controller/api v0.14.1
+	github.com/fluxcd/kustomize-controller/api v0.14.2-0.20211004114745-50c71354ab31
 	github.com/fluxcd/notification-controller/api v0.16.0
 	github.com/fluxcd/pkg/apis/meta v0.10.0
 	github.com/fluxcd/pkg/runtime v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -228,8 +228,8 @@ github.com/fluxcd/image-automation-controller/api v0.14.1 h1:8EDUs61Gi5HgSA9ou0r
 github.com/fluxcd/image-automation-controller/api v0.14.1/go.mod h1:22GZblh0CmaZItQpvCBe40i5ql/oCZllpLqkGmoglEQ=
 github.com/fluxcd/image-reflector-controller/api v0.11.1 h1:8pmUKL7Pise0JOBFgqw7eWtOK/rs3HNibXqCK9aJ8LE=
 github.com/fluxcd/image-reflector-controller/api v0.11.1/go.mod h1:lgQHGFz29OHmDU5Jwg689C/M+P/f9ujt6NS0zCLT0BQ=
-github.com/fluxcd/kustomize-controller/api v0.14.1 h1:OsErJQ3U3ReYTAtkeFo1t8UW4sjISF0a+6wsz942MT0=
-github.com/fluxcd/kustomize-controller/api v0.14.1/go.mod h1:3RNiEd/XnYjSTGzMqDzDbQkOYpdPFrKuS+XdgWt9pds=
+github.com/fluxcd/kustomize-controller/api v0.14.2-0.20211004114745-50c71354ab31 h1:BJgrqDyDcoqQNT7g5buHcJXMtKf+hR1id3wx8Tq1h/Q=
+github.com/fluxcd/kustomize-controller/api v0.14.2-0.20211004114745-50c71354ab31/go.mod h1:OhnZuXBeDl4NqbDZgpYKRg8nmsmeUIddH3vX8wxym9A=
 github.com/fluxcd/notification-controller/api v0.16.0 h1:3vaIj3AJRUA4dsfISuok8URV1RUmoe9NFpCAZ+tjOeU=
 github.com/fluxcd/notification-controller/api v0.16.0/go.mod h1:t28GMWMLiLqho+ikpZrldv22/vmCsFdQR8vdJluxknc=
 github.com/fluxcd/pkg/apis/kustomize v0.1.0/go.mod h1:gEl+W5cVykCC3RfrCaqe+Pz+j4lKl2aeR4dxsom/zII=

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta1"
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
 	"github.com/fluxcd/pkg/apis/meta"
 
 	"github.com/fluxcd/flux2/pkg/manifestgen/install"

--- a/internal/bootstrap/bootstrap_plain_git.go
+++ b/internal/bootstrap/bootstrap_plain_git.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/yaml"
 
-	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta1"
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
 
 	"github.com/fluxcd/flux2/internal/bootstrap/git"
 	"github.com/fluxcd/flux2/internal/utils"

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -45,7 +45,7 @@ import (
 	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
 	imageautov1 "github.com/fluxcd/image-automation-controller/api/v1beta1"
 	imagereflectv1 "github.com/fluxcd/image-reflector-controller/api/v1beta1"
-	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta1"
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
 	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta1"
 	"github.com/fluxcd/pkg/runtime/dependency"
 	"github.com/fluxcd/pkg/version"

--- a/manifests/bases/kustomize-controller/kustomization.yaml
+++ b/manifests/bases/kustomize-controller/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/fluxcd/kustomize-controller/releases/download/v0.14.1/kustomize-controller.crds.yaml
+- https://raw.githubusercontent.com/fluxcd/kustomize-controller/v1beta2/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
 - https://github.com/fluxcd/kustomize-controller/releases/download/v0.14.1/kustomize-controller.deployment.yaml
 - account.yaml
 patchesJson6902:
@@ -11,3 +11,7 @@ patchesJson6902:
     kind: Deployment
     name: kustomize-controller
   path: patch.yaml
+images:
+  - name: fluxcd/kustomize-controller
+    newName: fluxcd/kustomize-controller
+    newTag: v1beta2-50c71354

--- a/pkg/manifestgen/sync/sync.go
+++ b/pkg/manifestgen/sync/sync.go
@@ -26,7 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
-	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta1"
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
 	"github.com/fluxcd/pkg/apis/meta"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
 
@@ -85,7 +85,6 @@ func Generate(options Options) (*manifestgen.Manifest, error) {
 				Kind: sourcev1.GitRepositoryKind,
 				Name: options.Name,
 			},
-			Validation: "client",
 		},
 	}
 

--- a/pkg/manifestgen/sync/sync_test.go
+++ b/pkg/manifestgen/sync/sync_test.go
@@ -20,10 +20,11 @@ package sync
 
 import (
 	"fmt"
-	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta1"
-	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
 	"strings"
 	"testing"
+
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
 )
 
 func TestGenerate(t *testing.T) {

--- a/tests/azure/azure_test.go
+++ b/tests/azure/azure_test.go
@@ -30,7 +30,7 @@ import (
 
 	automationv1beta1 "github.com/fluxcd/image-automation-controller/api/v1beta1"
 	reflectorv1beta1 "github.com/fluxcd/image-reflector-controller/api/v1beta1"
-	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta1"
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
 	notiv1beta1 "github.com/fluxcd/notification-controller/api/v1beta1"
 	"github.com/fluxcd/pkg/apis/meta"
 	"github.com/fluxcd/pkg/runtime/events"

--- a/tests/azure/util_test.go
+++ b/tests/azure/util_test.go
@@ -23,7 +23,7 @@ import (
 	helmv2beta1 "github.com/fluxcd/helm-controller/api/v2beta1"
 	automationv1beta1 "github.com/fluxcd/image-automation-controller/api/v1beta1"
 	reflectorv1beta1 "github.com/fluxcd/image-reflector-controller/api/v1beta1"
-	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta1"
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
 	notiv1beta1 "github.com/fluxcd/notification-controller/api/v1beta1"
 	"github.com/fluxcd/pkg/apis/meta"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"


### PR DESCRIPTION
This PR updates the kustomize-controller API to v1beta2 from https://github.com/fluxcd/kustomize-controller/pull/426 and deprecates the `--validation` arg in `flux create kustomization` command.

⚠️ Note that the kustomize-controller container image is set to the release candidate build.

Part of: #1889 

⚠️ This PR is made against the `ssa` branch which is used to collect all SSA related changes.