### PR TITLE
Restore function of flux logs with filter selectors engaged

### DIFF
--- a/cmd/flux/logs.go
+++ b/cmd/flux/logs.go
@@ -278,9 +278,9 @@ func logRequest(ctx context.Context, request rest.ResponseWrapper, w io.Writer) 
 
 func filterPrintLog(t *template.Template, l *ControllerLogEntry, w io.Writer) {
 	if logsArgs.logLevel != "" && logsArgs.logLevel != l.Level ||
-		logsArgs.kind != "" && strings.EqualFold(logsArgs.kind, l.Kind) ||
-		logsArgs.name != "" && strings.EqualFold(logsArgs.name, l.Name) ||
-		!logsArgs.allNamespaces && strings.EqualFold(*kubeconfigArgs.Namespace, l.Namespace) {
+		logsArgs.kind != "" && strings.ToLower(logsArgs.kind) != strings.ToLower(l.Kind) ||
+		logsArgs.name != "" && strings.ToLower(logsArgs.name) != strings.ToLower(l.Name) ||
+		!logsArgs.allNamespaces && strings.ToLower(*kubeconfigArgs.Namespace) != strings.ToLower(l.Namespace) {
 		return
 	}
 	err := t.Execute(w, l)


### PR DESCRIPTION
Fix #2949

An unrelated logic change appears to have been accidentally included with #2851 - this reverts the logic change.

This PR reverts the update to use EqualFold, and the discarding of the
ToLower calls so the function reads as it was when it was approved here:

https://github.com/fluxcd/flux2/commit/8abaa39f9775edd97ae5bc6424cbf872a15cd57c

FYI @somtochiama @stefanprodan

I can try to write some tests around this issue, but for now since the release is broken and I have isolated the fix (I have tested it locally and confirmed it works here) I thought I should send it as-is ASAP.