### PR TITLE
monitoring: Use kube-prometheus-stack signed OCI Helm chart

### DIFF
--- a/.github/workflows/e2e-arm64.yaml
+++ b/.github/workflows/e2e-arm64.yaml
@@ -58,6 +58,33 @@ jobs:
           kubectl -n flux-system wait kustomization/tenants --for=condition=ready --timeout=5m
           kubectl -n apps wait kustomization/dev-team --for=condition=ready --timeout=1m
           kubectl -n apps wait helmrelease/podinfo --for=condition=ready --timeout=1m
+      - name: Run monitoring tests
+        # Keep this test in sync with https://fluxcd.io/flux/guides/monitoring/
+        env:
+          KUBECONFIG: /tmp/${{ steps.prep.outputs.CLUSTER }}
+        run: |
+          ./bin/flux create source git flux-monitoring \
+          --interval=30m \
+          --url=https://github.com/fluxcd/flux2 \
+          --branch=${GITHUB_REF#refs/heads/}
+          ./bin/flux create kustomization kube-prometheus-stack \
+          --interval=1h \
+          --prune \
+          --source=flux-monitoring \
+          --path="./manifests/monitoring/kube-prometheus-stack" \
+          --health-check-timeout=5m \
+          --wait
+          ./bin/flux create kustomization monitoring-config \
+          --depends-on=kube-prometheus-stack \
+          --interval=1h \
+          --prune=true \
+          --source=flux-monitoring \
+          --path="./manifests/monitoring/monitoring-config" \
+          --health-check-timeout=1m \
+          --wait
+          kubectl -n flux-system wait kustomization/kube-prometheus-stack --for=condition=ready --timeout=5m
+          kubectl -n flux-system wait kustomization/monitoring-config --for=condition=ready --timeout=5m
+          kubectl -n monitoring wait helmrelease/kube-prometheus-stack --for=condition=ready --timeout=1m
       - name: Debug failure
         if: failure()
         env:

--- a/manifests/monitoring/kube-prometheus-stack/release.yaml
+++ b/manifests/monitoring/kube-prometheus-stack/release.yaml
@@ -6,11 +6,13 @@ spec:
   interval: 5m
   chart:
     spec:
-      version: "35.x"
+      version: "41.x"
       chart: kube-prometheus-stack
       sourceRef:
         kind: HelmRepository
         name: prometheus-community
+      verify:
+        provider: cosign
       interval: 60m
   install:
     crds: Create

--- a/manifests/monitoring/kube-prometheus-stack/repository.yaml
+++ b/manifests/monitoring/kube-prometheus-stack/repository.yaml
@@ -4,4 +4,5 @@ metadata:
   name: prometheus-community
 spec:
   interval: 120m
-  url: https://prometheus-community.github.io/helm-charts
+  type: oci
+  url: oci://ghcr.io/prometheus-community/charts


### PR DESCRIPTION
Changes:
- Switch the  prometheus-community HelmRepository to OCI
- Bump the kube-prometheus-stack version to latest v41
- Enable keyless cosign verification in the  kube-prometheus-stack HelmRelease
- Add the monitoring stack to the ARM64 e2e tests