### PR TITLE
Improve error message in get cmd

### DIFF
--- a/cmd/flux/get.go
+++ b/cmd/flux/get.go
@@ -162,7 +162,9 @@ func (get getCommand) run(cmd *cobra.Command, args []string) error {
 	}
 
 	if get.list.len() == 0 {
-		if !getAll {
+		if len(args) > 0 {
+			logger.Failuref("%s object '%s' not found in '%s' namespace", get.kind, args[0], *kubeconfigArgs.Namespace)
+		} else if !getAll {
 			logger.Failuref("no %s objects found in %s namespace", get.kind, *kubeconfigArgs.Namespace)
 		}
 		return nil


### PR DESCRIPTION
Before 
```
➜  flux get ks me
✗ no Kustomization objects found in flux-system namespace # misleading as there are Kustomizations in the flux-system namespace
```

Now:
```
➜  ./bin/flux get ks me
✗ Kustomization object 'me' not found in `flux-system` namespace
```

Signed-off-by: Somtochi Onyekwere <somtochionyekwere@gmail.com>