### PR TITLE
Aggregate errors in uninstall functions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,6 @@ require (
 	github.com/gonvenience/ytbx v1.4.4
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-containerregistry v0.12.1
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/homeport/dyff v1.5.6
 	github.com/lucasb-eyer/go-colorful v1.2.0
 	github.com/manifoldco/promptui v0.9.0
@@ -141,6 +140,7 @@ require (
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect

--- a/internal/build/diff.go
+++ b/internal/build/diff.go
@@ -27,20 +27,22 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/fluxcd/flux2/pkg/printers"
-	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
-	"github.com/fluxcd/pkg/ssa"
 	"github.com/gonvenience/bunt"
 	"github.com/gonvenience/ytbx"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/go-multierror"
 	"github.com/homeport/dyff/pkg/dyff"
 	"github.com/lucasb-eyer/go-colorful"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/errors"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling"
 	"sigs.k8s.io/cli-utils/pkg/object"
 	"sigs.k8s.io/yaml"
+
+	"github.com/fluxcd/pkg/ssa"
+
+	"github.com/fluxcd/flux2/pkg/printers"
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
 )
 
 func (b *Builder) Manager() (*ssa.ResourceManager, error) {
@@ -85,7 +87,7 @@ func (b *Builder) Diff() (string, bool, error) {
 		}
 	}
 
-	var diffErrs error
+	var diffErrs []error
 	// create an inventory of objects to be reconciled
 	newInventory := newInventory()
 	for _, obj := range objects {
@@ -97,7 +99,7 @@ func (b *Builder) Diff() (string, bool, error) {
 		change, liveObject, mergedObject, err := resourceManager.Diff(ctx, obj, diffOptions)
 		if err != nil {
 			// gather errors and continue, as we want to see all the diffs
-			diffErrs = multierror.Append(diffErrs, err)
+			diffErrs = append(diffErrs, err)
 			continue
 		}
 
@@ -135,7 +137,7 @@ func (b *Builder) Diff() (string, bool, error) {
 		b.spinner.Message("processing inventory")
 	}
 
-	if b.kustomization.Spec.Prune && diffErrs == nil {
+	if b.kustomization.Spec.Prune && len(diffErrs) == 0 {
 		oldStatus := b.kustomization.Status.DeepCopy()
 		if oldStatus.Inventory != nil {
 			diffObjects, err := diffInventory(oldStatus.Inventory, newInventory)
@@ -155,7 +157,7 @@ func (b *Builder) Diff() (string, bool, error) {
 		}
 	}
 
-	return output.String(), createdOrDrifted, diffErrs
+	return output.String(), createdOrDrifted, errors.Reduce(errors.Flatten(errors.NewAggregate(diffErrs)))
 }
 
 func writeYamls(liveObject, mergedObject *unstructured.Unstructured) (string, string, string, error) {

--- a/pkg/uninstall/uninstall.go
+++ b/pkg/uninstall/uninstall.go
@@ -25,6 +25,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/fluxcd/flux2/pkg/log"
@@ -35,12 +36,11 @@ import (
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
 	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta1"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
-	"github.com/hashicorp/go-multierror"
 )
 
 // Components removes all Kubernetes components that are part of Flux excluding the CRDs and namespace.
 func Components(ctx context.Context, logger log.Logger, kubeClient client.Client, namespace string, dryRun bool) error {
-	var aggregateErr error
+	var aggregateErr []error
 	opts, dryRunStr := getDeleteOptions(dryRun)
 	selector := client.MatchingLabels{manifestgen.PartOfLabelKey: manifestgen.PartOfLabelValue}
 	{
@@ -49,7 +49,7 @@ func Components(ctx context.Context, logger log.Logger, kubeClient client.Client
 			for _, r := range list.Items {
 				if err := kubeClient.Delete(ctx, &r, opts); err != nil {
 					logger.Failuref("Deployment/%s/%s deletion failed: %s", r.Namespace, r.Name, err.Error())
-					aggregateErr = multierror.Append(aggregateErr, err)
+					aggregateErr = append(aggregateErr, err)
 				} else {
 					logger.Successf("Deployment/%s/%s deleted %s", r.Namespace, r.Name, dryRunStr)
 				}
@@ -62,7 +62,7 @@ func Components(ctx context.Context, logger log.Logger, kubeClient client.Client
 			for _, r := range list.Items {
 				if err := kubeClient.Delete(ctx, &r, opts); err != nil {
 					logger.Failuref("Service/%s/%s deletion failed: %s", r.Namespace, r.Name, err.Error())
-					aggregateErr = multierror.Append(aggregateErr, err)
+					aggregateErr = append(aggregateErr, err)
 				} else {
 					logger.Successf("Service/%s/%s deleted %s", r.Namespace, r.Name, dryRunStr)
 				}
@@ -75,7 +75,7 @@ func Components(ctx context.Context, logger log.Logger, kubeClient client.Client
 			for _, r := range list.Items {
 				if err := kubeClient.Delete(ctx, &r, opts); err != nil {
 					logger.Failuref("NetworkPolicy/%s/%s deletion failed: %s", r.Namespace, r.Name, err.Error())
-					aggregateErr = multierror.Append(aggregateErr, err)
+					aggregateErr = append(aggregateErr, err)
 				} else {
 					logger.Successf("NetworkPolicy/%s/%s deleted %s", r.Namespace, r.Name, dryRunStr)
 				}
@@ -88,7 +88,7 @@ func Components(ctx context.Context, logger log.Logger, kubeClient client.Client
 			for _, r := range list.Items {
 				if err := kubeClient.Delete(ctx, &r, opts); err != nil {
 					logger.Failuref("ServiceAccount/%s/%s deletion failed: %s", r.Namespace, r.Name, err.Error())
-					aggregateErr = multierror.Append(aggregateErr, err)
+					aggregateErr = append(aggregateErr, err)
 				} else {
 					logger.Successf("ServiceAccount/%s/%s deleted %s", r.Namespace, r.Name, dryRunStr)
 				}
@@ -101,7 +101,7 @@ func Components(ctx context.Context, logger log.Logger, kubeClient client.Client
 			for _, r := range list.Items {
 				if err := kubeClient.Delete(ctx, &r, opts); err != nil {
 					logger.Failuref("ClusterRole/%s deletion failed: %s", r.Name, err.Error())
-					aggregateErr = multierror.Append(aggregateErr, err)
+					aggregateErr = append(aggregateErr, err)
 				} else {
 					logger.Successf("ClusterRole/%s deleted %s", r.Name, dryRunStr)
 				}
@@ -114,7 +114,7 @@ func Components(ctx context.Context, logger log.Logger, kubeClient client.Client
 			for _, r := range list.Items {
 				if err := kubeClient.Delete(ctx, &r, opts); err != nil {
 					logger.Failuref("ClusterRoleBinding/%s deletion failed: %s", r.Name, err.Error())
-					aggregateErr = multierror.Append(aggregateErr, err)
+					aggregateErr = append(aggregateErr, err)
 				} else {
 					logger.Successf("ClusterRoleBinding/%s deleted %s", r.Name, dryRunStr)
 				}
@@ -122,12 +122,12 @@ func Components(ctx context.Context, logger log.Logger, kubeClient client.Client
 		}
 	}
 
-	return aggregateErr
+	return errors.Reduce(errors.Flatten(errors.NewAggregate(aggregateErr)))
 }
 
 // Finalizers removes all finalizes on Kubernetes components that have been added by a Flux controller.
 func Finalizers(ctx context.Context, logger log.Logger, kubeClient client.Client, dryRun bool) error {
-	var aggregateErr error
+	var aggregateErr []error
 	opts, dryRunStr := getUpdateOptions(dryRun)
 	{
 		var list sourcev1.GitRepositoryList
@@ -136,7 +136,7 @@ func Finalizers(ctx context.Context, logger log.Logger, kubeClient client.Client
 				r.Finalizers = []string{}
 				if err := kubeClient.Update(ctx, &r, opts); err != nil {
 					logger.Failuref("%s/%s/%s removing finalizers failed: %s", r.Kind, r.Namespace, r.Name, err.Error())
-					aggregateErr = multierror.Append(aggregateErr, err)
+					aggregateErr = append(aggregateErr, err)
 				} else {
 					logger.Successf("%s/%s/%s finalizers deleted %s", r.Kind, r.Namespace, r.Name, dryRunStr)
 				}
@@ -150,7 +150,7 @@ func Finalizers(ctx context.Context, logger log.Logger, kubeClient client.Client
 				r.Finalizers = []string{}
 				if err := kubeClient.Update(ctx, &r, opts); err != nil {
 					logger.Failuref("%s/%s/%s removing finalizers failed: %s", r.Kind, r.Namespace, r.Name, err.Error())
-					aggregateErr = multierror.Append(aggregateErr, err)
+					aggregateErr = append(aggregateErr, err)
 				} else {
 					logger.Successf("%s/%s/%s finalizers deleted %s", r.Kind, r.Namespace, r.Name, dryRunStr)
 				}
@@ -164,7 +164,7 @@ func Finalizers(ctx context.Context, logger log.Logger, kubeClient client.Client
 				r.Finalizers = []string{}
 				if err := kubeClient.Update(ctx, &r, opts); err != nil {
 					logger.Failuref("%s/%s/%s removing finalizers failed: %s", r.Kind, r.Namespace, r.Name, err.Error())
-					aggregateErr = multierror.Append(aggregateErr, err)
+					aggregateErr = append(aggregateErr, err)
 				} else {
 					logger.Successf("%s/%s/%s finalizers deleted %s", r.Kind, r.Namespace, r.Name, dryRunStr)
 				}
@@ -178,7 +178,7 @@ func Finalizers(ctx context.Context, logger log.Logger, kubeClient client.Client
 				r.Finalizers = []string{}
 				if err := kubeClient.Update(ctx, &r, opts); err != nil {
 					logger.Failuref("%s/%s/%s removing finalizers failed: %s", r.Kind, r.Namespace, r.Name, err.Error())
-					aggregateErr = multierror.Append(aggregateErr, err)
+					aggregateErr = append(aggregateErr, err)
 				} else {
 					logger.Successf("%s/%s/%s finalizers deleted %s", r.Kind, r.Namespace, r.Name, dryRunStr)
 				}
@@ -192,7 +192,7 @@ func Finalizers(ctx context.Context, logger log.Logger, kubeClient client.Client
 				r.Finalizers = []string{}
 				if err := kubeClient.Update(ctx, &r, opts); err != nil {
 					logger.Failuref("%s/%s/%s removing finalizers failed: %s", r.Kind, r.Namespace, r.Name, err.Error())
-					aggregateErr = multierror.Append(aggregateErr, err)
+					aggregateErr = append(aggregateErr, err)
 				} else {
 					logger.Successf("%s/%s/%s finalizers deleted %s", r.Kind, r.Namespace, r.Name, dryRunStr)
 				}
@@ -206,7 +206,7 @@ func Finalizers(ctx context.Context, logger log.Logger, kubeClient client.Client
 				r.Finalizers = []string{}
 				if err := kubeClient.Update(ctx, &r, opts); err != nil {
 					logger.Failuref("%s/%s/%s removing finalizers failed: %s", r.Kind, r.Namespace, r.Name, err.Error())
-					aggregateErr = multierror.Append(aggregateErr, err)
+					aggregateErr = append(aggregateErr, err)
 				} else {
 					logger.Successf("%s/%s/%s finalizers deleted %s", r.Kind, r.Namespace, r.Name, dryRunStr)
 				}
@@ -220,7 +220,7 @@ func Finalizers(ctx context.Context, logger log.Logger, kubeClient client.Client
 				r.Finalizers = []string{}
 				if err := kubeClient.Update(ctx, &r, opts); err != nil {
 					logger.Failuref("%s/%s/%s removing finalizers failed: %s", r.Kind, r.Namespace, r.Name, err.Error())
-					aggregateErr = multierror.Append(aggregateErr, err)
+					aggregateErr = append(aggregateErr, err)
 				} else {
 					logger.Successf("%s/%s/%s finalizers deleted %s", r.Kind, r.Namespace, r.Name, dryRunStr)
 				}
@@ -234,7 +234,7 @@ func Finalizers(ctx context.Context, logger log.Logger, kubeClient client.Client
 				r.Finalizers = []string{}
 				if err := kubeClient.Update(ctx, &r, opts); err != nil {
 					logger.Failuref("%s/%s/%s removing finalizers failed: %s", r.Kind, r.Namespace, r.Name, err.Error())
-					aggregateErr = multierror.Append(aggregateErr, err)
+					aggregateErr = append(aggregateErr, err)
 				} else {
 					logger.Successf("%s/%s/%s finalizers deleted %s", r.Kind, r.Namespace, r.Name, dryRunStr)
 				}
@@ -248,7 +248,7 @@ func Finalizers(ctx context.Context, logger log.Logger, kubeClient client.Client
 				r.Finalizers = []string{}
 				if err := kubeClient.Update(ctx, &r, opts); err != nil {
 					logger.Failuref("%s/%s/%s removing finalizers failed: %s", r.Kind, r.Namespace, r.Name, err.Error())
-					aggregateErr = multierror.Append(aggregateErr, err)
+					aggregateErr = append(aggregateErr, err)
 				} else {
 					logger.Successf("%s/%s/%s finalizers deleted %s", r.Kind, r.Namespace, r.Name, dryRunStr)
 				}
@@ -262,7 +262,7 @@ func Finalizers(ctx context.Context, logger log.Logger, kubeClient client.Client
 				r.Finalizers = []string{}
 				if err := kubeClient.Update(ctx, &r, opts); err != nil {
 					logger.Failuref("%s/%s/%s removing finalizers failed: %s", r.Kind, r.Namespace, r.Name, err.Error())
-					aggregateErr = multierror.Append(aggregateErr, err)
+					aggregateErr = append(aggregateErr, err)
 				} else {
 					logger.Successf("%s/%s/%s finalizers deleted %s", r.Kind, r.Namespace, r.Name, dryRunStr)
 				}
@@ -276,7 +276,7 @@ func Finalizers(ctx context.Context, logger log.Logger, kubeClient client.Client
 				r.Finalizers = []string{}
 				if err := kubeClient.Update(ctx, &r, opts); err != nil {
 					logger.Failuref("%s/%s/%s removing finalizers failed: %s", r.Kind, r.Namespace, r.Name, err.Error())
-					aggregateErr = multierror.Append(aggregateErr, err)
+					aggregateErr = append(aggregateErr, err)
 				} else {
 					logger.Successf("%s/%s/%s finalizers deleted %s", r.Kind, r.Namespace, r.Name, dryRunStr)
 				}
@@ -290,7 +290,7 @@ func Finalizers(ctx context.Context, logger log.Logger, kubeClient client.Client
 				r.Finalizers = []string{}
 				if err := kubeClient.Update(ctx, &r, opts); err != nil {
 					logger.Failuref("%s/%s/%s removing finalizers failed: %s", r.Kind, r.Namespace, r.Name, err.Error())
-					aggregateErr = multierror.Append(aggregateErr, err)
+					aggregateErr = append(aggregateErr, err)
 				} else {
 					logger.Successf("%s/%s/%s finalizers deleted %s", r.Kind, r.Namespace, r.Name, dryRunStr)
 				}
@@ -304,19 +304,19 @@ func Finalizers(ctx context.Context, logger log.Logger, kubeClient client.Client
 				r.Finalizers = []string{}
 				if err := kubeClient.Update(ctx, &r, opts); err != nil {
 					logger.Failuref("%s/%s/%s removing finalizers failed: %s", r.Kind, r.Namespace, r.Name, err.Error())
-					aggregateErr = multierror.Append(aggregateErr, err)
+					aggregateErr = append(aggregateErr, err)
 				} else {
 					logger.Successf("%s/%s/%s finalizers deleted %s", r.Kind, r.Namespace, r.Name, dryRunStr)
 				}
 			}
 		}
 	}
-	return aggregateErr
+	return errors.Reduce(errors.Flatten(errors.NewAggregate(aggregateErr)))
 }
 
 // CustomResourceDefinitions removes all Kubernetes CRDs that are a part of Flux.
 func CustomResourceDefinitions(ctx context.Context, logger log.Logger, kubeClient client.Client, dryRun bool) error {
-	var aggregateErr error
+	var aggregateErr []error
 	opts, dryRunStr := getDeleteOptions(dryRun)
 	selector := client.MatchingLabels{manifestgen.PartOfLabelKey: manifestgen.PartOfLabelValue}
 	{
@@ -325,28 +325,28 @@ func CustomResourceDefinitions(ctx context.Context, logger log.Logger, kubeClien
 			for _, r := range list.Items {
 				if err := kubeClient.Delete(ctx, &r, opts); err != nil {
 					logger.Failuref("CustomResourceDefinition/%s deletion failed: %s", r.Name, err.Error())
-					aggregateErr = multierror.Append(aggregateErr, err)
+					aggregateErr = append(aggregateErr, err)
 				} else {
 					logger.Successf("CustomResourceDefinition/%s deleted %s", r.Name, dryRunStr)
 				}
 			}
 		}
 	}
-	return aggregateErr
+	return errors.Reduce(errors.Flatten(errors.NewAggregate(aggregateErr)))
 }
 
 // Namespace removes the namespace Flux is installed in.
 func Namespace(ctx context.Context, logger log.Logger, kubeClient client.Client, namespace string, dryRun bool) error {
-	var aggregateErr error
+	var aggregateErr []error
 	opts, dryRunStr := getDeleteOptions(dryRun)
 	ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
 	if err := kubeClient.Delete(ctx, &ns, opts); err != nil {
 		logger.Failuref("Namespace/%s deletion failed: %s", namespace, err.Error())
-		aggregateErr = multierror.Append(aggregateErr, err)
+		aggregateErr = append(aggregateErr, err)
 	} else {
 		logger.Successf("Namespace/%s deleted %s", namespace, dryRunStr)
 	}
-	return aggregateErr
+	return errors.Reduce(errors.Flatten(errors.NewAggregate(aggregateErr)))
 }
 
 func getDeleteOptions(dryRun bool) (*client.DeleteOptions, string) {


### PR DESCRIPTION
Adds an error return value to the uninstall functions. The cli ignores the returned error as it relies on the error message being logged to the user. It is however useful for other programs which want the actual returned error.