### PR TITLE
Add the `--branch` arg to the basic auth example

### DIFF
--- a/cmd/flux/create_source_git.go
+++ b/cmd/flux/create_source_git.go
@@ -117,6 +117,7 @@ For private Git repositories, the basic authentication credentials are stored in
   # Create a source for a Git repository using basic authentication
   flux create source git podinfo \
     --url=https://github.com/stefanprodan/podinfo \
+    --branch=master \
     --username=username \
     --password=password`,
 	RunE: createSourceGitCmdRun,


### PR DESCRIPTION
Without a reference specified, the create command will fail. 

Signed-off-by: David Harris <david.harris@weave.works>

Not tested given nature of the change.