### PR TITLE
[Grafana] Use `container_memory_working_set_bytes` to report memory consumption

### DIFF
--- a/manifests/monitoring/monitoring-config/dashboards/control-plane.json
+++ b/manifests/monitoring/monitoring-config/dashboards/control-plane.json
@@ -548,7 +548,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(go_memstats_alloc_bytes_total{namespace=\"$namespace\",pod=~\".*-controller-.*\"}[1m])",
+          "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",container!=\"POD\",container!=\"\",pod=~\".*-controller-.*\"}) by (pod)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}}",


### PR DESCRIPTION
This PR could close [#3086](https://github.com/fluxcd/flux2/issues/3086#issue-1366306801)

Updating current metric of type `go_memstats_alloc_bytes_total` with `container_memory_working_set_bytes` to correctly report memory consumption. 