### PR TITLE
feat: add linux/s390x builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,7 @@ builds:
       - amd64
       - arm64
       - arm
+      - s390x
     goarm:
       - 7
   - <<: *build_defaults
@@ -158,17 +159,35 @@ dockers:
     - "--label=org.opencontainers.image.version={{ .Version }}"
     - "--label=org.opencontainers.image.source={{ .GitURL }}"
     - "--platform=linux/arm/v7"
+- image_templates:
+    - 'fluxcd/flux-cli:{{ .Tag }}-s390x'
+    - 'ghcr.io/fluxcd/flux-cli:{{ .Tag }}-s390x'
+  dockerfile: Dockerfile
+  use: buildx
+  goos: linux
+  goarch: s390x
+  build_flag_templates:
+    - "--pull"
+    - "--build-arg=ARCH=linux/s390x"
+    - "--label=org.opencontainers.image.created={{ .Date }}"
+    - "--label=org.opencontainers.image.name={{ .ProjectName }}"
+    - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+    - "--label=org.opencontainers.image.version={{ .Version }}"
+    - "--label=org.opencontainers.image.source={{ .GitURL }}"
+    - "--platform=linux/s390x"
 docker_manifests:
 - name_template: 'fluxcd/flux-cli:{{ .Tag }}'
   image_templates:
     - 'fluxcd/flux-cli:{{ .Tag }}-amd64'
     - 'fluxcd/flux-cli:{{ .Tag }}-arm64'
     - 'fluxcd/flux-cli:{{ .Tag }}-arm'
+    - 'fluxcd/flux-cli:{{ .Tag }}-s390x'
 - name_template: 'ghcr.io/fluxcd/flux-cli:{{ .Tag }}'
   image_templates:
     - 'ghcr.io/fluxcd/flux-cli:{{ .Tag }}-amd64'
     - 'ghcr.io/fluxcd/flux-cli:{{ .Tag }}-arm64'
     - 'ghcr.io/fluxcd/flux-cli:{{ .Tag }}-arm'
+    - 'ghcr.io/fluxcd/flux-cli:{{ .Tag }}-s390x'
 docker_signs:
   - cmd: cosign
     env:


### PR DESCRIPTION
Signed-off-by: skuethe <56306041+skuethe@users.noreply.github.com>

This PR adds the `s390x` platform to build and release automation. As multi arch builds are setup perfectly already, the necessary changes are minimal.
A (stripped down) successful version of the github action can be seen here:
https://github.com/skuethe/flux2/actions/runs/1893656250

I have thought about also adapting e2e tests for s390x, but that seems (at least at this point) out of the question, as there are no s390x instances on equinix:
https://metal.equinix.com/developers/docs/servers/about/#architecture

I hope opening this PR directly (without a referencing issue) is okay, I did not find anything related to that in your CONTRIBUTING.md

Will look into adding s390x support on the GitOps Toolkit components in the next days.