### PR TITLE
Fix makefile envtest setup and usage

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -29,10 +29,6 @@ jobs:
           version: v0.11.1
           image: kindest/node:v1.19.11@sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729
           config: .github/kind/config.yaml # disable KIND-net
-      - name: Setup envtest
-        uses: fluxcd/pkg/actions/envtest@main
-        with:
-          version: "1.21.x"
       - name: Setup Calico for network policy
         run: |
           kubectl apply -f https://docs.projectcalico.org/v3.20/manifests/calico.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ bin/
 output/
 cmd/flux/manifests/
 cmd/flux/.manifests.done
+testbin/
 
 # Docs
 site/


### PR DESCRIPTION
Refactor logic to install helper tools into one function in the
Makefile. Add support for envtest to help install tools like kubectl,
etcd which helps users run tests more conveniently.

Ref: https://github.com/fluxcd/flux2/issues/2273

Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>