### PR TITLE
Run the ARM64 e2e tests on Equinix hardware

### DIFF
--- a/.github/runners/prereq.sh
+++ b/.github/runners/prereq.sh
@@ -14,19 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This script is meant to be run locally and in CI to validate the Kubernetes
-# manifests (including Flux custom resources) before changes are merged into
-# the branch synced by Flux in-cluster.
+# This script installs the prerequisites for running Flux end-to-end tests with Docker and GitHub self-hosted runners.
 
 set -eu
-
-REPOSITORY_TOKEN=$1
-REPOSITORY_URL=${2:-https://github.com/fluxcd/flux2}
 
 KIND_VERSION=0.11.1
 KUBECTL_VERSION=1.21.2
 KUSTOMIZE_VERSION=4.1.3
-GITHUB_RUNNER_VERSION=2.278.0
+GITHUB_RUNNER_VERSION=2.285.1
 PACKAGES="apt-transport-https ca-certificates software-properties-common build-essential libssl-dev gnupg lsb-release jq"
 
 # install prerequisites
@@ -64,10 +59,3 @@ curl -o actions-runner-linux-arm64.tar.gz -L https://github.com/actions/runner/r
 
 # install runner dependencies
 ./bin/installdependencies.sh
-
-# register runner with GitHub
-sudo -u ubuntu ./config.sh --unattended --url ${REPOSITORY_URL} --token ${REPOSITORY_TOKEN}
-
-# start runner
-./svc.sh install
-./svc.sh start

--- a/.github/runners/runner-setup.sh
+++ b/.github/runners/runner-setup.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Flux authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script installs a GitHub self-hosted ARM64 runner for running Flux end-to-end tests.
+
+set -eu
+
+RUNNER_NAME=$1
+REPOSITORY_TOKEN=$2
+REPOSITORY_URL=${3:-https://github.com/fluxcd/flux2}
+
+GITHUB_RUNNER_VERSION=2.285.1
+
+# download runner
+curl -o actions-runner-linux-arm64.tar.gz -L https://github.com/actions/runner/releases/download/v${GITHUB_RUNNER_VERSION}/actions-runner-linux-arm64-${GITHUB_RUNNER_VERSION}.tar.gz \
+  && tar xzf actions-runner-linux-arm64.tar.gz \
+  && rm actions-runner-linux-arm64.tar.gz
+
+# register runner with GitHub
+./config.sh --unattended --url ${REPOSITORY_URL} --token ${REPOSITORY_TOKEN} --name ${RUNNER_NAME}
+
+# start runner
+sudo ./svc.sh install
+sudo ./svc.sh start

--- a/.github/workflows/e2e-arm64.yaml
+++ b/.github/workflows/e2e-arm64.yaml
@@ -3,14 +3,13 @@ name: e2e-arm64
 on:
   workflow_dispatch:
   push:
-    branches: [ main, update-components, arm64-e2e ]
+    branches: [ main, update-components, equinix-runners ]
 
 jobs:
-  ampere:
-    # Runner info
-    # Owner: Stefan Prodan
+  test:
+    # Hosted on Equinix
     # Docs: https://github.com/fluxcd/flux2/tree/main/.github/runners
-    runs-on: [self-hosted, Linux, ARM64]
+    runs-on: [self-hosted, Linux, ARM64, equinix]
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Move the runners from Oracle Cloud free tier to Equinix ARM64 hardware (account sponsored by CNCF).

| Runner        | Instance            | Region |
|---------------|---------------------|--------|
| equinix-arm-1 | flux-equinix-arm-01 | AMS1   |
| equinix-arm-2 | flux-equinix-arm-01 | AMS1   |
| equinix-arm-3 | flux-equinix-arm-01 | AMS1   |
| equinix-arm-4 | flux-equinix-arm-02 | DFW2   |
| equinix-arm-5 | flux-equinix-arm-02 | DFW2   |
| equinix-arm-6 | flux-equinix-arm-02 | DFW2   |

PS. @squaremo @hiddeco you can delete your Oracle runners after this PR is merged.