### PR TITLE
Add `--ignore-paths` flag to `flux create source (git|bucket)`

### DIFF
--- a/cmd/flux/create_source_git_test.go
+++ b/cmd/flux/create_source_git_test.go
@@ -85,6 +85,31 @@ func (r *reconciler) conditionFunc() (bool, error) {
 	return true, err
 }
 
+func TestCreateSourceGitExport(t *testing.T) {
+	var command = "create source git podinfo --url=https://github.com/stefanprodan/podinfo --branch=master --ignore-paths .cosign,non-existent-dir/ -n default --interval 1m --export --timeout=" + testTimeout.String()
+
+	cases := []struct {
+		name   string
+		args   string
+		assert assertFunc
+	}{
+		{
+			"ExportSucceeded",
+			command,
+			assertGoldenFile("testdata/create_source_git/export.golden"),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := cmdTestCase{
+				args:   tc.args,
+				assert: tc.assert,
+			}
+			cmd.runTestCmd(t)
+		})
+	}
+}
+
 func TestCreateSourceGit(t *testing.T) {
 	// Default command used for multiple tests
 	var command = "create source git podinfo --url=https://github.com/stefanprodan/podinfo --branch=master --timeout=" + testTimeout.String()

--- a/cmd/flux/testdata/create_source_git/export.golden
+++ b/cmd/flux/testdata/create_source_git/export.golden
@@ -1,0 +1,15 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: GitRepository
+metadata:
+  name: podinfo
+  namespace: default
+spec:
+  ignore: |-
+    .cosign
+    non-existent-dir/
+  interval: 1m0s
+  ref:
+    branch: master
+  url: https://github.com/stefanprodan/podinfo
+


### PR DESCRIPTION
A new --ignore-path flag is added to following commands:

```
flux create source git --ignore-paths ...
flux create source bucket --ignore-paths ...
```

A StringSliceVar is used which supports specifying the flag multiple
times to populate a list or either a comma seperated string value

Fixes https://github.com/fluxcd/flux2/issues/2763