### PR TITLE
Adapt diff test to match Kubernetes 1.23.3 API response

### DIFF
--- a/cmd/flux/testdata/diff-kustomization/diff-with-drifted-service.golden
+++ b/cmd/flux/testdata/diff-kustomization/diff-with-drifted-service.golden
@@ -2,11 +2,6 @@
 ► HorizontalPodAutoscaler/default/podinfo created
 ► Service/default/podinfo drifted
 
-spec.ports
-  ⇆ order changed
-    - http, grpc
-    + grpc, http
-
 spec.ports.http.port
   ± value change
     - 9899


### PR DESCRIPTION
Kubernetes 1.23.3 comes with a fix where the ports are no longer reordered by the API when performing a sever-side apply dry-run. This PR updates the diff test golden file to match Kubernetes 1.23.3.