### PR TITLE
bootstrap: Set ECDSA as the default SSH key algorithm

### DIFF
--- a/cmd/flux/bootstrap.go
+++ b/cmd/flux/bootstrap.go
@@ -140,7 +140,7 @@ func NewBootstrapFlags() bootstrapFlags {
 	return bootstrapFlags{
 		logLevel:           flags.LogLevel(rootArgs.defaults.LogLevel),
 		requiredComponents: []string{"source-controller", "kustomize-controller"},
-		keyAlgorithm:       flags.PublicKeyAlgorithm(sourcesecret.RSAPrivateKeyAlgorithm),
+		keyAlgorithm:       flags.PublicKeyAlgorithm(sourcesecret.ECDSAPrivateKeyAlgorithm),
 		keyRSABits:         2048,
 		keyECDSACurve:      flags.ECDSACurve{Curve: elliptic.P384()},
 	}

--- a/cmd/flux/create_secret_git.go
+++ b/cmd/flux/create_secret_git.go
@@ -105,7 +105,7 @@ func init() {
 
 func NewSecretGitFlags() secretGitFlags {
 	return secretGitFlags{
-		keyAlgorithm: flags.PublicKeyAlgorithm(sourcesecret.RSAPrivateKeyAlgorithm),
+		keyAlgorithm: flags.PublicKeyAlgorithm(sourcesecret.ECDSAPrivateKeyAlgorithm),
 		rsaBits:      2048,
 		ecdsaCurve:   flags.ECDSACurve{Curve: elliptic.P384()},
 	}


### PR DESCRIPTION
Motivation: RSA SHA-1 SSH keys are no longer accepted by GitHub https://github.blog/2021-09-01-improving-git-protocol-security-github/.

Given this we are switching the default from RSA to ECDSA for `git`, `github` and `gitlab` variants of `flux bootstrap`.

Fix: #2040 