### PR TITLE
Set ECDSA as the default algorithm for `flux create source git`

### DIFF
--- a/cmd/flux/create_source_git.go
+++ b/cmd/flux/create_source_git.go
@@ -143,7 +143,7 @@ func init() {
 
 func newSourceGitFlags() sourceGitFlags {
 	return sourceGitFlags{
-		keyAlgorithm:  flags.PublicKeyAlgorithm(sourcesecret.RSAPrivateKeyAlgorithm),
+		keyAlgorithm:  flags.PublicKeyAlgorithm(sourcesecret.ECDSAPrivateKeyAlgorithm),
 		keyRSABits:    2048,
 		keyECDSACurve: flags.ECDSACurve{Curve: elliptic.P384()},
 	}


### PR DESCRIPTION
Followup: #2041