### PR TITLE
Build with Go 1.19

### DIFF
--- a/.github/workflows/bootstrap.yaml
+++ b/.github/workflows/bootstrap.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
       - name: Setup Kubernetes
         uses: engineerd/setup-kind@v0.5.0
         with:

--- a/.github/workflows/bootstrap.yaml
+++ b/.github/workflows/bootstrap.yaml
@@ -27,8 +27,8 @@ jobs:
       - name: Setup Kubernetes
         uses: engineerd/setup-kind@v0.5.0
         with:
-          version: v0.11.1
-          image: kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
+          version: v0.16.0
+          image: kindest/node:v1.25.2@sha256:9be91e9e9cdf116809841fc77ebdb8845443c4c72fe5218f3ae9eb57fdb4bace
       - name: Setup Kustomize
         uses: fluxcd/pkg//actions/kustomize@main
       - name: Build

--- a/.github/workflows/e2e-arm64.yaml
+++ b/.github/workflows/e2e-arm64.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
       - name: Prepare
         id: prep
         run: |

--- a/.github/workflows/e2e-azure.yaml
+++ b/.github/workflows/e2e-azure.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
       - name: Install libgit2
         run: |
           sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 648ACFD622F3D138

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
       - name: Setup Kubernetes
         uses: engineerd/setup-kind@v0.5.0
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v2
       - name: Setup Docker Buildx

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19.x
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
       - name: Update component versions
         id: update
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ for source changes.
 
 Prerequisites:
 
-* go >= 1.17
+* go >= 1.19
 * kubectl >= 1.20
 * kustomize >= 4.4
 * coreutils (on Mac OS)

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ rwildcard=$(foreach d,$(wildcard $(addsuffix *,$(1))),$(call rwildcard,$(d)/,$(2
 all: test build
 
 tidy:
-	go mod tidy -compat=1.18
-	cd tests/azure && go mod tidy -compat=1.18
+	go mod tidy -compat=1.19
+	cd tests/azure && go mod tidy -compat=1.19
 
 fmt:
 	go fmt ./...

--- a/cmd/flux/create.go
+++ b/cmd/flux/create.go
@@ -79,12 +79,12 @@ type upsertable interface {
 // want to update. The mutate function is nullary -- you mutate a
 // value in the closure, e.g., by doing this:
 //
-//     var existing Value
-//     existing.Name = name
-//     existing.Namespace = ns
-//     upsert(ctx, client, valueAdapter{&value}, func() error {
-//       value.Spec = onePreparedEarlier
-//     })
+//	var existing Value
+//	existing.Name = name
+//	existing.Namespace = ns
+//	upsert(ctx, client, valueAdapter{&value}, func() error {
+//	  value.Spec = onePreparedEarlier
+//	})
 func (names apiType) upsert(ctx context.Context, kubeClient client.Client, object upsertable, mutate func() error) (types.NamespacedName, error) {
 	nsname := types.NamespacedName{
 		Namespace: object.GetNamespace(),

--- a/cmd/flux/get.go
+++ b/cmd/flux/get.go
@@ -214,7 +214,6 @@ func getRowsToPrint(getAll bool, list summarisable) ([][]string, error) {
 	return rows, nil
 }
 
-//
 // watch starts a client-side watch of one or more resources.
 func (get *getCommand) watch(ctx context.Context, kubeClient client.WithWatch, cmd *cobra.Command, args []string, listOpts []client.ListOption) error {
 	w, err := kubeClient.Watch(ctx, get.list.asClientList(), listOpts...)


### PR DESCRIPTION
Changes:
- Update Go to 1.19 in CI
- Update Kubernetes to 1.25.2 in bootstrap e2e test