### PR TITLE
Fix GitHub bootstrap when using custom TLS CA

### DIFF
--- a/cmd/flux/bootstrap_github.go
+++ b/cmd/flux/bootstrap_github.go
@@ -141,7 +141,7 @@ func bootstrapGitHubCmdRun(cmd *cobra.Command, args []string) error {
 	defer os.RemoveAll(manifestsBase)
 
 	var caBundle []byte
-	if bootstrapArgs.caFile != " " {
+	if bootstrapArgs.caFile != "" {
 		var err error
 		caBundle, err = os.ReadFile(bootstrapArgs.caFile)
 		if err != nil {


### PR DESCRIPTION
Remove extra space in check for ca file.

Signed-off-by: Somtochi Onyekwere <somtochionyekwere@gmail.com>