### PR TITLE
feat: create view/edit ClusterRoles upon install

### DIFF
--- a/manifests/rbac/clusterroles.yaml
+++ b/manifests/rbac/clusterroles.yaml
@@ -1,0 +1,100 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: flux-view
+rules:
+- apiGroups:
+  - source.toolkit.fluxcd.io
+  resources:
+  - buckets
+  - gitrepositories
+  - helmcharts
+  - helmrepositories
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - notification.toolkit.fluxcd.io
+  resources:
+  - alerts
+  - providers
+  - receivers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kustomize.toolkit.fluxcd.io
+  resources:
+  - kustomizations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - helm.toolkit.fluxcd.io
+  resources:
+  - helmreleases
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: flux-edit
+rules:
+- apiGroups:
+  - source.toolkit.fluxcd.io
+  resources:
+  - buckets
+  - gitrepositories
+  - helmcharts
+  - helmrepositories
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - notification.toolkit.fluxcd.io
+  resources:
+  - alerts
+  - providers
+  - receivers
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - kustomize.toolkit.fluxcd.io
+  resources:
+  - kustomizations
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - helm.toolkit.fluxcd.io
+  resources:
+  - helmreleases
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update

--- a/manifests/rbac/kustomization.yaml
+++ b/manifests/rbac/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - controller.yaml
   - reconciler.yaml
+  - clusterroles.yaml


### PR DESCRIPTION
This way users can make use of these roles by having them
aggregated into the 'view', 'admin' and 'edit' ClusterRoles
present on Kubernetes clusters by default.

Without these roles you would have to bind subjects in a confined
Namespace to the `cluster-admin` ClusterRole which lets them create
cluster-scoped resources. To really confine subjects to a single
Namespace you would rather want to bind them to the `admin` or `edit`
ClusterRole so that they cannot create cluster-scoped resources. This
is where these new ClusterRoles created in this commit come into play,
letting subjects bound to one of these two ClusterRoles created Flux
CRDs such as HelmRelease or Kustomization.

Signed-off-by: Max Jonas Werner <mail@makk.es>