### PR TITLE
Remove trailing `---` for `flux install` to match `flux bootstrap` generated YAML

### DIFF
--- a/cmd/flux/install.go
+++ b/cmd/flux/install.go
@@ -177,7 +177,6 @@ func installCmdRun(cmd *cobra.Command, args []string) error {
 
 	if installArgs.export {
 		fmt.Print(manifest.Content)
-		fmt.Println("---")
 		return nil
 	} else if rootArgs.verbose {
 		fmt.Print(manifest.Content)


### PR DESCRIPTION
Signed-off-by: Jack Evans <jack.evans1@ibm.com>

fix: #2056 

- remove trailing `---` that I missed in the first PR 😢 
- flux bootstrap and flux install commands now generate the exact same thing
