### PR TITLE
monitoring: Pin kube-prometheus-stack  to v19.3.0

### DIFF
--- a/manifests/monitoring/kube-prometheus-stack/release.yaml
+++ b/manifests/monitoring/kube-prometheus-stack/release.yaml
@@ -6,6 +6,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      version: 19.3.0
       chart: kube-prometheus-stack
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
Something wrong (a bug) in kube-prometheus-stack 20.0.0 and on has broken our example.

See:

* https://github.com/fluxcd/flux2/pull/2193 and
* #2192 for more information.