### PR TITLE
Add fetch timeout arg to create source commands

### DIFF
--- a/cmd/flux/create_source.go
+++ b/cmd/flux/create_source.go
@@ -17,6 +17,8 @@ limitations under the License.
 package main
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 )
 
@@ -26,6 +28,14 @@ var createSourceCmd = &cobra.Command{
 	Long:  "The create source sub-commands generate sources.",
 }
 
+type createSourceFlags struct {
+	fetchTimeout time.Duration
+}
+
+var createSourceArgs createSourceFlags
+
 func init() {
+	createSourceCmd.PersistentFlags().DurationVar(&createSourceArgs.fetchTimeout, "fetch-timeout", createSourceArgs.fetchTimeout,
+		"set a timeout for fetch operations performed by source-controller (e.g. 'git clone' or 'helm repo update')")
 	createCmd.AddCommand(createSourceCmd)
 }

--- a/cmd/flux/create_source_bucket.go
+++ b/cmd/flux/create_source_bucket.go
@@ -134,6 +134,11 @@ func createSourceBucketCmdRun(cmd *cobra.Command, args []string) error {
 			},
 		},
 	}
+
+	if createSourceArgs.fetchTimeout > 0 {
+		bucket.Spec.Timeout = &metav1.Duration{Duration: createSourceArgs.fetchTimeout}
+	}
+
 	if sourceBucketArgs.secretRef != "" {
 		bucket.Spec.SecretRef = &meta.LocalObjectReference{
 			Name: sourceBucketArgs.secretRef,

--- a/cmd/flux/create_source_git.go
+++ b/cmd/flux/create_source_git.go
@@ -206,6 +206,10 @@ func createSourceGitCmdRun(cmd *cobra.Command, args []string) error {
 		},
 	}
 
+	if createSourceArgs.fetchTimeout > 0 {
+		gitRepository.Spec.Timeout = &metav1.Duration{Duration: createSourceArgs.fetchTimeout}
+	}
+
 	if sourceGitArgs.gitImplementation != "" {
 		gitRepository.Spec.GitImplementation = sourceGitArgs.gitImplementation.String()
 	}

--- a/cmd/flux/create_source_helm.go
+++ b/cmd/flux/create_source_helm.go
@@ -129,6 +129,10 @@ func createSourceHelmCmdRun(cmd *cobra.Command, args []string) error {
 		},
 	}
 
+	if createSourceArgs.fetchTimeout > 0 {
+		helmRepository.Spec.Timeout = &metav1.Duration{Duration: createSourceArgs.fetchTimeout}
+	}
+
 	if sourceHelmArgs.secretRef != "" {
 		helmRepository.Spec.SecretRef = &meta.LocalObjectReference{
 			Name: sourceHelmArgs.secretRef,


### PR DESCRIPTION
This PR adds an optional arg `--fetch-timeout` to all `flux create source` commands.

Adresses https://github.com/fluxcd/flux2/discussions/1991

Example:

```console
$ flux create source git podinfo --fetch-timeout=55s --url=ssh://git@github.com/stefanprodan/podinfo --branch=master --export

---
apiVersion: source.toolkit.fluxcd.io/v1beta1
kind: GitRepository
metadata:
  name: podinfo
  namespace: test-system
spec:
  interval: 1m0s
  ref:
    branch: master
  timeout: 55s
  url: ssh://git@github.com/stefanprodan/podinfo
```