### PR TITLE
Adapt event test for kustomize-controller v0.15

### DIFF
--- a/tests/azure/azure_test.go
+++ b/tests/azure/azure_test.go
@@ -814,7 +814,7 @@ func TestEventHubNotification(t *testing.T) {
 			if event.InvolvedObject.Kind != "Kustomization" {
 				return false
 			}
-			if event.Message != "Health check passed" {
+			if strings.Contains(event.Message, "Health check passed") {
 				return false
 			}
 			return true


### PR DESCRIPTION
The event "Health check passed" changed to "Health check passed in %d" in kustomize-controller v0.15