### PR TITLE
Remove file reading from bootstrap package

### DIFF
--- a/pkg/bootstrap/git/commit_options.go
+++ b/pkg/bootstrap/git/commit_options.go
@@ -1,5 +1,9 @@
 package git
 
+import (
+	"github.com/ProtonMail/go-crypto/openpgp"
+)
+
 // Option is a some configuration that modifies options for a commit.
 type Option interface {
 	// ApplyToCommit applies this configuration to a given commit option.
@@ -13,9 +17,9 @@ type CommitOptions struct {
 
 // GPGSigningInfo contains information for signing a commit.
 type GPGSigningInfo struct {
-	KeyRingPath string
-	Passphrase  string
-	KeyID       string
+	KeyRing    openpgp.EntityList
+	Passphrase string
+	KeyID      string
 }
 
 type GpgSigningOption struct {
@@ -26,17 +30,17 @@ func (w GpgSigningOption) ApplyToCommit(in *CommitOptions) {
 	in.GPGSigningInfo = w.GPGSigningInfo
 }
 
-func WithGpgSigningOption(path, passphrase, keyID string) Option {
+func WithGpgSigningOption(keyRing openpgp.EntityList, passphrase, keyID string) Option {
 	// Return nil if no path is set, even if other options are configured.
-	if path == "" {
+	if len(keyRing) == 0 {
 		return GpgSigningOption{}
 	}
 
 	return GpgSigningOption{
 		GPGSigningInfo: &GPGSigningInfo{
-			KeyRingPath: path,
-			Passphrase:  passphrase,
-			KeyID:       keyID,
+			KeyRing:    keyRing,
+			Passphrase: passphrase,
+			KeyID:      keyID,
 		},
 	}
 }

--- a/pkg/bootstrap/git/gogit/gogit_test.go
+++ b/pkg/bootstrap/git/gogit/gogit_test.go
@@ -4,8 +4,10 @@
 package gogit
 
 import (
+	"os"
 	"testing"
 
+	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/fluxcd/flux2/pkg/bootstrap/git"
 )
 
@@ -49,10 +51,21 @@ func TestGetOpenPgpEntity(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			var entityList openpgp.EntityList
+			if tt.keyPath != "" {
+				r, err := os.Open(tt.keyPath)
+				if err != nil {
+					t.Errorf("unexpected error: %s", err)
+				}
+				entityList, err = openpgp.ReadKeyRing(r)
+				if err != nil {
+					t.Errorf("unexpected error: %s", err)
+				}
+			}
 			gpgInfo := git.GPGSigningInfo{
-				KeyRingPath: tt.keyPath,
-				Passphrase:  tt.passphrase,
-				KeyID:       tt.id,
+				KeyRing:    entityList,
+				Passphrase: tt.passphrase,
+				KeyID:      tt.id,
 			}
 
 			_, err := getOpenPgpEntity(gpgInfo)

--- a/pkg/manifestgen/sourcesecret/options.go
+++ b/pkg/manifestgen/sourcesecret/options.go
@@ -18,6 +18,8 @@ package sourcesecret
 
 import (
 	"crypto/elliptic"
+
+	"github.com/fluxcd/pkg/ssh"
 )
 
 type PrivateKeyAlgorithm string
@@ -48,12 +50,12 @@ type Options struct {
 	PrivateKeyAlgorithm PrivateKeyAlgorithm
 	RSAKeyBits          int
 	ECDSACurve          elliptic.Curve
-	PrivateKeyPath      string
+	Keypair             *ssh.KeyPair
 	Username            string
 	Password            string
-	CAFilePath          string
-	CertFilePath        string
-	KeyFilePath         string
+	CAFile              []byte
+	CertFile            []byte
+	KeyFile             []byte
 	TargetPath          string
 	ManifestFile        string
 }
@@ -64,12 +66,11 @@ func MakeDefaultOptions() Options {
 		Namespace:           "flux-system",
 		Labels:              map[string]string{},
 		PrivateKeyAlgorithm: RSAPrivateKeyAlgorithm,
-		PrivateKeyPath:      "",
 		Username:            "",
 		Password:            "",
-		CAFilePath:          "",
-		CertFilePath:        "",
-		KeyFilePath:         "",
+		CAFile:              []byte{},
+		CertFile:            []byte{},
+		KeyFile:             []byte{},
 		ManifestFile:        "secret.yaml",
 	}
 }

--- a/pkg/manifestgen/sourcesecret/sourcesecret_test.go
+++ b/pkg/manifestgen/sourcesecret/sourcesecret_test.go
@@ -48,7 +48,7 @@ func Test_passwordLoadKeyPair(t *testing.T) {
 			pk, _ := os.ReadFile(tt.privateKeyPath)
 			ppk, _ := os.ReadFile(tt.publicKeyPath)
 
-			got, err := loadKeyPair(tt.privateKeyPath, tt.password)
+			got, err := LoadKeyPair(pk, tt.password)
 			if err != nil {
 				t.Errorf("loadKeyPair() error = %v", err)
 				return
@@ -67,24 +67,13 @@ func Test_passwordLoadKeyPair(t *testing.T) {
 func Test_PasswordlessLoadKeyPair(t *testing.T) {
 	for algo, privateKey := range testdata.PEMBytes {
 		t.Run(algo, func(t *testing.T) {
-			f, err := os.CreateTemp("", "test-private-key-")
-			if err != nil {
-				t.Fatalf("unable to create temporary file. err: %s", err)
-			}
-			defer os.Remove(f.Name())
-
-			if _, err = f.Write(privateKey); err != nil {
-				t.Fatalf("unable to write private key to file. err: %s", err)
-			}
-
-			got, err := loadKeyPair(f.Name(), "")
+			got, err := LoadKeyPair(privateKey, "")
 			if err != nil {
 				t.Errorf("loadKeyPair() error = %v", err)
 				return
 			}
 
-			pk, _ := os.ReadFile(f.Name())
-			if !reflect.DeepEqual(got.PrivateKey, pk) {
+			if !reflect.DeepEqual(got.PrivateKey, privateKey) {
 				t.Errorf("PrivateKey %s != %s", got.PrivateKey, string(privateKey))
 			}
 


### PR DESCRIPTION
This change moves all file reading for certificates and PGP from code located in pkg to the CLI command. The purpose for this is to make sharing the code easier where the content is not expected to be in files.