### PR TITLE
Fix bootstrap path check

### DIFF
--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -159,6 +159,10 @@ func kustomizationPathDiffers(ctx context.Context, kube client.Client, objKey cl
 		return "", err
 	}
 	normalizePath := func(p string) string {
+		// remove the trailing '/' if the path is not './'
+		if len(p) > 2 {
+			p = strings.TrimSuffix(p, "/")
+		}
 		return fmt.Sprintf("./%s", strings.TrimPrefix(p, "./"))
 	}
 	if normalizePath(path) == normalizePath(k.Spec.Path) {


### PR DESCRIPTION
Remove the trailing `/` before comparing the given bootstrap path to the in-cluster one.

Fix: #1979