### PR TITLE
 Allow namespaces readonly access in crd-controller RBAC ClusterRole

### DIFF
--- a/manifests/rbac/controller.yaml
+++ b/manifests/rbac/controller.yaml
@@ -21,6 +21,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
   - secrets
   verbs:
   - get


### PR DESCRIPTION
Readonly access to namespaces is needed by the image-reflector-controller to support the cross-namespace accessFrom functionality introduced in fluxcd/image-reflector-controller#162.

This fixes the error `ImageRepository '<namespace>/<image repo>' can't be accessed due to missing access list` on `ImagePolicy` resources.

On a side note, I suppose we need to have a more fine-grained RBAC configuration on a per controller SA basis rather than a single CluserRole to adhere to the principle of least privilege. But this is probably something already on the roadmap.