### PR TITLE
Fix output usage for `flux get <sources|images>`

### DIFF
--- a/cmd/flux/get_image.go
+++ b/cmd/flux/get_image.go
@@ -25,9 +25,6 @@ var getImageCmd = &cobra.Command{
 	Aliases: []string{"image"},
 	Short:   "Get image automation object status",
 	Long:    "The get image sub-commands print the status of image automation objects.",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return validateWatchOption(cmd, "images")
-	},
 }
 
 func init() {

--- a/cmd/flux/get_source.go
+++ b/cmd/flux/get_source.go
@@ -25,10 +25,6 @@ var getSourceCmd = &cobra.Command{
 	Aliases: []string{"source"},
 	Short:   "Get source statuses",
 	Long:    "The get source sub-commands print the statuses of the sources.",
-	RunE: func(cmd *cobra.Command, args []string) error {
-
-		return validateWatchOption(cmd, "sources")
-	},
 }
 
 func init() {


### PR DESCRIPTION
Fixes #2346

**Background:**

Cobra will automatically print Usage for commands that do not have a `.RunE`.
All of the `flux get` command tree (including the `flux get` root) have `--watch/-w`
registered as a PersistentFlag.
The `validateWatchOption()` func is used to short circuit runnable sub-commands that
operate on multiple kinds, since the watch is not designed to stream/output multiple GVK's.

**Justification:**

These commands are runnable and need filtering:
- `flux get all`
- `flux get sources all`
- `flux get images all`

These commands are not runnable, so there should be no `RunE` at all:
- `flux get sources`
- `flux get images`

**Current Bug/Inconsistency:**
```shell
$ flux get sources
# outputs nothing

$ flux get sources -w
✗ expected a single resource type, but found sources

$ flux get images
# outputs nothing

$ flux get images -w
✗ expected a single resource type, but found images
```
however:
```shell
$ flux get
# outputs Usage

$ flux get -w
# still outputs Usage
```

**Result of this patch:**
```shell
$ flux get sources
# outputs Usage

$ flux get sources -w
# outputs Usage

$ flux get images
# outputs Usage

$ flux get images -w
# outputs Usage
```

**ps:**
I miss you nerds
much love from the tanzu team