### PR TITLE
Revert "Fix broken "edit this page" links in Flux CLI section"

### DIFF
--- a/cmd/flux/docgen.go
+++ b/cmd/flux/docgen.go
@@ -28,7 +28,6 @@ import (
 
 const fmTemplate = `---
 title: "%s"
-importedDoc: true
 ---
 `
 


### PR DESCRIPTION
Reverts fluxcd/flux2#3034

Once we merge https://github.com/fluxcd/website/pull/1114 we won't need the change below any more.