### PR TITLE
Remove kubectl dependency from brew and aur pkgs 

### DIFF
--- a/.github/aur/flux-bin/.SRCINFO.template
+++ b/.github/aur/flux-bin/.SRCINFO.template
@@ -8,7 +8,6 @@ pkgbase = flux-bin
 	arch = armv7h
 	arch = aarch64
 	license = APACHE
-	optdepends = kubectl
 	source_x86_64 = flux-bin-${PKGVER}.tar.gz::https://github.com/fluxcd/flux2/releases/download/v1/flux_${PKGVER}_linux_amd64.tar.gz
 	source_armv6h = flux-bin-${PKGVER}.tar.gz::https://github.com/fluxcd/flux2/releases/download/v1/flux_${PKGVER}_linux_arm.tar.gz
 	source_armv7h = flux-bin-${PKGVER}.tar.gz::https://github.com/fluxcd/flux2/releases/download/v1/flux_${PKGVER}_linux_arm.tar.gz

--- a/.github/aur/flux-bin/PKGBUILD.template
+++ b/.github/aur/flux-bin/PKGBUILD.template
@@ -8,8 +8,7 @@ pkgdesc="Open and extensible continuous delivery solution for Kubernetes"
 url="https://fluxcd.io/"
 arch=("x86_64" "armv6h" "armv7h" "aarch64")
 license=("APACHE")
-optdepends=('kubectl: for apply actions on the Kubernetes cluster',
-'bash-completion: auto-completion for flux in Bash',
+optdepends=('bash-completion: auto-completion for flux in Bash',
 'zsh-completions: auto-completion for flux in ZSH')
 source_x86_64=(
   "${pkgname}-${pkgver}.tar.gz::https://github.com/fluxcd/flux2/releases/download/v${pkgver}/flux_${pkgver}_linux_amd64.tar.gz"

--- a/.github/aur/flux-go/.SRCINFO.template
+++ b/.github/aur/flux-go/.SRCINFO.template
@@ -10,7 +10,6 @@ pkgbase = flux-go
 	license = APACHE
 	makedepends = go
 	depends = glibc
-	optdepends = kubectl
 	provides = flux-bin
 	conflicts = flux-bin
   replaces = flux-cli

--- a/.github/aur/flux-go/PKGBUILD.template
+++ b/.github/aur/flux-go/PKGBUILD.template
@@ -13,8 +13,7 @@ conflicts=("flux-bin")
 replaces=("flux-cli")
 depends=("glibc")
 makedepends=('go>=1.16', 'kustomize>=3.0')
-optdepends=('kubectl: for apply actions on the Kubernetes cluster',
-'bash-completion: auto-completion for flux in Bash',
+optdepends=('bash-completion: auto-completion for flux in Bash',
 'zsh-completions: auto-completion for flux in ZSH')
 source=(
   "${pkgname}-${pkgver}.tar.gz::https://github.com/fluxcd/flux2/archive/v${pkgver}.tar.gz"

--- a/.github/aur/flux-scm/.SRCINFO.template
+++ b/.github/aur/flux-scm/.SRCINFO.template
@@ -10,7 +10,6 @@ pkgbase = flux-scm
 	license = APACHE
 	makedepends = go
 	depends = glibc
-	optdepends = kubectl
 	provides = flux-bin
 	conflicts = flux-bin
 	source = git+https://github.com/fluxcd/flux2.git

--- a/.github/aur/flux-scm/PKGBUILD.template
+++ b/.github/aur/flux-scm/PKGBUILD.template
@@ -12,8 +12,7 @@ provides=("flux-bin")
 conflicts=("flux-bin")
 depends=("glibc")
 makedepends=('go>=1.16', 'kustomize>=3.0')
-optdepends=('kubectl: for apply actions on the Kubernetes cluster',
-'bash-completion: auto-completion for flux in Bash',
+optdepends=('bash-completion: auto-completion for flux in Bash',
 'zsh-completions: auto-completion for flux in ZSH')
 source=(
   "git+https://github.com/fluxcd/flux2.git"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,9 +49,6 @@ brews:
     folder: Formula
     homepage: "https://fluxcd.io/"
     description: "Flux CLI"
-    dependencies:
-      - name: kubectl
-        type: optional
     install: |
       bin.install "flux"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.13 as builder
 RUN apk add --no-cache ca-certificates curl
 
 ARG ARCH=linux/amd64
-ARG KUBECTL_VER=1.20.4
+ARG KUBECTL_VER=1.22.2
 
 RUN curl -sL https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VER}/bin/${ARCH}/kubectl \
     -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl && \


### PR DESCRIPTION
This PR removes kubectl binary dependency from Homebrew and AUR packages. The kubectl binary packaged inside the flux-cli multi-arch container image was updated to  v1.22.2.

Part of: #1889 

⚠️ This PR is made against the `ssa` branch which is used to collect all SSA related changes.