### PR TITLE
Shorten Git SHA commit in `flux get` commands output

### DIFF
--- a/cmd/flux/get_source_git.go
+++ b/cmd/flux/get_source_git.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
@@ -80,6 +81,10 @@ func (a *gitRepositoryListAdapter) summariseItem(i int, includeNamespace bool, i
 		revision = item.GetArtifact().Revision
 	}
 	status, msg := statusAndMessage(item.Status.Conditions)
+	if status == string(metav1.ConditionTrue) {
+		revision = shortenCommitSha(revision)
+		msg = shortenCommitSha(msg)
+	}
 	return append(nameColumns(&item, includeNamespace, includeKind),
 		status, msg, revision, strings.Title(strconv.FormatBool(item.Spec.Suspend)))
 }

--- a/cmd/flux/testdata/kustomization/get_kustomization_from_git.golden
+++ b/cmd/flux/testdata/kustomization/get_kustomization_from_git.golden
@@ -1,2 +1,2 @@
-NAME	READY	MESSAGE                                                         	REVISION                                      	SUSPENDED 
-tkfg	True 	Applied revision: 6.0.0/627d5c4bb67b77185f37e31d734b085019ff2951	6.0.0/627d5c4bb67b77185f37e31d734b085019ff2951	False    	
+NAME	READY	MESSAGE                        	REVISION     	SUSPENDED 
+tkfg	True 	Applied revision: 6.0.0/627d5c4	6.0.0/627d5c4	False    	


### PR DESCRIPTION
This pull request shortens the sha1 commit hash from the status of Kustomization and GitRepository custom resource to the first seven digits when displaying output for `flux get kustomization` and `flux get source git`.

Fixes #2186 


Signed-off-by: Somtochi Onyekwere <somtochionyekwere@gmail.com>