### PR TITLE
Set minimum supported version to Kubernetes 1.20.6

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: engineerd/setup-kind@v0.5.0
         with:
           version: v0.11.1
-          image: kindest/node:v1.19.11@sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729
+          image: kindest/node:v1.20.7
           config: .github/kind/config.yaml # disable KIND-net
       - name: Setup Calico for network policy
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,9 +67,9 @@ for source changes.
 
 Prerequisites:
 
-* go >= 1.16
-* kubectl >= 1.19
-* kustomize >= 4.0
+* go >= 1.17
+* kubectl >= 1.20
+* kustomize >= 4.4
 
 Install the [controller-runtime/envtest](https://github.com/kubernetes-sigs/controller-runtime/tree/master/tools/setup-envtest) binaries with:
 

--- a/cmd/flux/check.go
+++ b/cmd/flux/check.go
@@ -56,10 +56,7 @@ type checkFlags struct {
 }
 
 var kubernetesConstraints = []string{
-	">=1.19.0-0",
-	">=1.16.11-0 <=1.16.15-0",
-	">=1.17.7-0 <=1.17.17-0",
-	">=1.18.4-0 <=1.18.20-0",
+	">=1.20.6-0",
 }
 
 var checkArgs checkFlags

--- a/cmd/flux/testdata/check/check_pre.golden
+++ b/cmd/flux/testdata/check/check_pre.golden
@@ -1,3 +1,3 @@
 ► checking prerequisites
-✔ Kubernetes {{ .serverVersion }} >=1.19.0-0
+✔ Kubernetes {{ .serverVersion }} >=1.20.6-0
 ✔ prerequisites checks passed


### PR DESCRIPTION
Drop support for the Kubernetes versions that have reached end-of-life. Given that Kubernetes between 1.20.0 and 1.20.5 had [a bug](https://github.com/kubernetes/kubernetes/pull/98576) with server-side apply, the `flux check` command constraint has been update to Kubernetes >= 1.20.6.

Part of: https://github.com/fluxcd/flux2/issues/2308