### PR TITLE
Add git build dependency to flux-scm

### DIFF
--- a/.github/aur/flux-scm/PKGBUILD.template
+++ b/.github/aur/flux-scm/PKGBUILD.template
@@ -11,7 +11,7 @@ license=("APACHE")
 provides=("flux-bin")
 conflicts=("flux-bin")
 depends=("glibc")
-makedepends=('go>=1.17', 'kustomize>=3.0')
+makedepends=('go>=1.17', 'kustomize>=3.0', 'git')
 optdepends=('bash-completion: auto-completion for flux in Bash',
 'zsh-completions: auto-completion for flux in ZSH')
 source=(

--- a/.github/aur/flux-scm/PKGBUILD.template
+++ b/.github/aur/flux-scm/PKGBUILD.template
@@ -32,7 +32,7 @@ build() {
   export CGO_CXXFLAGS="$CXXFLAGS"
   export CGO_CPPFLAGS="$CPPFLAGS"
   export GOFLAGS="-buildmode=pie -trimpath -mod=readonly -modcacherw"
-  make cmd/flux/manifests
+  make cmd/flux/.manifests.done
   go build -ldflags "-linkmode=external -X main.VERSION=${pkgver}" -o ${_srcname} ./cmd/flux
 }
 


### PR DESCRIPTION
For users who build their packages inside containers (for example aurutils with the `-c` flag), git may not yet be installed and therefore needs to be in the makedepends. This is also recommended on [the VCS package guildlines](https://wiki.archlinux.org/title/VCS_package_guidelines). This patch adds `git` to the `makedepends` for the flux-scm aur package.

I also ran into an issue where the `cmd/flux/manifests` make target does not exist. I think it was updated to `cmd/flux/.manifests.done` in 7ae4f2892035d9a8c22505905035092a340a7592 so I've updated it in this patch.

### Steps to reproduce the issue:
I've written a Dockerfile to recreate the issue. Simply pop this into a file named `Dockerfile` and run `docker build -t fluxtest .` and it will fail to build the package:
```
Step 12/12 : RUN makepkg -s --noconfirm --nocheck
 ---> Running in 3ba57f343adc
==> ERROR: Cannot find the git package needed to handle git sources.
The command '/bin/sh -c makepkg -s --noconfirm --nocheck' returned a non-zero code: 15
```

but if you uncomment the line to download from my branch, then it works.

Dockerfile:
```
FROM archlinux:latest

RUN pacman --noconfirm -Syu && \
    pacman --noconfirm -S base-devel unzip sudo && \
    useradd -m -g users -G wheel aurbuilder

# Download the latest flux2 from a zip to avoid installing git
ADD https://github.com/fluxcd/flux2/archive/refs/heads/main.zip /home/aurbuilder/flux.zip
# Uncomment this to test the fix:
# ADD https://github.com/tomalexander/flux2/archive/refs/heads/add_git_build_dep.zip /home/aurbuilder/flux.zip
RUN chown aurbuilder:users /home/aurbuilder/flux.zip

# Enable passwordless sudo for fetching dependencies during makepkg -s
RUN (umask 077 && echo '%wheel ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/wheel)

# Unzip flux2
USER aurbuilder
WORKDIR /home/aurbuilder
RUN unzip flux.zip && rm flux.zip && mv flux2* flux2

# Template the PKGBUILD
WORKDIR /home/aurbuilder/flux2/.github/aur/flux-scm/
ENV PKGVER=0.24.1 PKGREL=1
RUN envsubst '$PKGVER $PKGREL' < PKGBUILD.template > PKGBUILD

# Build package
# --nocheck because envtest is not installed by the PKGBUILD
RUN makepkg -s --noconfirm --nocheck
```

Alternatively, if you have aurutils set up, you can reproduce the issue directly from the aur with the command `aur sync -c flux-scm` which has the output:
```
$ aur sync -c flux-scm
==> Using [custom] repository
  -> flux-scm (none) -> 0.24.1-1
==> Retrieving package files
POST git-upload-pack (155 bytes)
From https://aur.archlinux.org/flux-scm
 = [up to date]      master     -> origin/master
Running aur chroot --create --pacman-conf /etc/aurutils/pacman-custom.conf
Running aur chroot --update --pacman-conf /etc/aurutils/pacman-custom.conf
:: Synchronizing package databases...
 core                                                    137.5 KiB   529 KiB/s 00:00 [#################################################] 100%
 extra                                                  1563.7 KiB  8.04 MiB/s 00:00 [#################################################] 100%
 community                                                 6.0 MiB  8.67 MiB/s 00:01 [#################################################] 100%
 multilib                                                152.1 KiB  3.46 MiB/s 00:00 [#################################################] 100%
:: Starting full system upgrade...
 there is nothing to do
Running aur chroot --packagelist --pacman-conf /etc/aurutils/pacman-custom.conf
Running aur chroot --build --pacman-conf /etc/aurutils/pacman-custom.conf -- -c -u --
==> Synchronizing chroot copy [/var/lib/aurbuild/x86_64/root] -> [talexander]...done
:: Synchronizing package databases...
 core                                                    137.5 KiB   982 KiB/s 00:00 [#################################################] 100%
 extra                                                  1563.7 KiB  7.75 MiB/s 00:00 [#################################################] 100%
 community                                                 6.0 MiB  8.12 MiB/s 00:01 [#################################################] 100%
 multilib                                                152.1 KiB  3.71 MiB/s 00:00 [#################################################] 100%
:: Starting full system upgrade...
 there is nothing to do
==> Making package: flux-scm 0.24.1-1 (Sat Jan  8 15:39:52 2022)
==> Retrieving sources...
  -> Updating flux2 git repo...
Fetching origin
==> Validating source files with md5sums...
    flux2 ... Skipped
==> ERROR: Cannot find the git package needed to handle git sources.
==> ERROR: Build failed, check /var/lib/aurbuild/x86_64/talexander/build
```