### PR TITLE
Use absolute domain name for the events address

### DIFF
--- a/manifests/bases/helm-controller/patch.yaml
+++ b/manifests/bases/helm-controller/patch.yaml
@@ -1,6 +1,6 @@
 - op: add
   path: /spec/template/spec/containers/0/args/0
-  value: --events-addr=http://notification-controller/
+  value: --events-addr=http://notification-controller.flux-system.svc.cluster.local./
 - op: add
   path: /spec/template/spec/serviceAccountName
   value: helm-controller

--- a/manifests/bases/image-automation-controller/patch.yaml
+++ b/manifests/bases/image-automation-controller/patch.yaml
@@ -1,6 +1,6 @@
 - op: add
   path: /spec/template/spec/containers/0/args/0
-  value: --events-addr=http://notification-controller/
+  value: --events-addr=http://notification-controller.flux-system.svc.cluster.local./
 - op: add
   path: /spec/template/spec/serviceAccountName
   value: image-automation-controller

--- a/manifests/bases/image-reflector-controller/patch.yaml
+++ b/manifests/bases/image-reflector-controller/patch.yaml
@@ -1,6 +1,6 @@
 - op: add
   path: /spec/template/spec/containers/0/args/0
-  value: --events-addr=http://notification-controller/
+  value: --events-addr=http://notification-controller.flux-system.svc.cluster.local./
 - op: add
   path: /spec/template/spec/serviceAccountName
   value: image-reflector-controller

--- a/manifests/bases/kustomize-controller/patch.yaml
+++ b/manifests/bases/kustomize-controller/patch.yaml
@@ -1,6 +1,6 @@
 - op: add
   path: /spec/template/spec/containers/0/args/0
-  value: --events-addr=http://notification-controller/
+  value: --events-addr=http://notification-controller.flux-system.svc.cluster.local./
 - op: add
   path: /spec/template/spec/serviceAccountName
   value: kustomize-controller

--- a/manifests/bases/source-controller/patch.yaml
+++ b/manifests/bases/source-controller/patch.yaml
@@ -1,6 +1,6 @@
 - op: add
   path: /spec/template/spec/containers/0/args/0
-  value: --events-addr=http://notification-controller/
+  value: --events-addr=http://notification-controller.flux-system.svc.cluster.local./
 - op: add
   path: /spec/template/spec/serviceAccountName
   value: source-controller

--- a/pkg/manifestgen/install/manifests.go
+++ b/pkg/manifestgen/install/manifests.go
@@ -73,7 +73,7 @@ func generate(base string, options Options) error {
 		// traffic from going through http proxy. Without fully specified
 		// domain they need to mention `notifications-controller` explicitly in
 		// `no_proxy` variable after debugging http proxy logs.
-		options.EventsAddr = fmt.Sprintf("http://%s.%s.svc.%s/", options.NotificationController, options.Namespace, options.ClusterDomain)
+		options.EventsAddr = fmt.Sprintf("http://%s.%s.svc.%s./", options.NotificationController, options.Namespace, options.ClusterDomain)
 	}
 
 	if err := execTemplate(options, namespaceTmpl, path.Join(base, "namespace.yaml")); err != nil {


### PR DESCRIPTION
Add ending dot to the events address to be consistent with source controller address.
This will affect `flux bootstrap` and `flux install` by setting `--events-addr=http://notification-controller.flux-system.svc.cluster.local./`.
