### PR TITLE
Validate that object name adheres to RFC 1123 for `flux create` commands

### DIFF
--- a/cmd/flux/create.go
+++ b/cmd/flux/create.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -51,6 +52,18 @@ func init() {
 	createCmd.PersistentFlags().BoolVar(&createArgs.export, "export", false, "export in YAML format to stdout")
 	createCmd.PersistentFlags().StringSliceVar(&createArgs.labels, "label", nil,
 		"set labels on the resource (can specify multiple labels with commas: label1=value1,label2=value2)")
+	createCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return fmt.Errorf("name is required")
+		}
+
+		name := args[0]
+		if !validateObjectName(name) {
+			return fmt.Errorf("name '%s' is invalid, it should adhere to standard defined in RFC 1123", name)
+		}
+
+		return nil
+	}
 	rootCmd.AddCommand(createCmd)
 }
 
@@ -149,4 +162,9 @@ func parseLabels() (map[string]string, error) {
 	}
 
 	return result, nil
+}
+
+func validateObjectName(name string) bool {
+	r := regexp.MustCompile("^[a-z0-9]([a-z0-9\\-]){0,61}[a-z0-9]$")
+	return r.MatchString(name)
 }

--- a/cmd/flux/create.go
+++ b/cmd/flux/create.go
@@ -59,7 +59,7 @@ func init() {
 
 		name := args[0]
 		if !validateObjectName(name) {
-			return fmt.Errorf("name '%s' is invalid, it should adhere to standard defined in RFC 1123", name)
+			return fmt.Errorf("name '%s' is invalid, it should adhere to standard defined in RFC 1123, the name can only contain alphanumeric characters or '-'", name)
 		}
 
 		return nil

--- a/cmd/flux/create_alert.go
+++ b/cmd/flux/create_alert.go
@@ -63,9 +63,6 @@ func init() {
 }
 
 func createAlertCmdRun(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		return fmt.Errorf("Alert name is required")
-	}
 	name := args[0]
 
 	if alertArgs.providerRef == "" {

--- a/cmd/flux/create_alertprovider.go
+++ b/cmd/flux/create_alertprovider.go
@@ -73,9 +73,6 @@ func init() {
 }
 
 func createAlertProviderCmdRun(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		return fmt.Errorf("Provider name is required")
-	}
 	name := args[0]
 
 	if alertProviderArgs.alertType == "" {

--- a/cmd/flux/create_helmrelease.go
+++ b/cmd/flux/create_helmrelease.go
@@ -139,9 +139,6 @@ func init() {
 }
 
 func createHelmReleaseCmdRun(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		return fmt.Errorf("HelmRelease name is required")
-	}
 	name := args[0]
 
 	if helmReleaseArgs.chart == "" {

--- a/cmd/flux/create_image_policy.go
+++ b/cmd/flux/create_image_policy.go
@@ -84,9 +84,6 @@ func (obj imagePolicyAdapter) getObservedGeneration() int64 {
 }
 
 func createImagePolicyRun(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		return fmt.Errorf("ImagePolicy name is required")
-	}
 	objectName := args[0]
 
 	if imagePolicyArgs.imageRef == "" {

--- a/cmd/flux/create_image_repository.go
+++ b/cmd/flux/create_image_repository.go
@@ -83,9 +83,6 @@ func init() {
 }
 
 func createImageRepositoryRun(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		return fmt.Errorf("ImageRepository name is required")
-	}
 	objectName := args[0]
 
 	if imageRepoArgs.image == "" {

--- a/cmd/flux/create_image_update.go
+++ b/cmd/flux/create_image_update.go
@@ -94,9 +94,6 @@ func init() {
 }
 
 func createImageUpdateRun(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		return fmt.Errorf("ImageUpdateAutomation name is required")
-	}
 	objectName := args[0]
 
 	if imageUpdateArgs.gitRepoName == "" {

--- a/cmd/flux/create_kustomization.go
+++ b/cmd/flux/create_kustomization.go
@@ -119,9 +119,6 @@ func NewKustomizationFlags() kustomizationFlags {
 }
 
 func createKsCmdRun(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		return fmt.Errorf("Kustomization name is required")
-	}
 	name := args[0]
 
 	if kustomizationArgs.path == "" {

--- a/cmd/flux/create_receiver.go
+++ b/cmd/flux/create_receiver.go
@@ -67,9 +67,6 @@ func init() {
 }
 
 func createReceiverCmdRun(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		return fmt.Errorf("Receiver name is required")
-	}
 	name := args[0]
 
 	if receiverArgs.receiverType == "" {

--- a/cmd/flux/create_secret_git.go
+++ b/cmd/flux/create_secret_git.go
@@ -112,9 +112,6 @@ func NewSecretGitFlags() secretGitFlags {
 }
 
 func createSecretGitCmdRun(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		return fmt.Errorf("secret name is required")
-	}
 	name := args[0]
 	if secretGitArgs.url == "" {
 		return fmt.Errorf("url is required")

--- a/cmd/flux/create_secret_git_test.go
+++ b/cmd/flux/create_secret_git_test.go
@@ -13,7 +13,7 @@ func TestCreateGitSecret(t *testing.T) {
 		{
 			name:   "no args",
 			args:   "create secret git",
-			assert: assertError("secret name is required"),
+			assert: assertError("name is required"),
 		},
 		{
 			name:   "basic secret",

--- a/cmd/flux/create_secret_helm.go
+++ b/cmd/flux/create_secret_helm.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -68,9 +67,6 @@ func init() {
 }
 
 func createSecretHelmCmdRun(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		return fmt.Errorf("secret name is required")
-	}
 	name := args[0]
 
 	labels, err := parseLabels()

--- a/cmd/flux/create_secret_helm_test.go
+++ b/cmd/flux/create_secret_helm_test.go
@@ -12,7 +12,7 @@ func TestCreateHelmSecret(t *testing.T) {
 	}{
 		{
 			args:   "create secret helm",
-			assert: assertError("secret name is required"),
+			assert: assertError("name is required"),
 		},
 		{
 			args:   "create secret helm helm-secret --username=my-username --password=my-password --namespace=my-namespace --export",

--- a/cmd/flux/create_secret_tls.go
+++ b/cmd/flux/create_secret_tls.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -67,9 +66,6 @@ func init() {
 }
 
 func createSecretTLSCmdRun(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		return fmt.Errorf("secret name is required")
-	}
 	name := args[0]
 
 	labels, err := parseLabels()

--- a/cmd/flux/create_secret_tls_test.go
+++ b/cmd/flux/create_secret_tls_test.go
@@ -12,7 +12,7 @@ func TestCreateTlsSecretNoArgs(t *testing.T) {
 	}{
 		{
 			args:   "create secret tls",
-			assert: assertError("secret name is required"),
+			assert: assertError("name is required"),
 		},
 		{
 			args:   "create secret tls certs --namespace=my-namespace --cert-file=./testdata/create_secret/tls/test-cert.pem --key-file=./testdata/create_secret/tls/test-key.pem --export",

--- a/cmd/flux/create_source_bucket.go
+++ b/cmd/flux/create_source_bucket.go
@@ -93,9 +93,6 @@ func NewSourceBucketFlags() sourceBucketFlags {
 }
 
 func createSourceBucketCmdRun(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		return fmt.Errorf("Bucket source name is required")
-	}
 	name := args[0]
 
 	if sourceBucketArgs.name == "" {

--- a/cmd/flux/create_source_git.go
+++ b/cmd/flux/create_source_git.go
@@ -150,9 +150,6 @@ func newSourceGitFlags() sourceGitFlags {
 }
 
 func createSourceGitCmdRun(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		return fmt.Errorf("GitRepository source name is required")
-	}
 	name := args[0]
 
 	if sourceGitArgs.url == "" {

--- a/cmd/flux/create_source_git_test.go
+++ b/cmd/flux/create_source_git_test.go
@@ -96,7 +96,7 @@ func TestCreateSourceGit(t *testing.T) {
 		{
 			"NoArgs",
 			"create source git",
-			assertError("GitRepository source name is required"),
+			assertError("name is required"),
 			nil,
 		}, {
 			"Succeeded",

--- a/cmd/flux/create_source_helm.go
+++ b/cmd/flux/create_source_helm.go
@@ -91,9 +91,6 @@ func init() {
 }
 
 func createSourceHelmCmdRun(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		return fmt.Errorf("HelmRepository source name is required")
-	}
 	name := args[0]
 
 	if sourceHelmArgs.url == "" {

--- a/cmd/flux/create_tenant.go
+++ b/cmd/flux/create_tenant.go
@@ -70,9 +70,6 @@ func init() {
 }
 
 func createTenantCmdRun(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		return fmt.Errorf("tenant name is required")
-	}
 	tenant := args[0]
 	if err := validation.IsQualifiedName(tenant); len(err) > 0 {
 		return fmt.Errorf("invalid tenant name '%s': %v", tenant, err)

--- a/cmd/flux/create_test.go
+++ b/cmd/flux/create_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/rand"
+)
+
+func Test_validateObjectName(t *testing.T) {
+	tests := []struct {
+		name  string
+		valid bool
+	}{
+		{
+			name:  "flux-system",
+			valid: true,
+		},
+		{
+			name:  "-flux-system",
+			valid: false,
+		},
+		{
+			name:  "-flux-system-",
+			valid: false,
+		},
+		{
+			name:  "third.first",
+			valid: false,
+		},
+		{
+			name:  "THirdfirst",
+			valid: false,
+		},
+		{
+			name:  "THirdfirst",
+			valid: false,
+		},
+		{
+			name:  rand.String(63),
+			valid: true,
+		},
+		{
+			name:  rand.String(64),
+			valid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		valid := validateObjectName(tt.name)
+		if valid != tt.valid {
+			t.Errorf("expected name %q to return %t for validateObjectName func but got %t",
+				tt.name, tt.valid, valid)
+		}
+	}
+}


### PR DESCRIPTION
This pull request validates the name passed to `flux create` commands matches the [RFC 1123 Label Names].(https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names)

Signed-off-by: Somtochi Onyekwere <somtochionyekwere@gmail.com>