### PR TITLE
cmd: start trace short description with T

### DIFF
--- a/cmd/flux/trace.go
+++ b/cmd/flux/trace.go
@@ -40,7 +40,7 @@ import (
 
 var traceCmd = &cobra.Command{
 	Use:   "trace [name]",
-	Short: "trace an in-cluster object throughout the GitOps delivery pipeline",
+	Short: "Trace an in-cluster object throughout the GitOps delivery pipeline",
 	Long: `The trace command shows how an object is managed by Flux,
 from which source and revision it comes, and what's the latest reconciliation status.'`,
 	Example: `  # Trace a Kubernetes Deployment


### PR DESCRIPTION
This fixes a styling issue:

```
$ flux --help

Command line utility for assembling Kubernetes CD pipelines the GitOps
way.

Usage:
  flux [command]

...

Available Commands:
  ...
  suspend     Suspend resources
  trace       trace an in-cluster object throughout the GitOps delivery
pipeline
  uninstall   Uninstall Flux and its custom resource definitions
...
```