### PR TITLE
logs: select manager container when multiple exist

### DIFF
--- a/cmd/flux/logs.go
+++ b/cmd/flux/logs.go
@@ -80,6 +80,8 @@ var logsArgs = &logsFlags{
 	tail: -1,
 }
 
+const controllerContainer = "manager"
+
 func init() {
 	logsCmd.Flags().Var(&logsArgs.logLevel, "level", logsArgs.logLevel.Description())
 	logsCmd.Flags().StringVarP(&logsArgs.kind, "kind", "", logsArgs.kind, "displays errors of a particular toolkit kind e.g GitRepository")
@@ -146,6 +148,10 @@ func logsCmdRun(cmd *cobra.Command, args []string) error {
 
 	var requests []rest.ResponseWrapper
 	for _, pod := range pods {
+		logOpts := logOpts.DeepCopy()
+		if len(pod.Spec.Containers) > 1 {
+			logOpts.Container = controllerContainer
+		}
 		req := clientset.CoreV1().Pods(logsArgs.fluxNamespace).GetLogs(pod.Name, logOpts)
 		requests = append(requests, req)
 	}


### PR DESCRIPTION
This sets the container to `manager` which is used by all Flux
controllers as the container name.

The other options I thought about were selecting the first, or doing
something with image detection. But both can be sensitive to either
users adding their patch as a first entry, or e.g. mirroring the image
to a different name.

Fixes #2843