### PR TITLE
Add an option to diff with a local Flux Kustomization file

### DIFF
--- a/cmd/flux/build_kustomization_test.go
+++ b/cmd/flux/build_kustomization_test.go
@@ -20,7 +20,10 @@ limitations under the License.
 package main
 
 import (
+	"bytes"
+	"os"
 	"testing"
+	"text/template"
 )
 
 func setup(t *testing.T, tmpl map[string]string) {
@@ -55,7 +58,7 @@ func TestBuildKustomization(t *testing.T) {
 			assertFunc: "assertGoldenTemplateFile",
 		},
 		{
-			name:       "build deployment and configmpa with var substitution",
+			name:       "build deployment and configmap with var substitution",
 			args:       "build kustomization podinfo --path ./testdata/build-kustomization/var-substitution",
 			resultFile: "./testdata/build-kustomization/podinfo-with-var-substitution-result.yaml",
 			assertFunc: "assertGoldenTemplateFile",
@@ -66,6 +69,104 @@ func TestBuildKustomization(t *testing.T) {
 		"fluxns": allocateNamespace("flux-system"),
 	}
 	setup(t, tmpl)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var assert assertFunc
+
+			switch tt.assertFunc {
+			case "assertGoldenTemplateFile":
+				assert = assertGoldenTemplateFile(tt.resultFile, tmpl)
+			case "assertError":
+				assert = assertError(tt.resultFile)
+			}
+
+			cmd := cmdTestCase{
+				args:   tt.args + " -n " + tmpl["fluxns"],
+				assert: assert,
+			}
+
+			cmd.runTestCmd(t)
+		})
+	}
+}
+
+func TestBuildLocalKustomization(t *testing.T) {
+	podinfo := `apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: podinfo
+  namespace: {{ .fluxns }}
+spec:
+  interval: 5m0s
+  path: ./kustomize
+  force: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: podinfo
+  targetNamespace: default
+  postBuild:
+    substitute:
+      cluster_env: "prod"
+      cluster_region: "eu-central-1"
+`
+
+	tests := []struct {
+		name       string
+		args       string
+		resultFile string
+		assertFunc string
+	}{
+		{
+			name:       "no args",
+			args:       "build kustomization podinfo --kustomization-file ./wrongfile/ --path ./testdata/build-kustomization/podinfo",
+			resultFile: "invalid kustomization file \"./wrongfile/\"",
+			assertFunc: "assertError",
+		},
+		{
+			name:       "build podinfo",
+			args:       "build kustomization podinfo --kustomization-file ./testdata/build-kustomization/podinfo.yaml --path ./testdata/build-kustomization/podinfo",
+			resultFile: "./testdata/build-kustomization/podinfo-result.yaml",
+			assertFunc: "assertGoldenTemplateFile",
+		},
+		{
+			name:       "build podinfo without service",
+			args:       "build kustomization podinfo --kustomization-file ./testdata/build-kustomization/podinfo.yaml --path ./testdata/build-kustomization/delete-service",
+			resultFile: "./testdata/build-kustomization/podinfo-without-service-result.yaml",
+			assertFunc: "assertGoldenTemplateFile",
+		},
+		{
+			name:       "build deployment and configmap with var substitution",
+			args:       "build kustomization podinfo --kustomization-file ./testdata/build-kustomization/podinfo.yaml --path ./testdata/build-kustomization/var-substitution",
+			resultFile: "./testdata/build-kustomization/podinfo-with-var-substitution-result.yaml",
+			assertFunc: "assertGoldenTemplateFile",
+		},
+	}
+
+	tmpl := map[string]string{
+		"fluxns": allocateNamespace("flux-system"),
+	}
+
+	testEnv.CreateObjectFile("./testdata/build-kustomization/podinfo-source.yaml", tmpl, t)
+
+	temp, err := template.New("podinfo").Parse(podinfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var b bytes.Buffer
+	err = temp.Execute(&b, tmpl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = os.WriteFile("./testdata/build-kustomization/podinfo.yaml", b.Bytes(), 0666)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.Remove("./testdata/build-kustomization/podinfo.yaml")
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
If implemented, users will be able to provide a local Flux Kustomization YAML file to `flux build/diff`.

Signed-off-by: Soule BA <soule@weave.works>