### PR TITLE
Publish Flux Software Bill of Materials (SBOM)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,6 +66,10 @@ jobs:
       - name: Archive the OpenAPI JSON schemas
         run: |
           tar -czvf ./output/crd-schemas.tar.gz -C schemas .
+      - name: Setup Syft
+        uses: fluxcd/pkg//actions/sbom@main
+        with:
+          version: "v0.35.1"
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,6 +40,8 @@ archives:
     format: zip
     files:
       - none*
+sboms:
+  - artifacts: archive
 brews:
   - name: flux
     tap:


### PR DESCRIPTION
Changes to the release workflow:
- generate [SBOM](https://www.linuxfoundation.org/blog/what-is-an-sbom/) for Flux Go modules with [Syft](https://github.com/anchore/syft)
- publish the SBOM [SPDX](https://spdx.dev/) JSON files to GitHub releases with GoReleaser

Depends on: https://github.com/fluxcd/pkg/pull/219