### PR TITLE
Update `get` subcommand column order

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,13 @@ Then you can run the end-to-end tests with:
 make e2e
 ```
 
+When the output of the Flux CLI changes, to automatically update the golden
+files used in the test, pass `-update` flag to the test as:
+
+```bash
+make e2e TEST_ARGS="-update"
+```
+
 Teardown the e2e environment with:
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,18 @@ files used in the test, pass `-update` flag to the test as:
 make e2e TEST_ARGS="-update"
 ```
 
+Since not all packages use golden files for testing, `-update` argument must be
+passed only for the packages that use golden files. Use the variables
+`TEST_PKG_PATH` for unit tests and `E2E_TEST_PKG_PATH` for e2e tests, to set the
+path of the target test package:
+
+```bash
+# Unit test
+make test TEST_PKG_PATH="./cmd/flux" TEST_ARGS="-update"
+# e2e test
+make e2e E2E_TEST_PKG_PATH="./cmd/flux" TEST_ARGS="-update"
+```
+
 Teardown the e2e environment with:
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,13 @@ cleanup-kind:
 	rm $(TEST_KUBECONFIG)
 
 KUBEBUILDER_ASSETS?="$(shell $(ENVTEST) --arch=$(ENVTEST_ARCH) use -i $(ENVTEST_KUBERNETES_VERSION) --bin-dir=$(ENVTEST_ASSETS_DIR) -p path)"
+TEST_PKG_PATH="./..."
 test: $(EMBEDDED_MANIFESTS_TARGET) tidy fmt vet install-envtest
-	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test ./... -coverprofile cover.out --tags=unit
+	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test $(TEST_PKG_PATH) -coverprofile cover.out --tags=unit $(TEST_ARGS)
 
+E2E_TEST_PKG_PATH="./cmd/flux/..."
 e2e: $(EMBEDDED_MANIFESTS_TARGET) tidy fmt vet
-	TEST_KUBECONFIG=$(TEST_KUBECONFIG) go test ./cmd/flux/... -coverprofile e2e.cover.out --tags=e2e -v -failfast $(TEST_ARGS)
+	TEST_KUBECONFIG=$(TEST_KUBECONFIG) go test $(E2E_TEST_PKG_PATH) -coverprofile e2e.cover.out --tags=e2e -v -failfast $(TEST_ARGS)
 
 test-with-kind: install-envtest
 	make setup-kind

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ test: $(EMBEDDED_MANIFESTS_TARGET) tidy fmt vet install-envtest
 	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test ./... -coverprofile cover.out --tags=unit
 
 e2e: $(EMBEDDED_MANIFESTS_TARGET) tidy fmt vet
-	TEST_KUBECONFIG=$(TEST_KUBECONFIG) go test ./cmd/flux/... -coverprofile e2e.cover.out --tags=e2e -v -failfast
+	TEST_KUBECONFIG=$(TEST_KUBECONFIG) go test ./cmd/flux/... -coverprofile e2e.cover.out --tags=e2e -v -failfast $(TEST_ARGS)
 
 test-with-kind: install-envtest
 	make setup-kind

--- a/cmd/flux/get_alert.go
+++ b/cmd/flux/get_alert.go
@@ -77,11 +77,11 @@ func init() {
 func (s alertListAdapter) summariseItem(i int, includeNamespace bool, includeKind bool) []string {
 	item := s.Items[i]
 	status, msg := statusAndMessage(item.Status.Conditions)
-	return append(nameColumns(&item, includeNamespace, includeKind), status, msg, strings.Title(strconv.FormatBool(item.Spec.Suspend)))
+	return append(nameColumns(&item, includeNamespace, includeKind), strings.Title(strconv.FormatBool(item.Spec.Suspend)), status, msg)
 }
 
 func (s alertListAdapter) headers(includeNamespace bool) []string {
-	headers := []string{"Name", "Ready", "Message", "Suspended"}
+	headers := []string{"Name", "Suspended", "Ready", "Message"}
 	if includeNamespace {
 		return append(namespaceHeader, headers...)
 	}

--- a/cmd/flux/get_helmrelease.go
+++ b/cmd/flux/get_helmrelease.go
@@ -75,11 +75,11 @@ func (a helmReleaseListAdapter) summariseItem(i int, includeNamespace bool, incl
 	revision := item.Status.LastAppliedRevision
 	status, msg := statusAndMessage(item.Status.Conditions)
 	return append(nameColumns(&item, includeNamespace, includeKind),
-		status, msg, revision, strings.Title(strconv.FormatBool(item.Spec.Suspend)))
+		revision, strings.Title(strconv.FormatBool(item.Spec.Suspend)), status, msg)
 }
 
 func (a helmReleaseListAdapter) headers(includeNamespace bool) []string {
-	headers := []string{"Name", "Ready", "Message", "Revision", "Suspended"}
+	headers := []string{"Name", "Revision", "Suspended", "Ready", "Message"}
 	if includeNamespace {
 		headers = append([]string{"Namespace"}, headers...)
 	}

--- a/cmd/flux/get_image_policy.go
+++ b/cmd/flux/get_image_policy.go
@@ -74,11 +74,11 @@ func init() {
 func (s imagePolicyListAdapter) summariseItem(i int, includeNamespace bool, includeKind bool) []string {
 	item := s.Items[i]
 	status, msg := statusAndMessage(item.Status.Conditions)
-	return append(nameColumns(&item, includeNamespace, includeKind), status, msg, item.Status.LatestImage)
+	return append(nameColumns(&item, includeNamespace, includeKind), item.Status.LatestImage, status, msg)
 }
 
 func (s imagePolicyListAdapter) headers(includeNamespace bool) []string {
-	headers := []string{"Name", "Ready", "Message", "Latest image"}
+	headers := []string{"Name", "Latest image", "Ready", "Message"}
 	if includeNamespace {
 		return append(namespaceHeader, headers...)
 	}

--- a/cmd/flux/get_image_repository.go
+++ b/cmd/flux/get_image_repository.go
@@ -82,11 +82,11 @@ func (s imageRepositoryListAdapter) summariseItem(i int, includeNamespace bool, 
 		lastScan = item.Status.LastScanResult.ScanTime.Time.Format(time.RFC3339)
 	}
 	return append(nameColumns(&item, includeNamespace, includeKind),
-		status, msg, lastScan, strings.Title(strconv.FormatBool(item.Spec.Suspend)))
+		lastScan, strings.Title(strconv.FormatBool(item.Spec.Suspend)), status, msg)
 }
 
 func (s imageRepositoryListAdapter) headers(includeNamespace bool) []string {
-	headers := []string{"Name", "Ready", "Message", "Last scan", "Suspended"}
+	headers := []string{"Name", "Last scan", "Suspended", "Ready", "Message"}
 	if includeNamespace {
 		return append(namespaceHeader, headers...)
 	}

--- a/cmd/flux/get_image_update.go
+++ b/cmd/flux/get_image_update.go
@@ -81,11 +81,11 @@ func (s imageUpdateAutomationListAdapter) summariseItem(i int, includeNamespace 
 	if item.Status.LastAutomationRunTime != nil {
 		lastRun = item.Status.LastAutomationRunTime.Time.Format(time.RFC3339)
 	}
-	return append(nameColumns(&item, includeNamespace, includeKind), status, msg, lastRun, strings.Title(strconv.FormatBool(item.Spec.Suspend)))
+	return append(nameColumns(&item, includeNamespace, includeKind), lastRun, strings.Title(strconv.FormatBool(item.Spec.Suspend)), status, msg)
 }
 
 func (s imageUpdateAutomationListAdapter) headers(includeNamespace bool) []string {
-	headers := []string{"Name", "Ready", "Message", "Last run", "Suspended"}
+	headers := []string{"Name", "Last run", "Suspended", "Ready", "Message"}
 	if includeNamespace {
 		return append(namespaceHeader, headers...)
 	}

--- a/cmd/flux/get_kustomization.go
+++ b/cmd/flux/get_kustomization.go
@@ -85,11 +85,11 @@ func (a kustomizationListAdapter) summariseItem(i int, includeNamespace bool, in
 		msg = shortenCommitSha(msg)
 	}
 	return append(nameColumns(&item, includeNamespace, includeKind),
-		status, msg, revision, strings.Title(strconv.FormatBool(item.Spec.Suspend)))
+		revision, strings.Title(strconv.FormatBool(item.Spec.Suspend)), status, msg)
 }
 
 func (a kustomizationListAdapter) headers(includeNamespace bool) []string {
-	headers := []string{"Name", "Ready", "Message", "Revision", "Suspended"}
+	headers := []string{"Name", "Revision", "Suspended", "Ready", "Message"}
 	if includeNamespace {
 		headers = append([]string{"Namespace"}, headers...)
 	}

--- a/cmd/flux/get_receiver.go
+++ b/cmd/flux/get_receiver.go
@@ -74,11 +74,11 @@ func init() {
 func (s receiverListAdapter) summariseItem(i int, includeNamespace bool, includeKind bool) []string {
 	item := s.Items[i]
 	status, msg := statusAndMessage(item.Status.Conditions)
-	return append(nameColumns(&item, includeNamespace, includeKind), status, msg, strings.Title(strconv.FormatBool(item.Spec.Suspend)))
+	return append(nameColumns(&item, includeNamespace, includeKind), strings.Title(strconv.FormatBool(item.Spec.Suspend)), status, msg)
 }
 
 func (s receiverListAdapter) headers(includeNamespace bool) []string {
-	headers := []string{"Name", "Ready", "Message", "Suspended"}
+	headers := []string{"Name", "Suspended", "Ready", "Message"}
 	if includeNamespace {
 		return append(namespaceHeader, headers...)
 	}

--- a/cmd/flux/get_source_bucket.go
+++ b/cmd/flux/get_source_bucket.go
@@ -81,11 +81,11 @@ func (a *bucketListAdapter) summariseItem(i int, includeNamespace bool, includeK
 	}
 	status, msg := statusAndMessage(item.Status.Conditions)
 	return append(nameColumns(&item, includeNamespace, includeKind),
-		status, msg, revision, strings.Title(strconv.FormatBool(item.Spec.Suspend)))
+		revision, strings.Title(strconv.FormatBool(item.Spec.Suspend)), status, msg)
 }
 
 func (a bucketListAdapter) headers(includeNamespace bool) []string {
-	headers := []string{"Name", "Ready", "Message", "Revision", "Suspended"}
+	headers := []string{"Name", "Revision", "Suspended", "Ready", "Message"}
 	if includeNamespace {
 		headers = append([]string{"Namespace"}, headers...)
 	}

--- a/cmd/flux/get_source_chart.go
+++ b/cmd/flux/get_source_chart.go
@@ -81,11 +81,11 @@ func (a *helmChartListAdapter) summariseItem(i int, includeNamespace bool, inclu
 	}
 	status, msg := statusAndMessage(item.Status.Conditions)
 	return append(nameColumns(&item, includeNamespace, includeKind),
-		status, msg, revision, strings.Title(strconv.FormatBool(item.Spec.Suspend)))
+		revision, strings.Title(strconv.FormatBool(item.Spec.Suspend)), status, msg)
 }
 
 func (a helmChartListAdapter) headers(includeNamespace bool) []string {
-	headers := []string{"Name", "Ready", "Message", "Revision", "Suspended"}
+	headers := []string{"Name", "Revision", "Suspended", "Ready", "Message"}
 	if includeNamespace {
 		headers = append([]string{"Namespace"}, headers...)
 	}

--- a/cmd/flux/get_source_git.go
+++ b/cmd/flux/get_source_git.go
@@ -86,11 +86,11 @@ func (a *gitRepositoryListAdapter) summariseItem(i int, includeNamespace bool, i
 		msg = shortenCommitSha(msg)
 	}
 	return append(nameColumns(&item, includeNamespace, includeKind),
-		status, msg, revision, strings.Title(strconv.FormatBool(item.Spec.Suspend)))
+		revision, strings.Title(strconv.FormatBool(item.Spec.Suspend)), status, msg)
 }
 
 func (a gitRepositoryListAdapter) headers(includeNamespace bool) []string {
-	headers := []string{"Name", "Ready", "Message", "Revision", "Suspended"}
+	headers := []string{"Name", "Revision", "Suspended", "Ready", "Message"}
 	if includeNamespace {
 		headers = append([]string{"Namespace"}, headers...)
 	}

--- a/cmd/flux/get_source_helm.go
+++ b/cmd/flux/get_source_helm.go
@@ -81,11 +81,11 @@ func (a *helmRepositoryListAdapter) summariseItem(i int, includeNamespace bool, 
 	}
 	status, msg := statusAndMessage(item.Status.Conditions)
 	return append(nameColumns(&item, includeNamespace, includeKind),
-		status, msg, revision, strings.Title(strconv.FormatBool(item.Spec.Suspend)))
+		revision, strings.Title(strconv.FormatBool(item.Spec.Suspend)), status, msg)
 }
 
 func (a helmRepositoryListAdapter) headers(includeNamespace bool) []string {
-	headers := []string{"Name", "Ready", "Message", "Revision", "Suspended"}
+	headers := []string{"Name", "Revision", "Suspended", "Ready", "Message"}
 	if includeNamespace {
 		headers = append([]string{"Namespace"}, headers...)
 	}

--- a/cmd/flux/main_test.go
+++ b/cmd/flux/main_test.go
@@ -304,10 +304,15 @@ func assertGoldenTemplateFile(goldenFile string, templateValues map[string]strin
 		if assertErr := assertGoldenValue(expectedOutput)(output, err); assertErr != nil {
 			// Update the golden files if comparision fails and the update flag is set.
 			if *update && output != "" {
-				if err := os.WriteFile(goldenFile, []byte(output), 0644); err != nil {
-					return fmt.Errorf("failed to update golden file '%s': %v", goldenFile, err)
+				// Skip update if there are template values.
+				if len(templateValues) > 0 {
+					fmt.Println("NOTE: -update flag passed but golden template files can't be updated, please update it manually")
+				} else {
+					if err := os.WriteFile(goldenFile, []byte(output), 0644); err != nil {
+						return fmt.Errorf("failed to update golden file '%s': %v", goldenFile, err)
+					}
+					return nil
 				}
-				return nil
 			}
 			return fmt.Errorf("Mismatch from golden file '%s': %v", goldenFile, assertErr)
 		}

--- a/cmd/flux/testdata/helmrelease/get_helmrelease_from_git.golden
+++ b/cmd/flux/testdata/helmrelease/get_helmrelease_from_git.golden
@@ -1,2 +1,2 @@
-NAME 	READY	MESSAGE                         	REVISION	SUSPENDED 
-thrfg	True 	Release reconciliation succeeded	6.0.0   	False    	
+NAME 	REVISION	SUSPENDED	READY	MESSAGE                          
+thrfg	6.0.0   	False    	True 	Release reconciliation succeeded	

--- a/cmd/flux/testdata/image/get_image_policy_regex.golden
+++ b/cmd/flux/testdata/image/get_image_policy_regex.golden
@@ -1,2 +1,2 @@
-NAME         	READY	MESSAGE                                                               	LATEST IMAGE                       
-podinfo-regex	True 	Latest image tag for 'ghcr.io/stefanprodan/podinfo' resolved to: 5.0.0	ghcr.io/stefanprodan/podinfo:5.0.0	
+NAME         	LATEST IMAGE                      	READY	MESSAGE                                                                
+podinfo-regex	ghcr.io/stefanprodan/podinfo:5.0.0	True 	Latest image tag for 'ghcr.io/stefanprodan/podinfo' resolved to: 5.0.0	

--- a/cmd/flux/testdata/image/get_image_policy_semver.golden
+++ b/cmd/flux/testdata/image/get_image_policy_semver.golden
@@ -1,2 +1,2 @@
-NAME          	READY	MESSAGE                                                               	LATEST IMAGE                       
-podinfo-semver	True 	Latest image tag for 'ghcr.io/stefanprodan/podinfo' resolved to: 5.0.3	ghcr.io/stefanprodan/podinfo:5.0.3	
+NAME          	LATEST IMAGE                      	READY	MESSAGE                                                                
+podinfo-semver	ghcr.io/stefanprodan/podinfo:5.0.3	True 	Latest image tag for 'ghcr.io/stefanprodan/podinfo' resolved to: 5.0.3	

--- a/cmd/flux/testdata/kustomization/get_kustomization_from_git.golden
+++ b/cmd/flux/testdata/kustomization/get_kustomization_from_git.golden
@@ -1,2 +1,2 @@
-NAME	READY	MESSAGE                        	REVISION     	SUSPENDED 
-tkfg	True 	Applied revision: 6.0.0/627d5c4	6.0.0/627d5c4	False    	
+NAME	REVISION     	SUSPENDED	READY	MESSAGE                         
+tkfg	6.0.0/627d5c4	False    	True 	Applied revision: 6.0.0/627d5c4	


### PR DESCRIPTION
- Move `READY` and `MESSAGE` to the end of `get` subcommand output.
- Add test flag `-update` to update the golden files.
- Update the golden files based on the output change using.

Fixes https://github.com/fluxcd/flux2/issues/2385

Associated PRs:
- https://github.com/fluxcd/source-controller/pull/592
- https://github.com/fluxcd/kustomize-controller/pull/578
- https://github.com/fluxcd/helm-controller/pull/425
- https://github.com/fluxcd/notification-controller/pull/337