### PR TITLE
Fix broken "edit this page" links in Flux CLI section

### DIFF
--- a/cmd/flux/docgen.go
+++ b/cmd/flux/docgen.go
@@ -28,6 +28,7 @@ import (
 
 const fmTemplate = `---
 title: "%s"
+importedDoc: true
 ---
 `
 


### PR DESCRIPTION
This MR closes https://github.com/fluxcd/flux2/issues/2203

As described in the original issue, the fix to disable the source page related links is pretty simple by adding `importedDoc: true` within the header.

It took me a while to realise where this was exactly needed, I was unable to find documentation about that option and another while to test that the change was good.

### Validation procedure

I did checkout https://github.com/fluxcd/website then I ran
```shell
$ make serve
```
Which generated the site and served it on http://localhost:1313 then navigated to http://localhost:1313/docs/cmd/flux/ and observed the "Edit this page" along with the other source page links.

<img width="1322" alt="image" src="https://user-images.githubusercontent.com/9039085/186759118-b480537f-103e-4629-83f1-4797ec1845e8.png">

After that edited `content/en/docs/cmd/flux.md` by adding `importedDoc: true` under title.
```markdown
---
title: "flux"
importedDoc: true
---
```
then copy paste the `hugo server` from the previous `make serve` run to avoid overriding my change.
```shell
$ hugo server \
                --bind 127.0.0.1 \
                --buildDrafts \
                --buildFuture \
                --disableFastRender
```
And observed the links related to the source page (view page source, edit this page and create child page) disappear.

<img width="1322" alt="image" src="https://user-images.githubusercontent.com/9039085/186759846-e28de2ad-7edf-4e38-8e4d-fb8517433fbc.png">

I think this change is good to go.
