### PR TITLE
Publish OpenAPI JSON schemas for Visual Studio Code IntelliSense

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,8 +61,10 @@ jobs:
         with:
           crd: all-crds.yaml
           output: schemas
+          combined_filename: crd-schemas.json
       - name: Archive the OpenAPI JSON schemas
         run: |
+          mv schemas/crd-schemas.json ./output/crd-schemas.json
           tar -czvf ./output/crd-schemas.tar.gz -C schemas .
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -83,6 +83,7 @@ release:
     - glob: ./output/crd-schemas.tar.gz
     - glob: ./output/manifests.tar.gz
     - glob: ./output/install.yaml
+    - glob: ./output/crd-schemas.json
 dockers:
 - image_templates:
     - 'fluxcd/flux-cli:{{ .Tag }}-amd64'


### PR DESCRIPTION
Signed-off-by: Chanwit Kaewkasi <chanwit@gmail.com>

This change publishes the auto-generated JSON schemas as a single URL,
so that it is consumable by a tool like VS Code.

The CRD generator creates 2 files, a tar.gz for Kubeval,
and another one is a JSON file. The JSON file is a combination of
all schemas, put under the "oneOf" operator.

This PR depends on https://github.com/fluxcd/pkg/pull/189.