### PR TITLE
Add component label for controllers and their CRDs

### DIFF
--- a/manifests/bases/helm-controller/kustomization.yaml
+++ b/manifests/bases/helm-controller/kustomization.yaml
@@ -4,6 +4,8 @@ resources:
 - https://github.com/fluxcd/helm-controller/releases/download/v0.24.0/helm-controller.crds.yaml
 - https://github.com/fluxcd/helm-controller/releases/download/v0.24.0/helm-controller.deployment.yaml
 - account.yaml
+transformers:
+- labels.yaml
 patchesJson6902:
 - target:
     group: apps

--- a/manifests/bases/helm-controller/labels.yaml
+++ b/manifests/bases/helm-controller/labels.yaml
@@ -1,0 +1,9 @@
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: labels
+labels:
+  app.kubernetes.io/component: helm-controller
+fieldSpecs:
+  - path: metadata/labels
+    create: true

--- a/manifests/bases/image-automation-controller/kustomization.yaml
+++ b/manifests/bases/image-automation-controller/kustomization.yaml
@@ -4,6 +4,8 @@ resources:
 - https://github.com/fluxcd/image-automation-controller/releases/download/v0.25.0/image-automation-controller.crds.yaml
 - https://github.com/fluxcd/image-automation-controller/releases/download/v0.25.0/image-automation-controller.deployment.yaml
 - account.yaml
+transformers:
+- labels.yaml
 patchesJson6902:
 - target:
     group: apps

--- a/manifests/bases/image-automation-controller/labels.yaml
+++ b/manifests/bases/image-automation-controller/labels.yaml
@@ -1,0 +1,9 @@
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: labels
+labels:
+  app.kubernetes.io/component: image-automation-controller
+fieldSpecs:
+  - path: metadata/labels
+    create: true

--- a/manifests/bases/image-reflector-controller/kustomization.yaml
+++ b/manifests/bases/image-reflector-controller/kustomization.yaml
@@ -4,6 +4,8 @@ resources:
 - https://github.com/fluxcd/image-reflector-controller/releases/download/v0.21.0/image-reflector-controller.crds.yaml
 - https://github.com/fluxcd/image-reflector-controller/releases/download/v0.21.0/image-reflector-controller.deployment.yaml
 - account.yaml
+transformers:
+- labels.yaml
 patchesJson6902:
 - target:
     group: apps

--- a/manifests/bases/image-reflector-controller/labels.yaml
+++ b/manifests/bases/image-reflector-controller/labels.yaml
@@ -1,0 +1,9 @@
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: labels
+labels:
+  app.kubernetes.io/component: image-reflector-controller
+fieldSpecs:
+  - path: metadata/labels
+    create: true

--- a/manifests/bases/kustomize-controller/kustomization.yaml
+++ b/manifests/bases/kustomize-controller/kustomization.yaml
@@ -4,6 +4,8 @@ resources:
 - https://github.com/fluxcd/kustomize-controller/releases/download/v0.28.0/kustomize-controller.crds.yaml
 - https://github.com/fluxcd/kustomize-controller/releases/download/v0.28.0/kustomize-controller.deployment.yaml
 - account.yaml
+transformers:
+- labels.yaml
 patchesJson6902:
 - target:
     group: apps
@@ -11,4 +13,3 @@ patchesJson6902:
     kind: Deployment
     name: kustomize-controller
   path: patch.yaml
-

--- a/manifests/bases/kustomize-controller/labels.yaml
+++ b/manifests/bases/kustomize-controller/labels.yaml
@@ -1,0 +1,9 @@
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: labels
+labels:
+  app.kubernetes.io/component: kustomize-controller
+fieldSpecs:
+  - path: metadata/labels
+    create: true

--- a/manifests/bases/notification-controller/kustomization.yaml
+++ b/manifests/bases/notification-controller/kustomization.yaml
@@ -4,6 +4,8 @@ resources:
 - https://github.com/fluxcd/notification-controller/releases/download/v0.26.0/notification-controller.crds.yaml
 - https://github.com/fluxcd/notification-controller/releases/download/v0.26.0/notification-controller.deployment.yaml
 - account.yaml
+transformers:
+- labels.yaml
 patchesJson6902:
   - target:
       group: apps

--- a/manifests/bases/notification-controller/labels.yaml
+++ b/manifests/bases/notification-controller/labels.yaml
@@ -1,0 +1,9 @@
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: labels
+labels:
+  app.kubernetes.io/component: notification-controller
+fieldSpecs:
+  - path: metadata/labels
+    create: true

--- a/manifests/bases/source-controller/kustomization.yaml
+++ b/manifests/bases/source-controller/kustomization.yaml
@@ -4,6 +4,8 @@ resources:
 - https://github.com/fluxcd/source-controller/releases/download/v0.29.0/source-controller.crds.yaml
 - https://github.com/fluxcd/source-controller/releases/download/v0.29.0/source-controller.deployment.yaml
 - account.yaml
+transformers:
+- labels.yaml
 patchesJson6902:
 - target:
     group: apps
@@ -11,4 +13,3 @@ patchesJson6902:
     kind: Deployment
     name: source-controller
   path: patch.yaml
-

--- a/manifests/bases/source-controller/labels.yaml
+++ b/manifests/bases/source-controller/labels.yaml
@@ -1,0 +1,9 @@
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: labels
+labels:
+  app.kubernetes.io/component: source-controller
+fieldSpecs:
+  - path: metadata/labels
+    create: true


### PR DESCRIPTION
Label each controller deployment, service, service account and CRDs with `app.kubernetes.io/component: <controller-name>`.

Ref: https://github.com/fluxcd/flux2/discussions/3100