### PR TITLE
Put the dashboard configmap in the right namespace for monitoring

### DIFF
--- a/manifests/monitoring/monitoring-config/kustomization.yaml
+++ b/manifests/monitoring/monitoring-config/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: flux-system
+namespace: monitoring
 resources:
   - podmonitor.yaml
 configMapGenerator:


### PR DESCRIPTION
Hi

The current monitoring-manifest namespace is set to flux-system namespace.
Grafana sidecar looks up for configmaps in the monitoring namespace.

[2022-06-22 14:55:35] Working on ADDED configmap monitoring/flux-grafana-dashboards-625985h2t7
[2022-06-22 14:55:35] Found 'data' on configmap