### PR TITLE
Improve the bootstrap e2e test workflow

### DIFF
--- a/.github/workflows/bootstrap.yaml
+++ b/.github/workflows/bootstrap.yaml
@@ -110,6 +110,7 @@ jobs:
           GITHUB_REPO_NAME: ${{ steps.vars.outputs.test_repo_name }}
           GITHUB_ORG_NAME: fluxcd-testing
       - name: delete repository
+        if: ${{ always() }}
         run: |
           curl \
             -X DELETE \

--- a/.github/workflows/bootstrap.yaml
+++ b/.github/workflows/bootstrap.yaml
@@ -103,8 +103,20 @@ jobs:
           /tmp/flux reconcile image repository podinfo
           /tmp/flux reconcile image update flux-system
           /tmp/flux get images all
-          /tmp/flux get images policy podinfo | grep "5.2.1"
-          /tmp/flux get image update flux-system | grep commit
+          
+          retries=10
+          count=0
+          ok=false
+          until ${ok}; do
+              /tmp/flux get image update flux-system | grep 'commit' && ok=true || ok=false
+              count=$(($count + 1))
+              if [[ ${count} -eq ${retries} ]]; then
+                  echo "No more retries left"
+                  exit 1
+              fi
+              sleep 6
+              /tmp/flux reconcile image update flux-system
+          done
         env:
           GITHUB_TOKEN: ${{ secrets.GITPROVIDER_BOT_TOKEN }}
           GITHUB_REPO_NAME: ${{ steps.vars.outputs.test_repo_name }}


### PR DESCRIPTION
Bootstrap e2e workflow changes:
- delete the repository regardless of the bootstrap test exit code
- wait for image automation to push changes to upstream (max 60s)
