### PR TITLE
[RFC-0003] Flux OCI support for Kubernetes manifests

### DIFF
--- a/rfcs/0003-kubernetes-oci/README.md
+++ b/rfcs/0003-kubernetes-oci/README.md
@@ -1,10 +1,10 @@
-# RFC-xxxx Flux OCI support for Kubernetes manifests
+# RFC-0003 Flux OCI support for Kubernetes manifests
 
-**Status:** provisional
+**Status:** implementable
 
 **Creation date:** 2022-03-31
 
-**Last update:** 2022-06-22
+**Last update:** 2022-07-06
 
 ## Summary
 

--- a/rfcs/kubernetes-oci/README.md
+++ b/rfcs/kubernetes-oci/README.md
@@ -291,7 +291,9 @@ spec:
 
 ### Alternatives
 
-TODO
+An alternative solution is to introduce an OCI artifact type especially made for Kubernetes configuration.
+That is considered unpractical, as introducing an OCI type has to go through the
+IANA process and Flux is not the owner of those type as Helm is for Helm artifact for example.
 
 ## Design Details
 

--- a/rfcs/kubernetes-oci/README.md
+++ b/rfcs/kubernetes-oci/README.md
@@ -110,7 +110,25 @@ spec:
 The `secretRef` points to a Kubernetes secret in the same namespace as the `OCIRepository`,
 the secret type must be `kubernetes.io/dockerconfigjson`.
 
-When Flux runs on EKS or GKE, an IAM role (that grants read-only access to ACR, ECR or GCR)
+For private repositories which require a certificate to authenticate,
+the client certificate, private key and the CA certificate (if self-signed), can be provided with:
+
+```yaml
+spec:
+  certSecretRef:
+    name: regcert
+```
+
+The `certSecretRef` points to a Kubernetes secret in the same namespace as the `OCIRepository`:
+
+```shell
+kubectl create secret generic regcert \
+  --from-file=certFile=client.crt \
+  --from-file=keyFile=client.key \
+  --from-file=caFile=ca.crt
+```
+
+When Flux runs on AKS, EKS or GKE, an IAM role (that grants read-only access to ACR, ECR or GCR)
 can be used to bind the `source-controller` to the IAM role.
 
 Similar to image-reflector-controller
@@ -125,6 +143,19 @@ source-controller will expose dedicated flags for each cloud provider:
 
 We should extract the flags and the AWS, Azure and GCP auth implementations from image-reflector-controller into 
 `fluxcd/pkg/oci/auth` to reuses the code in source-controller.
+
+### Pull artifacts from self-hosted repositories
+
+For self-hosted Docker registries where the API is exposed with a self-signed TLS certificate,
+the CA certificate and private key can be provided with: 
+
+```yaml
+spec:
+  secretRef:
+    name: regcred
+
+```
+
 
 ### Reconcile artifacts
 

--- a/rfcs/kubernetes-oci/README.md
+++ b/rfcs/kubernetes-oci/README.md
@@ -83,7 +83,23 @@ spec:
     semver: "6.0.x"
 ```
 
-For private repositories, the credentials can be supplied with:
+To verify the authenticity of an artifact, the Sigstore cosign public key can be supplied with:
+
+```yaml
+spec:
+  verify:
+    provider: cosign
+    secretRef:
+      name: cosign-key
+```
+
+### Pull artifacts from private repositories
+
+For authentication purposes, Flux users can choose between supplying static credentials with Kubernetes secrets
+and cloud-based OIDC using an IAM role binding to the source-controller Kubernetes service account.
+
+For private repositories hosted on DockerHub, GitHub, Quay, self-hosted Docker Registry and others,
+the credentials can be supplied with:
 
 ```yaml
 spec:
@@ -94,15 +110,21 @@ spec:
 The `secretRef` points to a Kubernetes secret in the same namespace as the `OCIRepository`,
 the secret type must be `kubernetes.io/dockerconfigjson`.
 
-To verify the authenticity of an artifact, the Sigstore cosign public key can be supplied with:
+When Flux runs on EKS or GKE, an IAM role (that grants read-only access to ACR, ECR or GCR)
+can be used to bind the `source-controller` to the IAM role.
 
-```yaml
-spec:
-  verify:
-    provider: cosign
-    secretRef:
-      name: cosign-key
+Similar to image-reflector-controller
+[auto-login feature](https://fluxcd.io/docs/guides/image-update/#imagerepository-cloud-providers-authentication),
+source-controller will expose dedicated flags for each cloud provider:
+
+```sh
+--aws-autologin-for-ecr
+--azure-autologin-for-acr
+--gcp-autologin-for-gcr
 ```
+
+We should extract the flags and the AWS, Azure and GCP auth implementations from image-reflector-controller into 
+`fluxcd/pkg/oci/auth` to reuses the code in source-controller.
 
 ### Reconcile artifacts
 

--- a/rfcs/kubernetes-oci/README.md
+++ b/rfcs/kubernetes-oci/README.md
@@ -1,0 +1,140 @@
+# RFC-xxxx Flux OCI support for Kubernetes manifests
+
+**Status:** provisional
+
+**Creation date:** 2022-03-31
+
+**Last update:** 2022-03-31
+
+## Summary
+
+Flux should be able to distribute and reconcile Kubernetes configuration packaged as OCI artifacts.
+
+On the client-side, the Flux CLI should offer a command for packaging Kubernetes configs into
+an OCI artifact and pushing the artifact to a container registry using the Docker config file
+and the Docker credential helpers for authentication.
+
+On the server-side, the Flux source-controller should offer a dedicated API Kind for defining
+how OCI artifacts are pulled from container registries and how the artifact's authenticity can be verified.
+Flux should be able to work with any type of artifact even if it's not created with the Flux CLI.
+
+## Motivation
+
+Given that OCI registries are evolving into a generic artifact storage solution,
+we should extend Flux to allow fetching Kubernetes manifests and related configs
+from container registries similar to how Flux works with Git and Bucket storage.
+
+With OCI support, Flux users can automate artifact updates to Git in the same way
+they do today for container images.
+
+### Goals
+
+- Add support to the Flux CLI for packaging Kubernetes manifests and related configs into OCI artifacts.
+- Add support to Flux source-controller for fetching configs stored as OCI artifacts.
+- Make it easy for users to switch from Git repositories and Buckets to OCI repositories.
+
+### Non-Goals
+
+- Introduce a new OCI media type for artifacts containing Kubernetes manifests.
+
+## Proposal
+
+### Push artifacts
+
+Flux users should be able to package a local directory containing Kubernetes configs into a tarball
+and push the archive to a container registry as an OCI artifact.
+
+```sh
+flux push artifact docker.io/org/app-config:v1.0.0 -f ./deploy
+```
+
+Flux CLI with produce artifacts of type `application/vnd.oci.image.config.v1+json`.
+The directory pointed to by `-f` is archived and compressed in the `tar+gzip` format
+and the layer media type is set to `application/vnd.oci.image.layer.v1.tar+gzip`.
+
+> A proof-of-concept CLI implementation for distributing Kubernetes configs as OCI artifacts
+> is available at [kustomizer.dev](https://github.com/stefanprodan/kustomizer).
+
+### Pull artifacts
+
+Flux users should be able to define a source for pulling manifests inside the cluster from an OCI repository.
+
+```yaml
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: app-config
+  namespace: flux-system
+spec:
+  interval: 10m
+  url: docker.io/org/app-config
+  ref:
+    tag: v1.0.0
+```
+
+An `OCIRepository` can refer to an artifact by tag, digest or semver range:
+
+```yaml
+spec:
+  ref:
+    # one of
+    tag: "latest"
+    digest: "sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2"
+    semver: "6.0.x"
+```
+
+For private repositories, the credentials can be supplied with:
+
+```yaml
+spec:
+  secretRef:
+    name: regcred
+```
+
+The `secretRef` points to a Kubernetes secret in the same namespace as the `OCIRepository`,
+the secret type must be `kubernetes.io/dockerconfigjson`.
+
+To verify the authenticity of an artifact, the Sigstore cosign public key can be supplied with:
+
+```yaml
+spec:
+  verify:
+    provider: cosign
+    secretRef:
+      name: cosign-key
+```
+
+### Reconcile artifacts
+
+The `OCIRepository` can be used as a drop-in replacement for `GitRepository` and `Bucket` sources.
+For example a Flux Kustomization can refer to an `OCIRepository` and reconcile the manifests found in the OCI artifact:
+
+```yaml
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: app
+  namespace: flux-system
+spec:
+  interval: 10m
+  sourceRef:
+    kind: OCIRepository
+    name: app-config
+  path: ./
+```
+
+### User Stories
+
+TODO
+
+### Alternatives
+
+TODO
+
+## Design Details
+
+TODO
+
+### Enabling the feature
+
+The feature is enabled by default.

--- a/rfcs/kubernetes-oci/README.md
+++ b/rfcs/kubernetes-oci/README.md
@@ -119,6 +119,13 @@ kubectl create secret docker-registry regcred \
   --docker-password=<your-pword>
 ```
 
+For image pull secrets attached to a service account, the account name can be specified with:
+
+```yaml
+spec:
+  serviceAccountName: regsa
+```
+
 #### Client cert auth
 
 For private repositories which require a certificate to authenticate,

--- a/rfcs/kubernetes-oci/README.md
+++ b/rfcs/kubernetes-oci/README.md
@@ -51,7 +51,7 @@ flux push artifact docker.io/org/app-config:v1.0.0 \
   --revision="$(git branch --show-current)/$(git rev-parse HEAD)"
 ```
 
-The Flux CLI with produce artifacts of type `"application/vnd.docker.distribution.manifest.v2+json`
+The Flux CLI will produce artifacts of type `application/vnd.docker.distribution.manifest.v2+json`
 which ensures compatibility with container registries that don't support custom OCI media types.
 
 The directory pointed to by `--path` is archived and compressed in the `tar+gzip` format
@@ -99,6 +99,10 @@ spec:
   ref:
     tag: v1.0.0
 ```
+
+The `spec.url` field points to the container image repository in the format `<host>:<port>/<org-name>/<repo-name>`. 
+Note that specifying a tag or digest is not in accepted for this field. The `spec.url` value is used by the controller
+to fetch the list of tags from the remote OCI repository.
 
 An `OCIRepository` can refer to an artifact by tag, digest or semver range:
 

--- a/rfcs/kubernetes-oci/README.md
+++ b/rfcs/kubernetes-oci/README.md
@@ -4,7 +4,7 @@
 
 **Creation date:** 2022-03-31
 
-**Last update:** 2022-03-31
+**Last update:** 2022-04-13
 
 ## Summary
 
@@ -98,6 +98,8 @@ spec:
 For authentication purposes, Flux users can choose between supplying static credentials with Kubernetes secrets
 and cloud-based OIDC using an IAM role binding to the source-controller Kubernetes service account.
 
+#### Basic auth
+
 For private repositories hosted on DockerHub, GitHub, Quay, self-hosted Docker Registry and others,
 the credentials can be supplied with:
 
@@ -108,7 +110,16 @@ spec:
 ```
 
 The `secretRef` points to a Kubernetes secret in the same namespace as the `OCIRepository`,
-the secret type must be `kubernetes.io/dockerconfigjson`.
+the secret type must be `kubernetes.io/dockerconfigjson`:
+
+```shell
+kubectl create secret docker-registry regcred \
+  --docker-server=<your-registry-server> \
+  --docker-username=<your-name> \
+  --docker-password=<your-pword>
+```
+
+#### Client cert auth
 
 For private repositories which require a certificate to authenticate,
 the client certificate, private key and the CA certificate (if self-signed), can be provided with:
@@ -128,6 +139,8 @@ kubectl create secret generic regcert \
   --from-file=caFile=ca.crt
 ```
 
+#### OIDC auth
+
 When Flux runs on AKS, EKS or GKE, an IAM role (that grants read-only access to ACR, ECR or GCR)
 can be used to bind the `source-controller` to the IAM role.
 
@@ -143,19 +156,6 @@ source-controller will expose dedicated flags for each cloud provider:
 
 We should extract the flags and the AWS, Azure and GCP auth implementations from image-reflector-controller into 
 `fluxcd/pkg/oci/auth` to reuses the code in source-controller.
-
-### Pull artifacts from self-hosted repositories
-
-For self-hosted Docker registries where the API is exposed with a self-signed TLS certificate,
-the CA certificate and private key can be provided with: 
-
-```yaml
-spec:
-  secretRef:
-    name: regcred
-
-```
-
 
 ### Reconcile artifacts
 

--- a/rfcs/kubernetes-oci/README.md
+++ b/rfcs/kubernetes-oci/README.md
@@ -45,7 +45,7 @@ Flux users should be able to package a local directory containing Kubernetes con
 and push the archive to a container registry as an OCI artifact.
 
 ```sh
-flux push artifact docker.io/org/app-config:v1.0.0 \
+flux push artifact oci://docker.io/org/app-config:v1.0.0 \
   --source="$(git config --get remote.origin.url)" \
   --revision="$(git branch --show-current)/$(git rev-parse HEAD)" \
   --path="./deploy"
@@ -74,14 +74,14 @@ To ease the promotion workflow of a specific version from one environment to ano
 should offer a tagging command.
 
 ```sh
-flux tag artifact docker.io/org/app-config:v1.0.0 --tag=latest --tag=production
+flux tag artifact oci://docker.io/org/app-config:v1.0.0 --tag=latest --tag=production
 ```
 
 To view all the available artifacts in a repository and their metadata, the CLI should
 offer a list command.
 
 ```sh
-flux list artifacts docker.io/org/app-config
+flux list artifacts oci://docker.io/org/app-config
 ```
 
 To help inspect artifacts, the Flux CLI will offer a `build` and a `pull` command for generating
@@ -89,7 +89,7 @@ tarballs locally and for downloading the tarballs from remote container registri
 
 ```sh
 flux build artifact --path ./deploy --output tmp/artifact.tgz
-flux pull artifact docker.io/org/app-config:v1.0.0 --output ./manifests
+flux pull artifact oci://docker.io/org/app-config:v1.0.0 --output ./manifests
 ```
 
 ### Pull artifacts
@@ -104,12 +104,12 @@ metadata:
   namespace: flux-system
 spec:
   interval: 10m
-  url: docker.io/org/app-config
+  url: oci://docker.io/org/app-config
   ref:
     tag: v1.0.0
 ```
 
-The `spec.url` field points to the container image repository in the format `<host>:<port>/<org-name>/<repo-name>`. 
+The `spec.url` field points to the container image repository in the format `oci://<host>:<port>/<org-name>/<repo-name>`. 
 Note that specifying a tag or digest is not in accepted for this field. The `spec.url` value is used by the controller
 to fetch the list of tags from the remote OCI repository.
 
@@ -202,13 +202,10 @@ source-controller will expose dedicated flags for each cloud provider:
 --gcp-autologin-for-gcr
 ```
 
-We should extract the flags and the AWS, Azure and GCP auth implementations from image-reflector-controller into 
-`fluxcd/pkg/oci/auth` to reuses the code in source-controller.
-
 ### Reconcile artifacts
 
 The `OCIRepository` can be used as a drop-in replacement for `GitRepository` and `Bucket` sources.
-For example a Flux Kustomization can refer to an `OCIRepository` and reconcile the manifests found in the OCI artifact:
+For example, a Flux Kustomization can refer to an `OCIRepository` and reconcile the manifests found in the OCI artifact:
 
 ```yaml
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
@@ -248,7 +245,7 @@ Edit the app deployment manifest and set the new image tag.
 Then push the Kubernetes manifests to GHCR:
 
 ```sh
-flux push artifact ghcr.io/org/my-app-config:v1.0.0 \
+flux push artifact oci://ghcr.io/org/my-app-config:v1.0.0 \
 	--source="$(git config --get remote.origin.url)" \
 	--revision="$(git tag --points-at HEAD)/$(git rev-parse HEAD)"\
 	--path="./deploy"
@@ -263,13 +260,13 @@ cosign sign --key cosign.key ghcr.io/org/my-app-config:v1.0.0
 Mark `v1.0.0` as latest:
 
 ```sh
-flux tag artifact ghcr.io/org/my-app-config:v1.0.0 --tag latest
+flux tag artifact oci://ghcr.io/org/my-app-config:v1.0.0 --tag latest
 ```
 
 List the artifacts and their metadata with:
 
 ```console
-$ flux list artifacts ghcr.io/org/my-app-config
+$ flux list artifacts oci://ghcr.io/org/my-app-config
 ARTIFACT                                DIGEST                                                                 	SOURCE                                          REVISION                                      
 ghcr.io/org/my-app-config:latest   	sha256:45b95019d30af335137977a369ad56e9ea9e9c75bb01afb081a629ba789b890c	https://github.com/org/my-app-config.git   	v1.0.0/20b3a674391df53f05e59a33554973d1cbd4d549	
 ghcr.io/org/my-app-config:v1.0.0	sha256:45b95019d30af335137977a369ad56e9ea9e9c75bb01afb081a629ba789b890c	https://github.com/org/my-app-config.git	v1.0.0/3f45e72f0d3457e91e3c530c346d86969f9f4034	
@@ -305,7 +302,7 @@ metadata:
   namespace: default
 spec:
   interval: 10m
-  url: ghcr.io/org/my-app-config
+  url: oci://ghcr.io/org/my-app-config
   ref:
     semver: "1.x"
   secretRef:
@@ -397,7 +394,7 @@ spec:
   ref:
     tag: 6.1.6
   timeout: 60s
-  url: ghcr.io/stefanprodan/manifests/podinfo
+  url: oci://ghcr.io/stefanprodan/manifests/podinfo
 status:
   artifact:
     checksum: d7e924b4882e55b97627355c7b3d2e711e9b54303afa2f50c25377f4df66a83b

--- a/rfcs/kubernetes-oci/README.md
+++ b/rfcs/kubernetes-oci/README.md
@@ -48,6 +48,13 @@ and push the archive to a container registry as an OCI artifact.
 flux push artifact docker.io/org/app-config:v1.0.0 -f ./deploy
 ```
 
+To ease the promotion workflow of a specific version from one environment to another, the CLI
+should offer a tagging command.
+
+```sh
+flux tag artifact docker.io/org/app-config:v1.0.0 latest
+```
+
 Flux CLI with produce artifacts of type `application/vnd.oci.image.config.v1+json`.
 The directory pointed to by `-f` is archived and compressed in the `tar+gzip` format
 and the layer media type is set to `application/vnd.oci.image.layer.v1.tar+gzip`.
@@ -214,6 +221,12 @@ Sign the config image with cosign:
 
 ```sh
 cosign sign --key cosign.key ghcr.io/org/my-app-config:v1.0.0
+```
+
+Mark v1.0.0 as latest:
+
+```sh
+flux tag artifact ghcr.io/org/my-app-config:v1.0.0 latest
 ```
 
 #### Story 2


### PR DESCRIPTION
Proposal for adding OCI support for Kubernetes manifests to Flux.

Flux should be able to distribute and reconcile Kubernetes configuration packaged as OCI artifacts.

On the client-side, the Flux CLI should offer a command for packaging Kubernetes configs into an OCI artifact and pushing the artifact to a container registry using the Docker config file and the Docker credential helpers for authentication.

```sh
flux push artifact oci://ghcr.io/org/my-app-config:v1.0.0 --path ./deploy
```

On the server-side, the Flux source-controller should offer a dedicated API Kind for defining how OCI artifacts are pulled from container registries and how the artifact's authenticity can be verified. Flux source-controller should be able to work with any type of artifact even if it's not created with the Flux CLI.

```yaml
apiVersion: source.toolkit.fluxcd.io/v1beta2
kind: OCIRepository
metadata:
  name: app-config
spec:
  interval: 10m
  url: oci://ghcr.io/org/my-app-config
  ref:
    semver: "1.x"
  secretRef:
    name: my-app-regcred
  verify:
    provider: cosign
    secretRef:
      name: my-app-cosgin-key
```

To apply manifests stored in OCI artifacts, Flux kustomize-controller should accept `OCIRepository` as a source:

```yaml
apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
kind: Kustomization
metadata:
  name: app
spec:
  interval: 10m
  serviceAccountName: app-applier
  sourceRef:
    kind: OCIRepository
    name: app-config
  path: ./
  wait: true
  prune: true
```

This RFC is sponsored by @hiddeco 