### PR TITLE
SRCINFO: fix path

### DIFF
--- a/.github/aur/flux-bin/.SRCINFO.template
+++ b/.github/aur/flux-bin/.SRCINFO.template
@@ -8,9 +8,9 @@ pkgbase = flux-bin
 	arch = armv7h
 	arch = aarch64
 	license = APACHE
-	source_x86_64 = flux-bin-${PKGVER}.tar.gz::https://github.com/fluxcd/flux2/releases/download/v1/flux_${PKGVER}_linux_amd64.tar.gz
-	source_armv6h = flux-bin-${PKGVER}.tar.gz::https://github.com/fluxcd/flux2/releases/download/v1/flux_${PKGVER}_linux_arm.tar.gz
-	source_armv7h = flux-bin-${PKGVER}.tar.gz::https://github.com/fluxcd/flux2/releases/download/v1/flux_${PKGVER}_linux_arm.tar.gz
-	source_aarch64 = flux-bin-${PKGVER}.tar.gz::https://github.com/fluxcd/flux2/releases/download/v1/flux_${PKGVER}_linux_arm64.tar.gz
+	source_x86_64 = flux-bin-${PKGVER}.tar.gz::https://github.com/fluxcd/flux2/releases/download/v${pkgver}/flux_${PKGVER}_linux_amd64.tar.gz
+	source_armv6h = flux-bin-${PKGVER}.tar.gz::https://github.com/fluxcd/flux2/releases/download/v${pkgver}/flux_${PKGVER}_linux_arm.tar.gz
+	source_armv7h = flux-bin-${PKGVER}.tar.gz::https://github.com/fluxcd/flux2/releases/download/v${pkgver}/flux_${PKGVER}_linux_arm.tar.gz
+	source_aarch64 = flux-bin-${PKGVER}.tar.gz::https://github.com/fluxcd/flux2/releases/download/v${pkgver}/flux_${PKGVER}_linux_arm64.tar.gz
 
 pkgname = flux-bin

--- a/.github/aur/flux-bin/.SRCINFO.template
+++ b/.github/aur/flux-bin/.SRCINFO.template
@@ -1,4 +1,5 @@
 pkgbase = flux-bin
+pkgname = flux-bin
 	pkgdesc = Open and extensible continuous delivery solution for Kubernetes
 	pkgver = ${PKGVER}
 	pkgrel = ${PKGREL}
@@ -8,9 +9,7 @@ pkgbase = flux-bin
 	arch = armv7h
 	arch = aarch64
 	license = APACHE
-	source_x86_64 = flux-bin-${PKGVER}.tar.gz::https://github.com/fluxcd/flux2/releases/download/v${pkgver}/flux_${PKGVER}_linux_amd64.tar.gz
-	source_armv6h = flux-bin-${PKGVER}.tar.gz::https://github.com/fluxcd/flux2/releases/download/v${pkgver}/flux_${PKGVER}_linux_arm.tar.gz
-	source_armv7h = flux-bin-${PKGVER}.tar.gz::https://github.com/fluxcd/flux2/releases/download/v${pkgver}/flux_${PKGVER}_linux_arm.tar.gz
-	source_aarch64 = flux-bin-${PKGVER}.tar.gz::https://github.com/fluxcd/flux2/releases/download/v${pkgver}/flux_${PKGVER}_linux_arm64.tar.gz
-
-pkgname = flux-bin
+	source_x86_64 = ${pkgname}-${pkgver}.tar.gz::https://github.com/fluxcd/flux2/releases/download/v${pkgver}/flux_${pkgver}_linux_amd64.tar.gz
+	source_armv6h = ${pkgname}-${pkgver}.tar.gz::https://github.com/fluxcd/flux2/releases/download/v${pkgver}/flux_${pkgver}_linux_arm.tar.gz
+	source_armv7h = ${pkgname}-${pkgver}.tar.gz::https://github.com/fluxcd/flux2/releases/download/v${pkgver}/flux_${pkgver}_linux_arm.tar.gz
+	source_aarch64 = ${pkgname}-${pkgver}.tar.gz::https://github.com/fluxcd/flux2/releases/download/v${pkgver}/flux_${pkgver}_linux_arm64.tar.gz


### PR DESCRIPTION
Upon noticing pkgrel = 2 of pkgver = 0.31.4 has [broken SHAs](https://aur.archlinux.org/cgit/aur.git/commit/?h=flux-bin&id=aca324e1cbc673bb6921ffc9ec3072bb8ce08766) for amd64, I also noticed the templates appear to need release URLs updating.