### PR TITLE
fix e2e tests

### DIFF
--- a/cmd/flux/check_test.go
+++ b/cmd/flux/check_test.go
@@ -22,6 +22,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/fluxcd/flux2/internal/utils"
@@ -38,7 +39,9 @@ func TestCheckPre(t *testing.T) {
 		t.Fatalf("Error unmarshalling '%s': %v", jsonOutput, err.Error())
 	}
 
-	serverGitVersion := versions["serverVersion"].(map[string]interface{})["gitVersion"].(string)
+	serverGitVersion := strings.TrimPrefix(
+		versions["serverVersion"].(map[string]interface{})["gitVersion"].(string),
+		"v")
 
 	cmd := cmdTestCase{
 		args: "check --pre",

--- a/cmd/flux/check_test.go
+++ b/cmd/flux/check_test.go
@@ -22,11 +22,9 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"strings"
 	"testing"
 
 	"github.com/fluxcd/flux2/internal/utils"
-	"k8s.io/apimachinery/pkg/version"
 )
 
 func TestCheckPre(t *testing.T) {
@@ -35,17 +33,17 @@ func TestCheckPre(t *testing.T) {
 		t.Fatalf("Error running utils.ExecKubectlCommand: %v", err.Error())
 	}
 
-	var versions map[string]version.Info
+	var versions map[string]interface{}
 	if err := json.Unmarshal([]byte(jsonOutput), &versions); err != nil {
 		t.Fatalf("Error unmarshalling '%s': %v", jsonOutput, err.Error())
 	}
 
-	serverVersion := strings.TrimPrefix(versions["serverVersion"].GitVersion, "v")
+	serverGitVersion := versions["serverVersion"].(map[string]interface{})["gitVersion"].(string)
 
 	cmd := cmdTestCase{
 		args: "check --pre",
 		assert: assertGoldenTemplateFile("testdata/check/check_pre.golden", map[string]string{
-			"serverVersion": serverVersion,
+			"serverVersion": serverGitVersion,
 		}),
 	}
 	cmd.runTestCmd(t)

--- a/cmd/flux/check_test.go
+++ b/cmd/flux/check_test.go
@@ -37,7 +37,7 @@ func TestCheckPre(t *testing.T) {
 
 	var versions map[string]version.Info
 	if err := json.Unmarshal([]byte(jsonOutput), &versions); err != nil {
-		t.Fatalf("Error unmarshalling: %v", err.Error())
+		t.Fatalf("Error unmarshalling '%s': %v", jsonOutput, err.Error())
 	}
 
 	serverVersion := strings.TrimPrefix(versions["serverVersion"].GitVersion, "v")


### PR DESCRIPTION
fix e2e check test

The output of `kubectl version` has changed with newer kubectl version
from

```
{
  "serverVersion": ...,
  "clientVersion": ...
}
```

to

```
{
  "serverVersion": ...,
  "clientVersion": ...,
  "kustomizeVersion": ...
}
```

So the `kustomizeVersion` field is new which causes the JSON
unmarshaling to fail.

We now just unmarshal it to `map[string]interface{}` and peel the
server git version out of that map manually w/o unmarshalling the JSON
into a custom type.
