### PR TITLE
Add `--allow-insecure-http` to `bootstrap git`

### DIFF
--- a/cmd/flux/bootstrap_git.go
+++ b/cmd/flux/bootstrap_git.go
@@ -273,7 +273,7 @@ func transportForURL(u *url.URL) (transport.AuthMethod, error) {
 	switch u.Scheme {
 	case "http":
 		if !gitArgs.insecureHttpAllowed {
-			return nil, fmt.Errorf("scheme http is not supported")
+			return nil, fmt.Errorf("scheme http is insecure, pass --allow-insecure-http=true to allow it")
 		}
 		return &http.BasicAuth{
 			Username: gitArgs.username,


### PR DESCRIPTION
This change will allow the end-user to bootstrap with HTTP git URLs
But the user must explicitly set --allow-insecure-http=true
Fix: https://github.com/fluxcd/flux2/issues/2786
