### PR TITLE
Fix Archlinux PKGBUILD check() run on ARM

### DIFF
--- a/.github/aur/flux-go/PKGBUILD.template
+++ b/.github/aur/flux-go/PKGBUILD.template
@@ -30,12 +30,20 @@ build() {
   export CGO_CXXFLAGS="$CXXFLAGS"
   export CGO_CPPFLAGS="$CPPFLAGS"
   export GOFLAGS="-buildmode=pie -trimpath -mod=readonly -modcacherw"
-  ./manifests/scripts/bundle.sh "${PWD}/manifests" "${PWD}/cmd/flux/manifests"
+  make cmd/flux/.manifests.done
   go build -ldflags "-linkmode=external -X main.VERSION=${pkgver}" -o ${_srcname} ./cmd/flux
 }
 
 check() {
   cd "flux2-${pkgver}"
+  case $CARCH in
+    aarch64)
+      export ENVTEST_ARCH=arm64
+      ;;
+    armv6h|armv7h)
+      export ENVTEST_ARCH=arm
+      ;;
+  esac
   make test
 }
 

--- a/.github/aur/flux-scm/PKGBUILD.template
+++ b/.github/aur/flux-scm/PKGBUILD.template
@@ -38,6 +38,14 @@ build() {
 
 check() {
   cd "flux2"
+  case $CARCH in
+    aarch64)
+      export ENVTEST_ARCH=arm64
+      ;;
+    armv6h|armv7h)
+      export ENVTEST_ARCH=arm
+      ;;
+  esac
   make test
 }
 


### PR DESCRIPTION
The `check()` run started to fail after #2288 since `ENVTEST_ARCH` was not
set correctly on ARM/ARM64. This should fix the problem for the flux-go
and flux-scm AUR packages.