### PR TITLE
Mask dockerconfigjson secret types and support StringData secrets

### DIFF
--- a/cmd/flux/diff_kustomization_test.go
+++ b/cmd/flux/diff_kustomization_test.go
@@ -79,6 +79,18 @@ func TestDiffKustomization(t *testing.T) {
 			objectFile: "./testdata/diff-kustomization/value-sops-secret.yaml",
 			assert:     assertGoldenFile("./testdata/diff-kustomization/diff-with-drifted-value-sops-secret.golden"),
 		},
+		{
+			name:       "diff with a sops dockerconfigjson secret object",
+			args:       "diff kustomization podinfo --path ./testdata/build-kustomization/podinfo",
+			objectFile: "./testdata/diff-kustomization/dockerconfigjson-sops-secret.yaml",
+			assert:     assertGoldenFile("./testdata/diff-kustomization/diff-with-dockerconfigjson-sops-secret.golden"),
+		},
+		{
+			name:       "diff with a sops stringdata secret object",
+			args:       "diff kustomization podinfo --path ./testdata/build-kustomization/podinfo",
+			objectFile: "./testdata/diff-kustomization/stringdata-sops-secret.yaml",
+			assert:     assertGoldenFile("./testdata/diff-kustomization/diff-with-stringdata-sops-secret.golden"),
+		},
 	}
 
 	tmpl := map[string]string{

--- a/cmd/flux/main.go
+++ b/cmd/flux/main.go
@@ -153,12 +153,18 @@ func NewRootFlags() rootFlags {
 func main() {
 	log.SetFlags(0)
 	if err := rootCmd.Execute(); err != nil {
-		logger.Failuref("%v", err)
 
 		if err, ok := err.(*RequestError); ok {
+			if err.StatusCode == 1 {
+				logger.Warningf("%v", err)
+			} else {
+				logger.Failuref("%v", err)
+			}
+
 			os.Exit(err.StatusCode)
 		}
 
+		logger.Failuref("%v", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/flux/testdata/build-kustomization/podinfo-result.yaml
+++ b/cmd/flux/testdata/build-kustomization/podinfo-result.yaml
@@ -124,6 +124,31 @@ spec:
 ---
 apiVersion: v1
 data:
+  .dockerconfigjson: eyJtYXNrIjoiKipTT1BTKioifQ==
+kind: Secret
+metadata:
+  labels:
+    kustomize.toolkit.fluxcd.io/name: podinfo
+    kustomize.toolkit.fluxcd.io/namespace: {{ .fluxns }}
+  name: docker-secret
+  namespace: default
+type: kubernetes.io/dockerconfigjson
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    kustomize.toolkit.fluxcd.io/name: podinfo
+    kustomize.toolkit.fluxcd.io/namespace: {{ .fluxns }}
+  name: secret-basic-auth-stringdata
+  namespace: default
+stringData:
+  password: KipTT1BTKio=
+  username: KipTT1BTKio=
+type: kubernetes.io/basic-auth
+---
+apiVersion: v1
+data:
   token: KipTT1BTKio=
 kind: Secret
 metadata:

--- a/cmd/flux/testdata/build-kustomization/podinfo/dockerconfigjson-sops-secret.yaml
+++ b/cmd/flux/testdata/build-kustomization/podinfo/dockerconfigjson-sops-secret.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+data:
+  .dockerconfigjson: ENC[AES256_GCM,data:KHCFH3hNnc+PMfWLFEPjebf3W4z4WXbGFAANRZyZC+07z7wlrTALJM6rn8YslW4tMAWCoAYxblC5WRCszTy0h9rw0U/RGOv5H0qCgnNg/FILFUqhwo9pNfrUH+MEP4M9qxxbLKZwObpHUE7DUsKx1JYAxsI=,iv:q48lqUbUQD+0cbYcjNMZMJLRdGHi78ZmDhNAT2th9tg=,tag:QRI2SZZXQrAcdql3R5AH2g==,type:str]
+kind: Secret
+metadata:
+  name: docker-secret
+type: kubernetes.io/dockerconfigjson
+sops:
+  kms: []
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age:
+    - recipient: age10la2ge0wtvx3qr7datqf7rs4yngxszdal927fs9rukamr8u2pshsvtz7ce
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3eU1CTEJhVXZ4eEVYYkVV
+        OU90TEcrR2pYckttN0pBanJoSUZWSW1RQXlRCkUydFJ3V1NZUTBuVFF0aC9GUEcw
+        bUdhNjJWTkoyL1FUVi9Dc1dxUDBkM0UKLS0tIE1sQXkwcWdGaEFuY0RHQTVXM0J6
+        dWpJcThEbW15V3dXYXpPZklBdW1Hd1kKoIAdmGNPrEctV8h1w8KuvQ5S+BGmgqN9
+        MgpNmUhJjWhgcQpb5BRYpQesBOgU5TBGK7j58A6DMDKlSiYZsdQchQ==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2022-02-03T16:03:17Z"
+  mac: ENC[AES256_GCM,data:AHdYSawajwgAFwlmDN1IPNmT9vWaYKzyVIra2d6sPcjTbZ8/p+VRSRpVm4XZFFsaNnW5AUJaouwXnKYDTmJDXKlr/rQcu9kXqsssQgdzcXaA6l5uJlgsnml8ba7J3OK+iEKMax23mwQEx2EUskCd9ENOwFDkunP02sxqDNOz20k=,iv:8F5OamHt3fAVorf6p+SoIrWoqkcATSGWVoM0EK87S4M=,tag:E1mxXnc7wWkEX5BxhpLtng==,type:str]
+  pgp: []
+  encrypted_regex: ^(data|stringData)$
+  version: 3.7.1

--- a/cmd/flux/testdata/build-kustomization/podinfo/kustomization.yaml
+++ b/cmd/flux/testdata/build-kustomization/podinfo/kustomization.yaml
@@ -4,6 +4,8 @@ resources:
 - ./deployment.yaml
 - ./hpa.yaml
 - ./service.yaml
+- ./dockerconfigjson-sops-secret.yaml
+- ./stringdata-secret.yaml
 secretGenerator:
  - files:
    - token=token.encrypted

--- a/cmd/flux/testdata/build-kustomization/podinfo/stringdata-secret.yaml
+++ b/cmd/flux/testdata/build-kustomization/podinfo/stringdata-secret.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: secret-basic-auth-stringdata
+type: kubernetes.io/basic-auth
+stringData:
+    username: ENC[AES256_GCM,data:uKiQR48=,iv:jh2lgyAVu7igJAgoJsnOGhjxFyvUAa9lvT21u3hhqpU=,tag:zXM2JEpk3ZEH7WfkcWXXkw==,type:str]
+    password: ENC[AES256_GCM,data:PyhZmNhy929JGQ==,iv:PBqPaJmSw21+kn4gIlg5VdjLNZyf613z5RUTCesBoVw=,tag:Hjc7DsuUrtsz7PYPdNkL3g==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age10la2ge0wtvx3qr7datqf7rs4yngxszdal927fs9rukamr8u2pshsvtz7ce
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJd0xxbDZhYjVoZzY4YWhK
+            d2NvMVgrSGRVUGhHRGg3R1FpVURnbmh1TDBzCjcwby85M3JaK09QVk0yZFNMb2NL
+            c2NQZW5hS1FhYlBHU0VoUzBVYzZYUUUKLS0tIEdaNEw2Y0VjVHpZc3pyYUtLVmJk
+            NmN3K2VLU0NiZ1d0VHBYbGlCM1lrNmMKeWz3yfFbMNE+ly21oLfc1XnDSPRmnlPP
+            wIs8lk/qrzVZ45C9GdWnnPeGZZiia46Yop9TxseUS8gCjJ6KCxJCAg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2022-02-06T12:51:07Z"
+    mac: ENC[AES256_GCM,data:jtdzwj19uxdxvnmXg1HkAkDA6XlKMJOYFy7uLI5t/t11LwGop5Yeo7a4nQEEELehRx9J7B6U6NiySxAxBxWx5uW5vI5c8+069VV6dkiCIefnYSzuoIhQafjlFl1/KvH7VEjIWfHYuXF09v9PEKXkxEHUYDpS3QqQ3ymHRRI08pU=,  iv:xX3E7F+AM29Pm8G5oqxRfYu9E7tEBGIaHeCJYgrtFmc=,tag:MJPGusNvu05z939jg8PAwQ==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.1

--- a/cmd/flux/testdata/diff-kustomization/diff-with-deployment.golden
+++ b/cmd/flux/testdata/diff-kustomization/diff-with-deployment.golden
@@ -1,4 +1,6 @@
 ► HorizontalPodAutoscaler/default/podinfo created
 ► Service/default/podinfo created
+► Secret/default/docker-secret created
+► Secret/default/secret-basic-auth-stringdata created
 ► Secret/default/podinfo-token-77t89m9b67 created
 ► Secret/default/db-user-pass-bkbd782d2c created

--- a/cmd/flux/testdata/diff-kustomization/diff-with-dockerconfigjson-sops-secret.golden
+++ b/cmd/flux/testdata/diff-kustomization/diff-with-dockerconfigjson-sops-secret.golden
@@ -1,13 +1,6 @@
 ► Deployment/default/podinfo created
 ► HorizontalPodAutoscaler/default/podinfo created
 ► Service/default/podinfo created
-► Secret/default/docker-secret created
 ► Secret/default/secret-basic-auth-stringdata created
 ► Secret/default/podinfo-token-77t89m9b67 created
-► Secret/default/db-user-pass-bkbd782d2c drifted
-
-data.password
-  ± value change
-    - ******
-    + *****
-
+► Secret/default/db-user-pass-bkbd782d2c created

--- a/cmd/flux/testdata/diff-kustomization/diff-with-drifted-key-sops-secret.golden
+++ b/cmd/flux/testdata/diff-kustomization/diff-with-drifted-key-sops-secret.golden
@@ -1,6 +1,8 @@
 ► Deployment/default/podinfo created
 ► HorizontalPodAutoscaler/default/podinfo created
 ► Service/default/podinfo created
+► Secret/default/docker-secret created
+► Secret/default/secret-basic-auth-stringdata created
 ► Secret/default/podinfo-token-77t89m9b67 drifted
 
 data

--- a/cmd/flux/testdata/diff-kustomization/diff-with-drifted-service.golden
+++ b/cmd/flux/testdata/diff-kustomization/diff-with-drifted-service.golden
@@ -7,5 +7,7 @@ spec.ports.http.port
     - 9899
     + 9898
 
+► Secret/default/docker-secret created
+► Secret/default/secret-basic-auth-stringdata created
 ► Secret/default/podinfo-token-77t89m9b67 created
 ► Secret/default/db-user-pass-bkbd782d2c created

--- a/cmd/flux/testdata/diff-kustomization/diff-with-drifted-value-sops-secret.golden
+++ b/cmd/flux/testdata/diff-kustomization/diff-with-drifted-value-sops-secret.golden
@@ -1,4 +1,6 @@
 ► Deployment/default/podinfo created
 ► HorizontalPodAutoscaler/default/podinfo created
 ► Service/default/podinfo created
+► Secret/default/docker-secret created
+► Secret/default/secret-basic-auth-stringdata created
 ► Secret/default/db-user-pass-bkbd782d2c created

--- a/cmd/flux/testdata/diff-kustomization/diff-with-stringdata-sops-secret.golden
+++ b/cmd/flux/testdata/diff-kustomization/diff-with-stringdata-sops-secret.golden
@@ -2,12 +2,5 @@
 ► HorizontalPodAutoscaler/default/podinfo created
 ► Service/default/podinfo created
 ► Secret/default/docker-secret created
-► Secret/default/secret-basic-auth-stringdata created
 ► Secret/default/podinfo-token-77t89m9b67 created
-► Secret/default/db-user-pass-bkbd782d2c drifted
-
-data.password
-  ± value change
-    - ******
-    + *****
-
+► Secret/default/db-user-pass-bkbd782d2c created

--- a/cmd/flux/testdata/diff-kustomization/dockerconfigjson-sops-secret.yaml
+++ b/cmd/flux/testdata/diff-kustomization/dockerconfigjson-sops-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  .dockerconfigjson: eyJtYXNrIjoiKipTT1BTKioifQ==
+kind: Secret
+metadata:
+  labels:
+    kustomize.toolkit.fluxcd.io/name: podinfo
+    kustomize.toolkit.fluxcd.io/namespace: {{ .fluxns }}
+  name: docker-secret
+  namespace: default
+type: kubernetes.io/dockerconfigjson

--- a/cmd/flux/testdata/diff-kustomization/nothing-is-deployed.golden
+++ b/cmd/flux/testdata/diff-kustomization/nothing-is-deployed.golden
@@ -1,5 +1,7 @@
 ► Deployment/default/podinfo created
 ► HorizontalPodAutoscaler/default/podinfo created
 ► Service/default/podinfo created
+► Secret/default/docker-secret created
+► Secret/default/secret-basic-auth-stringdata created
 ► Secret/default/podinfo-token-77t89m9b67 created
 ► Secret/default/db-user-pass-bkbd782d2c created

--- a/cmd/flux/testdata/diff-kustomization/stringdata-sops-secret.yaml
+++ b/cmd/flux/testdata/diff-kustomization/stringdata-sops-secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    kustomize.toolkit.fluxcd.io/name: podinfo
+    kustomize.toolkit.fluxcd.io/namespace: {{ .fluxns }}
+  name: secret-basic-auth-stringdata
+  namespace: default
+stringData:
+  password: KipTT1BTKio=
+  username: KipTT1BTKio=
+type: kubernetes.io/basic-auth

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -97,7 +97,7 @@ type: kubernetes.io/basic-auth
 			name: "secret sops secret",
 			yamlStr: `apiVersion: v1
 data:
-  .dockercfg: ENC[AES256_GCM,data:KHCFH3hNnc+PMfWLFEPjebf3W4z4WXbGFAANRZyZC+07z7wlrTALJM6rn8YslW4tMAWCoAYxblC5WRCszTy0h9rw0U/RGOv5H0qCgnNg/FILFUqhwo9pNfrUH+MEP4M9qxxbLKZwObpHUE7DUsKx1JYAxsI=,iv:q48lqUbUQD+0cbYcjNMZMJLRdGHi78ZmDhNAT2th9tg=,tag:QRI2SZZXQrAcdql3R5AH2g==,type:str]
+  .dockerconfigjson: ENC[AES256_GCM,data:KHCFH3hNnc+PMfWLFEPjebf3W4z4WXbGFAANRZyZC+07z7wlrTALJM6rn8YslW4tMAWCoAYxblC5WRCszTy0h9rw0U/RGOv5H0qCgnNg/FILFUqhwo9pNfrUH+MEP4M9qxxbLKZwObpHUE7DUsKx1JYAxsI=,iv:q48lqUbUQD+0cbYcjNMZMJLRdGHi78ZmDhNAT2th9tg=,tag:QRI2SZZXQrAcdql3R5AH2g==,type:str]
 kind: Secret
 metadata:
   name: secret
@@ -125,7 +125,7 @@ sops:
 `,
 			expected: `apiVersion: v1
 data:
-  .dockercfg: KipTT1BTKio=
+  .dockerconfigjson: eyJtYXNrIjoiKipTT1BTKioifQ==
 kind: Secret
 metadata:
   name: secret
@@ -142,7 +142,7 @@ type: kubernetes.io/dockerconfigjson
 			}
 
 			resource := &resource.Resource{RNode: *r}
-			err = trimSopsData(resource)
+			err = maskSopsData(resource)
 			if err != nil {
 				t.Fatalf("unable to trim sops data: %v", err)
 			}


### PR DESCRIPTION
If implemented, flux diff kustomization will managed correctly sops
managed dockerconfigjson secrets.

Sops encrypted secret with stringData maps are supported too.

Fix: #2387
Fix: #2388

Signed-off-by: Soule BA <soule@weave.works>