### PR TITLE
added additionalNodeSelector to manifestgen options

### DIFF
--- a/pkg/manifestgen/install/options.go
+++ b/pkg/manifestgen/install/options.go
@@ -19,23 +19,24 @@ package install
 import "time"
 
 type Options struct {
-	BaseURL                string
-	Version                string
-	Namespace              string
-	Components             []string
-	ComponentsExtra        []string
-	EventsAddr             string
-	Registry               string
-	ImagePullSecret        string
-	WatchAllNamespaces     bool
-	NetworkPolicy          bool
-	LogLevel               string
-	NotificationController string
-	ManifestFile           string
-	Timeout                time.Duration
-	TargetPath             string
-	ClusterDomain          string
-	TolerationKeys         []string
+	BaseURL                 string
+	Version                 string
+	Namespace               string
+	Components              []string
+	ComponentsExtra         []string
+	EventsAddr              string
+	Registry                string
+	ImagePullSecret         string
+	WatchAllNamespaces      bool
+	NetworkPolicy           bool
+	LogLevel                string
+	NotificationController  string
+	ManifestFile            string
+	Timeout                 time.Duration
+	TargetPath              string
+	ClusterDomain           string
+	TolerationKeys          []string
+	AdditionalNodeSelectors map[string]string
 }
 
 func MakeDefaultOptions() Options {

--- a/pkg/manifestgen/install/templates.go
+++ b/pkg/manifestgen/install/templates.go
@@ -133,6 +133,9 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+{{- range $k, $v := .AdditionalNodeSelectors }}
+        {{$k}}: "{{$v}}"
+{{- end }}
 {{- if .ImagePullSecret }}
       imagePullSecrets:
        - name: {{.ImagePullSecret}}


### PR DESCRIPTION
Thanks in advance for your review!

This adds the option of using AdditionalNodeSelectors in the manifestgen/install package.

Since tolerations are supported when installing flux to a kubernetes cluster, additional custom nodeSelectors would be go hand-in-hand to allow better control of where the flux components reside.
The main purpose of this is to raise a follow-up in the terraform provider.

I had trouble running the tests locally, quite a few failing due to timezones, so if this is considered worth having someone else test this.