### PR TITLE
Update Alpine to v3.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13 as builder
+FROM alpine:3.14 as builder
 
 RUN apk add --no-cache ca-certificates curl
 
@@ -9,7 +9,7 @@ RUN curl -sL https://storage.googleapis.com/kubernetes-release/release/v${KUBECT
     -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl && \
     kubectl version --client=true
 
-FROM alpine:3.13 as flux-cli
+FROM alpine:3.14 as flux-cli
 
 # Create minimal nsswitch.conf file to prioritize the usage of /etc/hosts over DNS queries.
 # https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-354316460


### PR DESCRIPTION
Followup for https://github.com/fluxcd/helm-controller/pull/360.

Unify Alpine minor-version used by container by bumping to 3.14.