### PR TITLE
Fix ./manifests/scripts/bundle.sh path resolution

### DIFF
--- a/manifests/scripts/bundle.sh
+++ b/manifests/scripts/bundle.sh
@@ -16,8 +16,8 @@
 
 set -e
 
-IN_PATH=${1:-"$(git rev-parse --show-toplevel)/manifests"}
-OUT_PATH=${2:-"$(git rev-parse --show-toplevel)/cmd/flux/manifests"}
+IN_PATH=${1:-"$(realpath $(dirname "${BASH_SOURCE[0]}")/../..)/manifests"}
+OUT_PATH=${2:-"$(realpath $(dirname "${BASH_SOURCE[0]}")/../..)/cmd/flux/manifests"}
 TAR=${3}
 
 info() {


### PR DESCRIPTION
The script now uses the path of the script file itself to determine the
manifests directory paths. This fixes an issue when building the AUR
packages where the check() phase would fail because the git repository
of the package would be used and this would generate invalid paths.