### PR TITLE
Add poll interval flag to flux check cmd

### DIFF
--- a/cmd/flux/check.go
+++ b/cmd/flux/check.go
@@ -51,6 +51,7 @@ type checkFlags struct {
 	pre             bool
 	components      []string
 	extraComponents []string
+	pollInterval    time.Duration
 }
 
 var kubernetesConstraints = []string{
@@ -69,6 +70,8 @@ func init() {
 		"list of components, accepts comma-separated values")
 	checkCmd.Flags().StringSliceVar(&checkArgs.extraComponents, "components-extra", nil,
 		"list of components in addition to those supplied or defaulted, accepts comma-separated values")
+	checkCmd.Flags().DurationVar(&checkArgs.pollInterval, "poll-interval", 5*time.Second,
+		"how often the health checker should poll the cluster for the latest state of the resources.")
 	rootCmd.AddCommand(checkCmd)
 }
 
@@ -177,7 +180,7 @@ func componentsCheck() bool {
 		return false
 	}
 
-	statusChecker, err := status.NewStatusChecker(kubeConfig, time.Second, rootArgs.timeout, logger)
+	statusChecker, err := status.NewStatusChecker(kubeConfig, checkArgs.pollInterval, rootArgs.timeout, logger)
 	if err != nil {
 		return false
 	}

--- a/cmd/flux/install.go
+++ b/cmd/flux/install.go
@@ -206,7 +206,7 @@ func installCmdRun(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("install failed: %w", err)
 	}
-	statusChecker, err := status.NewStatusChecker(kubeConfig, time.Second, rootArgs.timeout, logger)
+	statusChecker, err := status.NewStatusChecker(kubeConfig, 5*time.Second, rootArgs.timeout, logger)
 	if err != nil {
 		return fmt.Errorf("install failed: %w", err)
 	}

--- a/internal/bootstrap/bootstrap_plain_git.go
+++ b/internal/bootstrap/bootstrap_plain_git.go
@@ -347,7 +347,7 @@ func (b *PlainGitBootstrapper) ReportComponentsHealth(ctx context.Context, insta
 		return err
 	}
 
-	checker, err := status.NewStatusChecker(cfg, 2*time.Second, timeout, b.logger)
+	checker, err := status.NewStatusChecker(cfg, 5*time.Second, timeout, b.logger)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR sets the status checker poll interval to 5 seconds and adds an optional flag to `flux check` command so users can fine tune its value.

Fix: #1921