### PR TITLE
Add part-of label to the static manifests

### DIFF
--- a/manifests/install/labels.yaml
+++ b/manifests/install/labels.yaml
@@ -3,6 +3,7 @@ kind: LabelTransformer
 metadata:
   name: labels
 labels:
+  app.kubernetes.io/part-of: flux
   app.kubernetes.io/instance: flux-system
 fieldSpecs:
   - path: metadata/labels


### PR DESCRIPTION
This PR adds `app.kubernetes.io/part-of: flux` label to the static install manifests.

Ref: #1894