### PR TITLE
Fix port overwrite for `flux bootstrap git`

### DIFF
--- a/cmd/flux/bootstrap_git.go
+++ b/cmd/flux/bootstrap_git.go
@@ -161,10 +161,15 @@ func bootstrapGitCmdRun(cmd *cobra.Command, args []string) error {
 			secretOpts.CAFilePath = bootstrapArgs.caFile
 		}
 
+		// Remove port of the given host when not syncing over HTTP/S to not assume port for protocol
+		// This _might_ be overwritten later on by e.g. --ssh-hostname
+		if repositoryURL.Scheme != "https" && repositoryURL.Scheme != "http" {
+			repositoryURL.Host = repositoryURL.Hostname()
+		}
+
 		// Configure repository URL to match auth config for sync.
 		repositoryURL.User = nil
 		repositoryURL.Scheme = "https"
-		repositoryURL.Host = repositoryURL.Hostname()
 	} else {
 		secretOpts.PrivateKeyAlgorithm = sourcesecret.PrivateKeyAlgorithm(bootstrapArgs.keyAlgorithm)
 		secretOpts.Password = gitArgs.password


### PR DESCRIPTION
Hello
This PR is related to [this one](https://github.com/fluxcd/flux2/pull/2216) and both them should be closed once this one is merged :)

**The problem:**
When you use the bootstrap command on Flux CLI using the generic git subcommand, the port is always removed from the URL that is written on gotk-sync.yaml. If you use a Git server on non-standard port this is a problem. Removing this line will keep the port untouched, when it is standard and when it is not.

**The proof:**
![Screenshot from 2021-12-14 12-32-56](https://user-images.githubusercontent.com/61636487/146000373-092a58d7-4f50-4406-b126-327c7e8d599b.png)

As you can see in the commits, I squashed previous ones but I can not clean it better now again because some others were merged in the middle and some of them are not shown in the git rebase -i
As far as I can not control the right behavior to upload the clean PR, I preferred to open this one without dust