### PR TITLE
monitoring-config: set grafana dashboards labelValues

### DIFF
--- a/manifests/monitoring/kube-prometheus-stack/release.yaml
+++ b/manifests/monitoring/kube-prometheus-stack/release.yaml
@@ -6,7 +6,7 @@ spec:
   interval: 5m
   chart:
     spec:
-      version: 23.2.0
+      version: 34.7.0
       chart: kube-prometheus-stack
       sourceRef:
         kind: HelmRepository

--- a/manifests/monitoring/monitoring-config/kustomization.yaml
+++ b/manifests/monitoring/monitoring-config/kustomization.yaml
@@ -10,4 +10,4 @@ configMapGenerator:
       - ../grafana/dashboards/cluster.json
     options:
       labels:
-        grafana_dashboard: flux-system
+        grafana_dashboard: "1"


### PR DESCRIPTION
Since kube-prometheus-stack helm chart v32.2.0, the `labelValue` has to
be set to "1" for the default grafana dashboard label selector to select
the flux dashboard configuration.
Refer: https://github.com/prometheus-community/helm-charts/commit/eba5b198f597a39f2d40d3edd209dfa09429623e

Also, update kube-prometheus-stack to v34.7.0, latest.