### PR TITLE
Add coreutils (for Mac OS) as a dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,7 @@ Prerequisites:
 * go >= 1.17
 * kubectl >= 1.20
 * kustomize >= 4.4
+* coreutils (on Mac OS)
 
 Install the [controller-runtime/envtest](https://github.com/kubernetes-sigs/controller-runtime/tree/master/tools/setup-envtest) binaries with:
 


### PR DESCRIPTION
When trying to run the tests on Mac OS Monterey (Apple Silicon), I get this error:
```
❯ make test
./manifests/scripts/bundle.sh
./manifests/scripts/bundle.sh: line 19: realpath: command not found
make: *** [cmd/flux/.manifests.done] Error 127
```

I solved it by doing a `brew install coreutils`. Not sure it's a dependency you'd like to have listed, but it was required for me at least.