### PR TITLE
Simplify arguments of flux trace command

### DIFF
--- a/cmd/flux/trace.go
+++ b/cmd/flux/trace.go
@@ -201,7 +201,7 @@ func getObjectDynamic(args []string) ([]*unstructured.Unstructured, error) {
 
 	objects := []*unstructured.Unstructured{}
 	for _, info := range infos {
-	obj := &unstructured.Unstructured{}
+		obj := &unstructured.Unstructured{}
 		obj.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(info.Object)
 		if err != nil {
 			return objects, err
@@ -213,12 +213,11 @@ func getObjectDynamic(args []string) ([]*unstructured.Unstructured, error) {
 
 func traceKustomization(ctx context.Context, kubeClient client.Client, ksName types.NamespacedName, obj *unstructured.Unstructured) (string, error) {
 	ks := &kustomizev1.Kustomization{}
-	ksReady := &metav1.Condition{}
 	err := kubeClient.Get(ctx, ksName, ks)
 	if err != nil {
 		return "", fmt.Errorf("failed to find kustomization: %w", err)
 	}
-	ksReady = meta.FindStatusCondition(ks.Status.Conditions, fluxmeta.ReadyCondition)
+	ksReady := meta.FindStatusCondition(ks.Status.Conditions, fluxmeta.ReadyCondition)
 
 	var ksRepository *sourcev1.GitRepository
 	var ksRepositoryReady *metav1.Condition
@@ -326,12 +325,11 @@ Status:        Unknown
 
 func traceHelm(ctx context.Context, kubeClient client.Client, hrName types.NamespacedName, obj *unstructured.Unstructured) (string, error) {
 	hr := &helmv2.HelmRelease{}
-	hrReady := &metav1.Condition{}
 	err := kubeClient.Get(ctx, hrName, hr)
 	if err != nil {
 		return "", fmt.Errorf("failed to find HelmRelease: %w", err)
 	}
-	hrReady = meta.FindStatusCondition(hr.Status.Conditions, fluxmeta.ReadyCondition)
+	hrReady := meta.FindStatusCondition(hr.Status.Conditions, fluxmeta.ReadyCondition)
 
 	var hrChart *sourcev1.HelmChart
 	var hrChartReady *metav1.Condition

--- a/cmd/flux/trace_test.go
+++ b/cmd/flux/trace_test.go
@@ -10,7 +10,7 @@ import (
 func TestTraceNoArgs(t *testing.T) {
 	cmd := cmdTestCase{
 		args:   "trace",
-		assert: assertError("object name is required"),
+		assert: assertError("either `<resource>/<name>` or `<resource> <name>` is required as an argument"),
 	}
 	cmd.runTestCmd(t)
 }


### PR DESCRIPTION
With the `--kind` and `--api-version` flags `flux trace` is pretty tedious to use, especially with custom resources. This PR adds support for using `<resource>/<name>` and `<resource> <name>` instead, like with `kubectl` commands.

Instead of
```
flux trace --api-version helm.toolkit.fluxcd.io/v2beta1 --kind HelmRelease -n flux-system prometheus
```
you can use
```
flux trace -n flux-system helmrelease prometheus
```

It is using the same logic from `k8s.io/cli-runtime` that's used within `kubectl`.

`internal/utils/restclientgetter.go` is something that should really be added to `k8s.io/cli-runtime` as it's needed to get from a `rest.Config` to a `resource.Builder`, which implements resource fetching with only resource and name.

There are also no tests yet. Just adding them to the list in `trace_test.go` is not sufficient, probably because resource discovery is not supported by the test client.

The previous command signature is also still supported.

CC @stefanprodan 