### PR TITLE
Add support for Kustomizations with dot-prefixed paths

### DIFF
--- a/internal/flags/safe_relative_path.go
+++ b/internal/flags/safe_relative_path.go
@@ -41,7 +41,10 @@ func (p *SafeRelativePath) Set(str string) error {
 		return fmt.Errorf("invalid relative path '%s': %w", cleanP, err)
 	}
 	// NB: required, as a secure join of "./" will result in "."
-	cleanP = fmt.Sprintf("./%s", strings.TrimPrefix(cleanP, "."))
+	if cleanP == "." {
+		cleanP = ""
+	}
+	cleanP = fmt.Sprintf("./%s", cleanP)
 	*p = SafeRelativePath(cleanP)
 	return nil
 }

--- a/internal/flags/safe_relative_path_test.go
+++ b/internal/flags/safe_relative_path_test.go
@@ -37,6 +37,10 @@ func TestRelativePath_Set(t *testing.T) {
 		{"traversing absolute path", "/foo/../bar", "./bar", false},
 		{"traversing overflowing absolute path", "/foo/../../../bar", "./bar", false},
 		{"empty", "", "./", false},
+		{"relative empty path", "./", "./", false},
+		{"double relative empty path", "././", "./", false},
+		{"dot path", ".foo", "./.foo", false},
+		{"relative dot path", "./.foo", "./.foo", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/flags/safe_relative_path_test.go
+++ b/internal/flags/safe_relative_path_test.go
@@ -42,6 +42,8 @@ func TestRelativePath_Set(t *testing.T) {
 		{"dot path", ".foo", "./.foo", false},
 		{"relative dot path", "./.foo", "./.foo", false},
 		{"current directory", ".", "./", false},
+		{"parent directory", "..", "./", false},
+		{"parent directory more qualified", "./..", "./", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/flags/safe_relative_path_test.go
+++ b/internal/flags/safe_relative_path_test.go
@@ -41,6 +41,7 @@ func TestRelativePath_Set(t *testing.T) {
 		{"double relative empty path", "././", "./", false},
 		{"dot path", ".foo", "./.foo", false},
 		{"relative dot path", "./.foo", "./.foo", false},
+		{"current directory", ".", "./", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
- in `flux bootstrap` and `flux create kustomization` etc.
- E.g. for example `--path=.flux` should work now
- Previous behaviour is to strip off any leading "." and leave you with
  "./flux" in the kustomizations / folder structure generated by `flux
  bootstrap`

Fixes https://github.com/fluxcd/flux2/issues/1669