### PR TITLE
Only run e2e tests for Dependabot PRs

### DIFF
--- a/.github/workflows/bootstrap.yaml
+++ b/.github/workflows/bootstrap.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   github:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -16,6 +16,7 @@ jobs:
   fossa:
     name: FOSSA
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v3
       - name: Run FOSSA scan and upload build data
@@ -28,7 +29,7 @@ jobs:
   snyk:
     name: Snyk
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v3
       - name: Setup Kustomize
@@ -51,6 +52,7 @@ jobs:
   codeql:
     name: CodeQL
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Dependabot doesn't have access to GitHub secrets, so as with PRs from forks, we need to skip those workflows which require secrets.