### PR TITLE
[security] Enable pod security warnings for flux-system

### DIFF
--- a/manifests/install/namespace.yaml
+++ b/manifests/install/namespace.yaml
@@ -2,3 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: flux-system
+  labels:
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest

--- a/pkg/manifestgen/install/templates.go
+++ b/pkg/manifestgen/install/templates.go
@@ -165,6 +165,9 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{.Namespace}}
+  labels:
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
 `
 
 func execTemplate(obj interface{}, tmpl, filename string) error {


### PR DESCRIPTION
Enable warnings for any violation of the `restrict` [Pod Security Standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/) at the `flux-system` namespace. This only works when [Pod Security Admission Controller](https://kubernetes.io/docs/concepts/security/pod-security-admission/) is installed and enabled, which is the default setting on Kubernetes `v1.23+`.

As of version `v0.26.0` all flux components should be compatible with above mentioned policy. This is not being enforced by default to allow backwards compatibility with users that decided deploying non-flux components into the `flux-system` namespace.