### PR TITLE
Maintain original scheme when using --token-auth

### DIFF
--- a/cmd/flux/bootstrap_git.go
+++ b/cmd/flux/bootstrap_git.go
@@ -192,7 +192,9 @@ func bootstrapGitCmdRun(cmd *cobra.Command, args []string) error {
 
 		// Configure repository URL to match auth config for sync.
 		repositoryURL.User = nil
-		repositoryURL.Scheme = "https"
+		if !gitArgs.insecureHttpAllowed {
+			repositoryURL.Scheme = "https"
+		}
 	} else {
 		secretOpts.PrivateKeyAlgorithm = sourcesecret.PrivateKeyAlgorithm(bootstrapArgs.keyAlgorithm)
 		secretOpts.Password = gitArgs.password


### PR DESCRIPTION
Fixes #3116.

If you're using an HTTP-based Git server with Flux, you need to provide `--token-auth` to avoid triggering an SSH host key check (see [#2825](https://github.com/fluxcd/flux2/issues/2825#issuecomment-1151355914)). Unfortunately, doing this forces the URL in the `GitRepository` resource created during bootstrapping to always use `https`. This will cause Kustomization reconcile errors for servers that do not have HTTPS enabled or do not have the appropriate certs installed or available.

This pull request fixes this by keeping the repository URL scheme intact when using `--token-auth`.

Signed-off-by: Carlos Nunez <75340335+carlosonunez-vmw@users.noreply.github.com>