### PR TITLE
Fix failure in TestTrace/* when timezone isn't UTC

### DIFF
--- a/cmd/flux/testdata/trace/deployment.golden
+++ b/cmd/flux/testdata/trace/deployment.golden
@@ -6,7 +6,7 @@ Status:         Managed by Flux
 HelmRelease:    podinfo
 Namespace:      {{ .ns }}
 Revision:       6.0.0
-Status:         Last reconciled at 2021-07-16 15:42:20 +0000 UTC
+Status:         Last reconciled at {{ .helmReleaseLastReconcile }}
 Message:        Release reconciliation succeeded
 ---
 HelmChart:      podinfo-podinfo
@@ -14,12 +14,12 @@ Namespace:      {{ .fluxns }}
 Chart:          podinfo
 Version:        6.0.0
 Revision:       6.0.0
-Status:         Last reconciled at 2021-07-16 15:32:09 +0000 UTC
+Status:         Last reconciled at {{ .helmChartLastReconcile }}
 Message:        Fetched revision: 6.0.0
 ---
 HelmRepository: podinfo
 Namespace:      {{ .fluxns }}
 URL:            https://stefanprodan.github.io/podinfo
 Revision:       8411f23d07d3701f0e96e7d9e503b7936d7e1d56
-Status:         Last reconciled at 2021-07-11 00:25:46 +0000 UTC
+Status:         Last reconciled at {{ .helmRepositoryLastReconcile }}
 Message:        Fetched revision: 8411f23d07d3701f0e96e7d9e503b7936d7e1d56

--- a/cmd/flux/testdata/trace/helmrelease.golden
+++ b/cmd/flux/testdata/trace/helmrelease.golden
@@ -7,7 +7,7 @@ Kustomization: infrastructure
 Namespace:     {{ .fluxns }}
 Path:          ./infrastructure
 Revision:      main/696f056df216eea4f9401adbee0ff744d4df390f
-Status:        Last reconciled at 2021-08-01 04:52:56 +0000 UTC
+Status:        Last reconciled at {{ .kustomizationLastReconcile }}
 Message:       Applied revision: main/696f056df216eea4f9401adbee0ff744d4df390f
 ---
 GitRepository: flux-system
@@ -15,5 +15,5 @@ Namespace:     {{ .fluxns }}
 URL:           ssh://git@github.com/example/repo
 Branch:        main
 Revision:      main/696f056df216eea4f9401adbee0ff744d4df390f
-Status:        Last reconciled at 2021-07-20 00:48:16 +0000 UTC
+Status:        Last reconciled at {{ .gitRepositoryLastReconcile }}
 Message:       Fetched revision: main/696f056df216eea4f9401adbee0ff744d4df390f

--- a/cmd/flux/trace_test.go
+++ b/cmd/flux/trace_test.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"testing"
+	"time"
 )
 
 func TestTraceNoArgs(t *testing.T) {
@@ -15,36 +16,54 @@ func TestTraceNoArgs(t *testing.T) {
 	cmd.runTestCmd(t)
 }
 
+func toLocalTime(t *testing.T, in string) string {
+	ts, err := time.Parse(time.RFC3339, in)
+	if err != nil {
+		t.Fatalf("Error converting golden test time '%s': %v", in, err)
+	}
+	return ts.Local().String()
+}
+
 func TestTrace(t *testing.T) {
 	cases := []struct {
 		name       string
 		args       string
 		objectFile string
 		goldenFile string
+		tmpl       map[string]string
 	}{
 		{
 			"Deployment",
 			"trace podinfo --kind deployment --api-version=apps/v1",
 			"testdata/trace/deployment.yaml",
 			"testdata/trace/deployment.golden",
+			map[string]string{
+				"ns":                          allocateNamespace("podinfo"),
+				"fluxns":                      allocateNamespace("flux-system"),
+				"helmReleaseLastReconcile":    toLocalTime(t, "2021-07-16T15:42:20Z"),
+				"helmChartLastReconcile":      toLocalTime(t, "2021-07-16T15:32:09Z"),
+				"helmRepositoryLastReconcile": toLocalTime(t, "2021-07-11T00:25:46Z"),
+			},
 		},
 		{
 			"HelmRelease",
 			"trace podinfo --kind HelmRelease --api-version=helm.toolkit.fluxcd.io/v2beta1",
 			"testdata/trace/helmrelease.yaml",
 			"testdata/trace/helmrelease.golden",
+			map[string]string{
+				"ns":                         allocateNamespace("podinfo"),
+				"fluxns":                     allocateNamespace("flux-system"),
+				"kustomizationLastReconcile": toLocalTime(t, "2021-08-01T04:52:56Z"),
+				"gitRepositoryLastReconcile": toLocalTime(t, "2021-07-20T00:48:16Z"),
+			},
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			tmpl := map[string]string{
-				"ns":     allocateNamespace("podinfo"),
-				"fluxns": allocateNamespace("flux-system"),
-			}
-			testEnv.CreateObjectFile(tc.objectFile, tmpl, t)
+			testEnv.CreateObjectFile(tc.objectFile, tc.tmpl, t)
 			cmd := cmdTestCase{
-				args:   tc.args + " -n=" + tmpl["ns"],
-				assert: assertGoldenTemplateFile(tc.goldenFile, tmpl),
+				args:   tc.args + " -n=" + tc.tmpl["ns"],
+				assert: assertGoldenTemplateFile(tc.goldenFile, tc.tmpl),
 			}
 			cmd.runTestCmd(t)
 		})


### PR DESCRIPTION
The TestTrace/Deployment and TestTrace/HelmRelease test cases fail in environments where the timezone isn't UTC, because they compare a local time string to the golden file, which has time in UTC.  Here is an example:

```
--- FAIL: TestTrace (0.12s)
    --- FAIL: TestTrace/Deployment (0.08s)
        main_test.go:337: Mismatch from golden file 'testdata/trace/deployment.golden': Mismatch from expected value (-want +got):
              strings.Join({
                ... // 88 identical bytes
                " Flux\n---\nHelmRelease:    podinfo\nNamespace:      podinfo-8\nRevi",
                "sion:       6.0.0\nStatus:         Last reconciled at 2021-07-16 ",
            -   "15:42:20 +0000 UTC",
            +   "09:42:20 -0600 MDT",
                "\nMessage:        Release reconciliation succeeded\n---\nHelmChart:",
                "      podinfo-podinfo\nNamespace:      flux-system-9\nChart:      ",
                "    podinfo\nVersion:        6.0.0\nRevision:       6.0.0\nStatus: ",
                "        Last reconciled at 2021-07-16 ",
            -   "15:32:09 +0000 UTC",
            +   "09:32:09 -0600 MDT",
                "\nMessage:        Fetched revision: 6.0.0\n---\nHelmRepository: pod",
                "info\nNamespace:      flux-system-9\nURL:            https://stefa",
                "nprodan.github.io/podinfo\nRevision:       8411f23d07d3701f0e96e7",
                "d9e503b7936d7e1d56\nStatus:         Last reconciled at 2021-07-",
            -   "1",
                "1",
            -   " 00:25:46 +0000 UTC",
            +   "0 18:25:46 -0600 MDT",
                "\nMessage:        Fetched revision: 8411f23d07d3701f0e96e7d9e503b",
                "7936d7e1d56\n",
              }, "")
```

This commit fixes the issue by converting the golden test times to local time before comparing. The utility function toLocalTime() is added to trace_test.go, and then it is used to provide localized times as template parameters to the golden files.

Signed-off-by: Andrew Jenkins <andrew@aspenmesh.io>