### PR TITLE
Docs: correct "pull" in pull artifact docs

### DIFF
--- a/cmd/flux/pull_artifact.go
+++ b/cmd/flux/pull_artifact.go
@@ -28,7 +28,7 @@ import (
 
 var pullArtifactCmd = &cobra.Command{
 	Use:   "artifact",
-	Short: "Push artifact",
+	Short: "Pull artifact",
 	Long: `The pull artifact command downloads and extracts the OCI artifact content to the given path.
 The pull command uses the credentials from '~/.docker/config.json'.`,
 	Example: `# Pull an OCI artifact created by flux from GHCR


### PR DESCRIPTION
Fixup docs string to match pull command - this one is for Pull artifact, but it says Push