### PR TITLE
Update kube-prometheus-stack to 23.2.0

### DIFF
--- a/manifests/monitoring/kube-prometheus-stack/release.yaml
+++ b/manifests/monitoring/kube-prometheus-stack/release.yaml
@@ -6,7 +6,7 @@ spec:
   interval: 5m
   chart:
     spec:
-      version: 19.3.0
+      version: 23.2.0
       chart: kube-prometheus-stack
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
this release contains the prometheus operator in version 0.52.1

see https://github.com/fluxcd/flux2/issues/2192 and https://github.com/fluxcd/flux2/pull/2193 for issues

Fix: #2150