### PR TITLE
Fix panic on bootstrap when orgRef is not retrieved

### DIFF
--- a/internal/bootstrap/bootstrap_provider.go
+++ b/internal/bootstrap/bootstrap_provider.go
@@ -275,7 +275,7 @@ func (b *GitProviderBootstrapper) reconcileOrgRepository(ctx context.Context) (g
 	subOrgs, repoName := splitSubOrganizationsFromRepositoryName(b.repositoryName)
 	orgRef, err := b.getOrganization(ctx, subOrgs)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create new Git repository for the organization %q: %w", orgRef.String(), err)
+		return nil, fmt.Errorf("failed to create new Git repository %q: %w", b.repositoryName, err)
 	}
 	repoRef := newOrgRepositoryRef(*orgRef, repoName)
 	repoInfo := newRepositoryInfo(b.description, b.defaultBranch, b.visibility)


### PR DESCRIPTION
If implemented, not retrieving an orgRef will always return an error

Signed-off-by: Soule BA <soule@weave.works>