### PR TITLE
Expand Helm releases in flux tree cmd

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -191,7 +191,14 @@ jobs:
           /tmp/flux create kustomization flux-system \
           --source=flux-system \
           --path=./clusters/staging
+          kubectl -n flux-system wait kustomization/infrastructure --for=condition=ready --timeout=5m
           kubectl -n flux-system wait kustomization/apps --for=condition=ready --timeout=5m
+          kubectl -n nginx wait helmrelease/nginx --for=condition=ready --timeout=5m
+          kubectl -n redis wait helmrelease/redis --for=condition=ready --timeout=5m
+          kubectl -n podinfo wait helmrelease/podinfo --for=condition=ready --timeout=5m
+      - name: flux tree
+        run: |
+          /tmp/flux tree kustomization flux-system | grep Service/podinfo
       - name: flux check
         run: |
           /tmp/flux check

--- a/cmd/flux/testdata/tree/kustomizations.yaml
+++ b/cmd/flux/testdata/tree/kustomizations.yaml
@@ -65,8 +65,6 @@ status:
         v: v1
       - id: cert-manager_cert-manager_source.toolkit.fluxcd.io_HelmRepository
         v: v1beta1
-      - id: cert-manager_cert-manager_helm.toolkit.fluxcd.io_HelmRelease
-        v: v2beta1
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
@@ -87,3 +85,4 @@ status:
       reason: ReconciliationSucceeded
       status: "True"
       type: Ready
+---

--- a/cmd/flux/testdata/tree/tree-compact.golden
+++ b/cmd/flux/testdata/tree/tree-compact.golden
@@ -1,6 +1,5 @@
 Kustomization/{{ .fluxns }}/flux-system
 ├── Kustomization/{{ .fluxns }}/infrastructure
-│   ├── HelmRepository/cert-manager/cert-manager
-│   └── HelmRelease/cert-manager/cert-manager
+│   └── HelmRepository/cert-manager/cert-manager
 └── GitRepository/{{ .fluxns }}/flux-system
 

--- a/cmd/flux/testdata/tree/tree.golden
+++ b/cmd/flux/testdata/tree/tree.golden
@@ -6,7 +6,6 @@ Kustomization/{{ .fluxns }}/flux-system
 ├── Deployment/{{ .fluxns }}/source-controller
 ├── Kustomization/{{ .fluxns }}/infrastructure
 │   ├── Namespace/cert-manager
-│   ├── HelmRepository/cert-manager/cert-manager
-│   └── HelmRelease/cert-manager/cert-manager
+│   └── HelmRepository/cert-manager/cert-manager
 └── GitRepository/{{ .fluxns }}/flux-system
 


### PR DESCRIPTION
This PR adds a function to list the reconciled resources of a HelmRelease object. The `flux tree kustomization` will now include the Helm releases inventory e.g.:

```console
$ flux tree kustomization podinfo
Kustomization/flux-system/podinfo
├── HelmRelease/flux-system/podinfo
│   ├── Service/podinfo
│   └── Deployment/podinfo
└── HelmRepository/flux-system/podinfo
```

Followup: #1998