### PR TITLE
kustomize: use FS from `fluxcd/pkg`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/fluxcd/kustomize-controller/api v0.24.4
 	github.com/fluxcd/notification-controller/api v0.23.4
 	github.com/fluxcd/pkg/apis/meta v0.12.2
-	github.com/fluxcd/pkg/kustomize v0.2.0
+	github.com/fluxcd/pkg/kustomize v0.4.0
 	github.com/fluxcd/pkg/runtime v0.14.1
 	github.com/fluxcd/pkg/ssa v0.15.2
 	github.com/fluxcd/pkg/ssh v0.3.2

--- a/go.sum
+++ b/go.sum
@@ -391,8 +391,8 @@ github.com/fluxcd/pkg/apis/kustomize v0.3.3 h1:bPN29SdVzWl0yhgivuf/83IAe2R6vUuDV
 github.com/fluxcd/pkg/apis/kustomize v0.3.3/go.mod h1:5HTOFZfQFVMMqR2rvuxpbZhpb+sQpcTT6RCQZOhjFzA=
 github.com/fluxcd/pkg/apis/meta v0.12.2 h1:AiKAZxLyPtV150y63WC+mL1Qm4x5qWQmW6r4mLy1i8c=
 github.com/fluxcd/pkg/apis/meta v0.12.2/go.mod h1:Z26X5uTU5LxAyWETGueRQY7TvdPaGfKU7Wye9bdUlho=
-github.com/fluxcd/pkg/kustomize v0.2.0 h1:twiGAFJctt2tyH8vHxL1uqb6BlU3B9ZqG8uSlluuioM=
-github.com/fluxcd/pkg/kustomize v0.2.0/go.mod h1:Qczvl7vNY9NJBpyaFrldsxfGjj6uaMcMmKGsSJ6hcxc=
+github.com/fluxcd/pkg/kustomize v0.4.0 h1:ct1YGrO/o++NVecAyeOxd3/YzGNvRdslaE6pmWxBt0M=
+github.com/fluxcd/pkg/kustomize v0.4.0/go.mod h1:ZlTFhk6Cxtmf1T7tpYuTACmMfqDdsPcXUGRAq3t9fH8=
 github.com/fluxcd/pkg/runtime v0.14.1 h1:ZbS3RzR+f+wu1e6Y7GoCxY9PFZkOgX6/gL7Enr75CY0=
 github.com/fluxcd/pkg/runtime v0.14.1/go.mod h1:eS4378ydLlWPt2fFjcrAAnJegGJNj3Q/iqYZqjBeWlM=
 github.com/fluxcd/pkg/ssa v0.15.2 h1:hLEIh7Ymlt6ihfQHIEx7DjAa+FCndBpHW6wyELToVsI=

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -37,11 +37,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/resource"
-	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
 	"github.com/fluxcd/pkg/kustomize"
+	"github.com/fluxcd/pkg/kustomize/filesys"
 	runclient "github.com/fluxcd/pkg/runtime/client"
 
 	"github.com/fluxcd/flux2/internal/utils"
@@ -275,7 +275,11 @@ func (b *Builder) generate(kustomization kustomizev1.Kustomization, dirPath stri
 }
 
 func (b *Builder) do(ctx context.Context, kustomization kustomizev1.Kustomization, dirPath string) (resmap.ResMap, error) {
-	fs := filesys.MakeFsOnDisk()
+	// TODO(hidde): provide option to enforce FS boundaries of local build
+	fs, err := filesys.MakeFsOnDiskSecureBuild("/")
+	if err != nil {
+		return nil, fmt.Errorf("kustomization build failed: %w", err)
+	}
 
 	// acuire the lock
 	b.mu.Lock()

--- a/pkg/manifestgen/install/manifests.go
+++ b/pkg/manifestgen/install/manifests.go
@@ -26,8 +26,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/fluxcd/pkg/kustomize/filesys"
 	"github.com/fluxcd/pkg/untar"
-	"sigs.k8s.io/kustomize/api/filesys"
 
 	"github.com/fluxcd/flux2/pkg/manifestgen/kustomization"
 )
@@ -126,8 +126,12 @@ func build(base, output string) error {
 		return err
 	}
 
-	fs := filesys.MakeFsOnDisk()
-	if err := fs.WriteFile(output, resources); err != nil {
+	outputBase := filepath.Dir(strings.TrimSuffix(output, string(filepath.Separator)))
+	fs, err := filesys.MakeFsOnDiskSecure(outputBase)
+	if err != nil {
+		return err
+	}
+	if err = fs.WriteFile(output, resources); err != nil {
 		return err
 	}
 

--- a/pkg/manifestgen/kustomization/options.go
+++ b/pkg/manifestgen/kustomization/options.go
@@ -25,6 +25,8 @@ type Options struct {
 }
 
 func MakeDefaultOptions() Options {
+	// TODO(hidde): switch MakeFsOnDisk to MakeFsOnDiskSecureBuild when we
+	//  break API.
 	return Options{
 		FileSystem: filesys.MakeFsOnDisk(),
 		BaseDir:    "",


### PR DESCRIPTION
This switches to a secure FS implementation in most places, except for
where we can not make changes at this moment because it would break
behavior.

Not handled in this commit:

- Allowing the root for `manifestgen` packages to be configured.
- Allowing the user to define a working root while building locally.
- Defaulting to the secure FS implementation in
  `kustomization.MakeDefaultOptions`. Problem here is that constructing
  the secure FS could result in an error, which we can not surface
  without signature changes to the constructor func.