### PR TITLE
Switch to `app.kubernetes.io/part-of` label selector

### DIFF
--- a/cmd/flux/check.go
+++ b/cmd/flux/check.go
@@ -30,6 +30,7 @@ import (
 	"github.com/fluxcd/pkg/version"
 
 	"github.com/fluxcd/flux2/internal/utils"
+	"github.com/fluxcd/flux2/pkg/manifestgen"
 	"github.com/fluxcd/flux2/pkg/manifestgen/install"
 	"github.com/fluxcd/flux2/pkg/status"
 )
@@ -191,7 +192,7 @@ func componentsCheck() bool {
 	}
 
 	ok := true
-	selector := client.MatchingLabels{"app.kubernetes.io/instance": rootArgs.namespace}
+	selector := client.MatchingLabels{manifestgen.PartOfLabelKey: manifestgen.PartOfLabelValue}
 	var list v1.DeploymentList
 	if err := kubeClient.List(ctx, &list, client.InNamespace(rootArgs.namespace), selector); err == nil {
 		for _, d := range list.Items {

--- a/cmd/flux/logs.go
+++ b/cmd/flux/logs.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/fluxcd/flux2/internal/flags"
 	"github.com/fluxcd/flux2/internal/utils"
+	"github.com/fluxcd/flux2/pkg/manifestgen"
 )
 
 var logsCmd = &cobra.Command{
@@ -93,7 +94,7 @@ func init() {
 }
 
 func logsCmdRun(cmd *cobra.Command, args []string) error {
-	fluxSelector := fmt.Sprintf("app.kubernetes.io/instance=%s", logsArgs.fluxNamespace)
+	fluxSelector := fmt.Sprintf("%s=%s", manifestgen.PartOfLabelKey, manifestgen.PartOfLabelValue)
 
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
 	defer cancel()

--- a/cmd/flux/uninstall.go
+++ b/cmd/flux/uninstall.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/fluxcd/flux2/internal/utils"
+	"github.com/fluxcd/flux2/pkg/manifestgen"
 	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
@@ -93,7 +94,7 @@ func uninstallCmdRun(cmd *cobra.Command, args []string) error {
 	uninstallFinalizers(ctx, kubeClient, uninstallArgs.dryRun)
 
 	logger.Actionf("deleting toolkit.fluxcd.io custom resource definitions")
-	uninstallCustomResourceDefinitions(ctx, kubeClient, rootArgs.namespace, uninstallArgs.dryRun)
+	uninstallCustomResourceDefinitions(ctx, kubeClient, uninstallArgs.dryRun)
 
 	if !uninstallArgs.keepNamespace {
 		uninstallNamespace(ctx, kubeClient, rootArgs.namespace, uninstallArgs.dryRun)
@@ -105,7 +106,7 @@ func uninstallCmdRun(cmd *cobra.Command, args []string) error {
 
 func uninstallComponents(ctx context.Context, kubeClient client.Client, namespace string, dryRun bool) {
 	opts, dryRunStr := getDeleteOptions(dryRun)
-	selector := client.MatchingLabels{"app.kubernetes.io/instance": namespace}
+	selector := client.MatchingLabels{manifestgen.PartOfLabelKey: manifestgen.PartOfLabelValue}
 	{
 		var list appsv1.DeploymentList
 		if err := kubeClient.List(ctx, &list, client.InNamespace(namespace), selector); err == nil {
@@ -262,9 +263,9 @@ func uninstallFinalizers(ctx context.Context, kubeClient client.Client, dryRun b
 	}
 }
 
-func uninstallCustomResourceDefinitions(ctx context.Context, kubeClient client.Client, namespace string, dryRun bool) {
+func uninstallCustomResourceDefinitions(ctx context.Context, kubeClient client.Client, dryRun bool) {
 	opts, dryRunStr := getDeleteOptions(dryRun)
-	selector := client.MatchingLabels{"app.kubernetes.io/instance": namespace}
+	selector := client.MatchingLabels{manifestgen.PartOfLabelKey: manifestgen.PartOfLabelValue}
 	{
 		var list apiextensionsv1.CustomResourceDefinitionList
 		if err := kubeClient.List(ctx, &list, selector); err == nil {

--- a/cmd/flux/version.go
+++ b/cmd/flux/version.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/fluxcd/flux2/internal/utils"
+	"github.com/fluxcd/flux2/pkg/manifestgen"
 )
 
 var versionCmd = &cobra.Command{
@@ -78,7 +79,7 @@ func versionCmdRun(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		selector := client.MatchingLabels{"app.kubernetes.io/instance": rootArgs.namespace}
+		selector := client.MatchingLabels{manifestgen.PartOfLabelKey: manifestgen.PartOfLabelValue}
 		var list v1.DeploymentList
 		if err := kubeClient.List(ctx, &list, client.InNamespace(rootArgs.namespace), selector); err != nil {
 			return err

--- a/pkg/manifestgen/labels.go
+++ b/pkg/manifestgen/labels.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2021 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manifestgen
+
+// These labels can be used to track down the namespace, custom resource definitions, deployments,
+// services, network policies, service accounts, cluster roles and cluster role bindings belonging to Flux.
+const (
+	PartOfLabelKey   = "app.kubernetes.io/part-of"
+	PartOfLabelValue = "flux"
+	InstanceLabelKey = "app.kubernetes.io/instance"
+	VersionLabelKey  = "app.kubernetes.io/version"
+)


### PR DESCRIPTION
Use `app.kubernetes.io/part-of: flux` label instead of `app.kubernetes.io/instance` to select the in-cluster objects used in flux version, check, logs and uninstall commands.

Fix: #1894