### PR TITLE
Add CRDs to `flux check` command

### DIFF
--- a/cmd/flux/check.go
+++ b/cmd/flux/check.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/apps/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -95,9 +96,16 @@ func runCheckCmd(cmd *cobra.Command, args []string) error {
 	if !componentsCheck() {
 		checkFailed = true
 	}
+
+	logger.Actionf("checking crds")
+	if !crdsCheck() {
+		checkFailed = true
+	}
+
 	if checkFailed {
 		os.Exit(1)
 	}
+
 	logger.Successf("all checks passed")
 	return nil
 }
@@ -200,6 +208,31 @@ func componentsCheck() bool {
 			}
 			for _, c := range d.Spec.Template.Spec.Containers {
 				logger.Actionf(c.Image)
+			}
+		}
+	}
+	return ok
+}
+
+func crdsCheck() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	kubeClient, err := utils.KubeClient(kubeconfigArgs, kubeclientOptions)
+	if err != nil {
+		return false
+	}
+
+	ok := true
+	selector := client.MatchingLabels{manifestgen.PartOfLabelKey: manifestgen.PartOfLabelValue}
+	var list apiextensionsv1.CustomResourceDefinitionList
+	if err := kubeClient.List(ctx, &list, client.InNamespace(*kubeconfigArgs.Namespace), selector); err == nil {
+		for _, crd := range list.Items {
+			if len(crd.Status.StoredVersions) > 0 {
+				logger.Successf(crd.Name + "/" + crd.Status.StoredVersions[0])
+			} else {
+				ok = false
+				logger.Failuref("no stored versions for %s", crd.Name)
 			}
 		}
 	}


### PR DESCRIPTION
Changes to `flux check`:
- Verify that the Flux CRDs are correctly registered on the cluster and print their version
- Error out if no controllers or crds are found

Example output:

```console
$ flux check
► checking prerequisites
✔ Kubernetes 1.23.5-gke.1501 >=1.20.6-0
► checking controllers
✔ helm-controller: deployment ready
► ghcr.io/fluxcd/helm-controller:v0.22.1
✔ image-automation-controller: deployment ready
► ghcr.io/fluxcd/image-automation-controller:v0.23.2
✔ image-reflector-controller: deployment ready
► ghcr.io/fluxcd/image-reflector-controller:v0.19.1
✔ kustomize-controller: deployment ready
► ghcr.io/fluxcd/kustomize-controller:v0.26.1
✔ notification-controller: deployment ready
► ghcr.io/fluxcd/notification-controller:v0.24.0
✔ source-controller: deployment ready
► ghcr.io/fluxcd/source-controller:v0.25.5
► checking crds
✔ alerts.notification.toolkit.fluxcd.io/v1beta1
✔ buckets.source.toolkit.fluxcd.io/v1beta2
✔ gitrepositories.source.toolkit.fluxcd.io/v1beta2
✔ helmcharts.source.toolkit.fluxcd.io/v1beta2
✔ helmreleases.helm.toolkit.fluxcd.io/v2beta1
✔ helmrepositories.source.toolkit.fluxcd.io/v1beta2
✔ imagepolicies.image.toolkit.fluxcd.io/v1beta1
✔ imagerepositories.image.toolkit.fluxcd.io/v1beta1
✔ imageupdateautomations.image.toolkit.fluxcd.io/v1beta1
✔ kustomizations.kustomize.toolkit.fluxcd.io/v1beta2
✔ providers.notification.toolkit.fluxcd.io/v1beta1
✔ receivers.notification.toolkit.fluxcd.io/v1beta1
✔ all checks passed
```

Failed check example:

```console
$ flux check -n test
► checking prerequisites
✔ Kubernetes 1.23.5-gke.1501 >=1.20.6-0
► checking controllers
✗ no controllers found in the 'test' namespace with the label selector 'app.kubernetes.io/part-of=flux'
► checking crds
✔ alerts.notification.toolkit.fluxcd.io/v1beta1
✔ buckets.source.toolkit.fluxcd.io/v1beta2
✔ gitrepositories.source.toolkit.fluxcd.io/v1beta2
✔ helmcharts.source.toolkit.fluxcd.io/v1beta2
✔ helmreleases.helm.toolkit.fluxcd.io/v2beta1
✔ helmrepositories.source.toolkit.fluxcd.io/v1beta2
✔ imagepolicies.image.toolkit.fluxcd.io/v1beta1
✔ imagerepositories.image.toolkit.fluxcd.io/v1beta1
✔ imageupdateautomations.image.toolkit.fluxcd.io/v1beta1
✔ kustomizations.kustomize.toolkit.fluxcd.io/v1beta2
✔ providers.notification.toolkit.fluxcd.io/v1beta1
✔ receivers.notification.toolkit.fluxcd.io/v1beta1
✗ check failed

```