### PR TITLE
Add detail to delete docs

### DIFF
--- a/cmd/flux/delete_kustomization.go
+++ b/cmd/flux/delete_kustomization.go
@@ -27,7 +27,7 @@ var deleteKsCmd = &cobra.Command{
 	Aliases: []string{"ks"},
 	Short:   "Delete a Kustomization resource",
 	Long:    "The delete kustomization command deletes the given Kustomization from the cluster.",
-	Example: `  # Delete a kustomization and the Kubernetes resources created by it
+	Example: `  # Delete a kustomization and the Kubernetes resources created by it when prune is enabled
   flux delete kustomization podinfo`,
 	ValidArgsFunction: resourceNamesCompletionFunc(kustomizev1.GroupVersion.WithKind(kustomizev1.KustomizationKind)),
 	RunE: deleteCommand{


### PR DESCRIPTION
The `flux delete kustomization` docs imply that deleting a Kustomization always deletes the resources created by it.

This is only true when the resource is not `suspended` and when `prune` is enabled.

I think it's clear enough that resources do not do anything when they are suspended, and I don't want to make the doc string too long, but in #2622 at least one user found this doc string wasn't detailed enough and was confused about the behavior.