### PR TITLE
Makefile: set install target as phony

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,9 @@ $(EMBEDDED_MANIFESTS_TARGET): $(call rwildcard,manifests/,*.yaml *.json)
 build: $(EMBEDDED_MANIFESTS_TARGET)
 	CGO_ENABLED=0 go build -ldflags="-s -w -X main.VERSION=$(VERSION)" -o ./bin/flux ./cmd/flux
 
+.PHONY: install
 install:
-	go install cmd/flux
+	CGO_ENABLED=0 go install ./cmd/flux
 
 install-dev:
 	CGO_ENABLED=0 go build -o /usr/local/bin ./cmd/flux


### PR DESCRIPTION
`install/` directory results in make install target always up to date.
Mark `install` as phony to be able to run it.

`cmd/flux` as package argument to `go install` results in error:

```console
package cmd/flux is not in GOROOT
```

Replace `cmd/flux` with `./cmd/flux` for install to work and add
`CGO_ENABLED=0` like in other build and install targets.
