### PR TITLE
Fix quoting around reconciliation error message

### DIFF
--- a/cmd/flux/reconcile.go
+++ b/cmd/flux/reconcile.go
@@ -122,7 +122,7 @@ func (reconcile reconcileCommand) run(cmd *cobra.Command, args []string) error {
 	}
 
 	if readyCond.Status != metav1.ConditionTrue {
-		return fmt.Errorf("%s reconciliation failed: ''%s", reconcile.kind, readyCond.Message)
+		return fmt.Errorf("%s reconciliation failed: '%s'", reconcile.kind, readyCond.Message)
 	}
 	logger.Successf(reconcile.object.successMessage())
 	return nil


### PR DESCRIPTION
While fixing an unrelated issue, I noticed:
    ✗ GitRepository reconciliation failed: ''PGP public keys secret error: expected pointer, but got nil

(the single quote should surround the readyCond.Message)