### PR TITLE
e2e: Update Calico to v3.20

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2,7 +2,7 @@ name: e2e
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, e2e* ]
   pull_request:
     branches: [ main ]
 
@@ -35,7 +35,7 @@ jobs:
           version: "1.21.x"
       - name: Setup Calico for network policy
         run: |
-          kubectl apply -f https://docs.projectcalico.org/v3.16/manifests/calico.yaml
+          kubectl apply -f https://docs.projectcalico.org/v3.20/manifests/calico.yaml
           kubectl -n kube-system set env daemonset/calico-node FELIX_IGNORELOOSERPF=true
       - name: Setup Kustomize
         uses: fluxcd/pkg//actions/kustomize@main


### PR DESCRIPTION
Update Calico to the latest stable version in end-to-end tests.

Ref: #2152