### PR TITLE
Fix infrastructure clean up on Azure e2e test failure

### DIFF
--- a/tests/azure/go.mod
+++ b/tests/azure/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/microsoft/azure-devops-go-api/azuredevops v1.0.0-b5
 	github.com/stretchr/testify v1.7.0
 	github.com/whilp/git-urls v1.0.0
+	go.uber.org/multierr v1.6.0
 	k8s.io/api v0.22.2
 	k8s.io/apimachinery v0.22.2
 	k8s.io/client-go v0.22.2


### PR DESCRIPTION
This change fixes the defer to make sure that the infrastructure is destroyed before ending the test. Additionally it adds a check that the state is clean before running the test, as running the tests from an already existing cluster may cause issues for the test.