### PR TITLE
docs(sync_test.go): Flux CD → Flux

### DIFF
--- a/pkg/manifestgen/sync/sync_test.go
+++ b/pkg/manifestgen/sync/sync_test.go
@@ -1,7 +1,7 @@
 // +build !e2e
 
 /*
-Copyright 2020 The Flux CD contributors.
+Copyright 2020 The Flux contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Flux is just called "Flux".
https://github.com/open-gitops/documents/pull/47/files#r762415300

Signed-off-by: lloydchang <lloydchang@gmail.com>