### PR TITLE
Update kubectl to 1.23.1 in flux-cli container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.15 as builder
 RUN apk add --no-cache ca-certificates curl
 
 ARG ARCH=linux/amd64
-ARG KUBECTL_VER=1.22.2
+ARG KUBECTL_VER=1.23.1
 
 RUN curl -sL https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VER}/bin/${ARCH}/kubectl \
     -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl && \


### PR DESCRIPTION
Update `kubectl` in the flux-cli container image to match the Kubernetes version used in Flux CLI.