### PR TITLE
Introduce a printer interface for flux resources

### DIFF
--- a/cmd/flux/get.go
+++ b/cmd/flux/get.go
@@ -33,6 +33,7 @@ import (
 	"github.com/fluxcd/pkg/apis/meta"
 
 	"github.com/fluxcd/flux2/internal/utils"
+	"github.com/fluxcd/flux2/pkg/printers"
 )
 
 type deriveType func(runtime.Object) (summarisable, error)
@@ -177,7 +178,10 @@ func (get getCommand) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	utils.PrintTable(cmd.OutOrStdout(), header, rows)
+	err = printers.TablePrinter(header).Print(cmd.OutOrStdout(), rows)
+	if err != nil {
+		return err
+	}
 
 	if getAll {
 		fmt.Println()
@@ -242,10 +246,16 @@ func watchUntil(ctx context.Context, w watch.Interface, get *getCommand) (bool, 
 			return false, err
 		}
 		if firstIteration {
-			utils.PrintTable(os.Stdout, header, rows)
+			err = printers.TablePrinter(header).Print(os.Stdout, rows)
+			if err != nil {
+				return false, err
+			}
 			firstIteration = false
 		} else {
-			utils.PrintTable(os.Stdout, []string{}, rows)
+			err = printers.TablePrinter([]string{}).Print(os.Stdout, rows)
+			if err != nil {
+				return false, err
+			}
 		}
 
 		return false, nil

--- a/internal/build/diff.go
+++ b/internal/build/diff.go
@@ -27,6 +27,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/fluxcd/flux2/pkg/printers"
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
 	"github.com/fluxcd/pkg/ssa"
 	"github.com/gonvenience/bunt"
@@ -112,7 +113,7 @@ func (b *Builder) Diff() (string, bool, error) {
 		}
 
 		if change.Action == string(ssa.ConfiguredAction) {
-			output.WriteString(writeString(fmt.Sprintf("► %s drifted\n", change.Subject), bunt.WhiteSmoke))
+			output.WriteString(bunt.Sprint(fmt.Sprintf("► %s drifted\n", change.Subject)))
 			liveFile, mergedFile, tmpDir, err := writeYamls(liveObject, mergedObject)
 			if err != nil {
 				return "", createdOrDrifted, err
@@ -204,14 +205,9 @@ func diff(liveFile, mergedFile string, output io.Writer) error {
 		return fmt.Errorf("failed to compare input files: %w", err)
 	}
 
-	reportWriter := &dyff.HumanReport{
-		Report:     report,
-		OmitHeader: true,
-	}
+	printer := printers.NewDyffPrinter()
 
-	if err := reportWriter.WriteReport(output); err != nil {
-		return fmt.Errorf("failed to print report: %w", err)
-	}
+	printer.Print(output, report)
 
 	return nil
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -27,7 +27,6 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/olekukonko/tablewriter"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -245,24 +244,6 @@ func MakeDependsOn(deps []string) []dependency.CrossNamespaceDependencyReference
 		})
 	}
 	return refs
-}
-
-func PrintTable(writer io.Writer, header []string, rows [][]string) {
-	table := tablewriter.NewWriter(writer)
-	table.SetHeader(header)
-	table.SetAutoWrapText(false)
-	table.SetAutoFormatHeaders(true)
-	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
-	table.SetAlignment(tablewriter.ALIGN_LEFT)
-	table.SetCenterSeparator("")
-	table.SetColumnSeparator("")
-	table.SetRowSeparator("")
-	table.SetHeaderLine(false)
-	table.SetBorder(false)
-	table.SetTablePadding("\t")
-	table.SetNoWhiteSpace(true)
-	table.AppendBulk(rows)
-	table.Render()
 }
 
 func ValidateComponents(components []string) error {

--- a/pkg/printers/dyff.go
+++ b/pkg/printers/dyff.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printers
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/homeport/dyff/pkg/dyff"
+)
+
+// DyffPrinter is a printer that prints dyff reports.
+type DyffPrinter struct {
+	OmitHeader bool
+}
+
+// NewDyffPrinter returns a new DyffPrinter.
+func NewDyffPrinter() *DyffPrinter {
+	return &DyffPrinter{
+		OmitHeader: true,
+	}
+}
+
+// Print prints the given args to the given writer.
+func (p *DyffPrinter) Print(w io.Writer, args ...interface{}) error {
+	for _, arg := range args {
+		switch arg := arg.(type) {
+		case dyff.Report:
+			reportWriter := &dyff.HumanReport{
+				Report:     arg,
+				OmitHeader: p.OmitHeader,
+			}
+
+			if err := reportWriter.WriteReport(w); err != nil {
+				return fmt.Errorf("failed to print report: %w", err)
+			}
+		default:
+			return fmt.Errorf("unsupported type %T", arg)
+		}
+	}
+	return nil
+}

--- a/pkg/printers/interface.go
+++ b/pkg/printers/interface.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printers
+
+import "io"
+
+// Printer is an interface for printing Flux cmd	outputs.
+type Printer interface {
+	// Print prints the given args to the given writer.
+	Print(io.Writer, ...interface{}) error
+}
+
+// PrinterFunc is a function that can print args to a writer.
+type PrinterFunc func(w io.Writer, args ...interface{}) error
+
+// Print implements Printer
+func (fn PrinterFunc) Print(w io.Writer, args ...interface{}) error {
+	return fn(w, args)
+}

--- a/pkg/printers/table_printer.go
+++ b/pkg/printers/table_printer.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printers
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/olekukonko/tablewriter"
+)
+
+// TablePrinter is a printer that prints Flux cmd	outputs.
+func TablePrinter(header []string) PrinterFunc {
+	return func(w io.Writer, args ...interface{}) error {
+		var rows [][]string
+		for _, arg := range args {
+			switch arg := arg.(type) {
+			case []interface{}:
+				for _, v := range arg {
+					s, ok := v.([][]string)
+					if !ok {
+						return fmt.Errorf("unsupported type %T", v)
+					}
+					for i := range s {
+						rows = append(rows, s[i])
+					}
+				}
+			default:
+				return fmt.Errorf("unsupported type %T", arg)
+			}
+		}
+
+		table := tablewriter.NewWriter(w)
+		table.SetHeader(header)
+		table.SetAutoWrapText(false)
+		table.SetAutoFormatHeaders(true)
+		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+		table.SetAlignment(tablewriter.ALIGN_LEFT)
+		table.SetCenterSeparator("")
+		table.SetColumnSeparator("")
+		table.SetRowSeparator("")
+		table.SetHeaderLine(false)
+		table.SetBorder(false)
+		table.SetTablePadding("\t")
+		table.SetNoWhiteSpace(true)
+		table.AppendBulk(rows)
+		table.Render()
+
+		return nil
+	}
+}


### PR DESCRIPTION
If implemented, there will a common interface to print flux resource.

We are adding new way to print resource information e.g. diff of objects (and unified diff in the future).

This will make it easier to add new printers for json, jsonpath, etc... when the need arise.

Signed-off-by: Soule BA <soule@weave.works>