### PR TITLE
Grant service account read-only access to controllers

### DIFF
--- a/manifests/rbac/controller.yaml
+++ b/manifests/rbac/controller.yaml
@@ -36,6 +36,27 @@ rules:
   verbs:
   - create
   - patch
+# required by leader election
+- apiGroups:
+    - ""
+  resources:
+    - configmaps
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+- apiGroups:
+    - ""
+  resources:
+    - configmaps/status
+  verbs:
+    - get
+    - update
+    - patch
 - apiGroups:
   - "coordination.k8s.io"
   resources:

--- a/manifests/rbac/controller.yaml
+++ b/manifests/rbac/controller.yaml
@@ -23,6 +23,8 @@ rules:
   resources:
   - namespaces
   - secrets
+  - configmaps
+  - serviceaccounts
   verbs:
   - get
   - list
@@ -34,19 +36,6 @@ rules:
   verbs:
   - create
   - patch
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - configmaps/status
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
 - apiGroups:
   - "coordination.k8s.io"
   resources:


### PR DESCRIPTION
For image automation to use a service account to authenticate to container registries, the controllers need read-only access to service accounts. 

Followup: https://github.com/fluxcd/image-reflector-controller/pull/253