### PR TITLE
Update kubectl and remove nsswitch.conf in flux-cli image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,13 @@ FROM alpine:3.16 as builder
 RUN apk add --no-cache ca-certificates curl
 
 ARG ARCH=linux/amd64
-ARG KUBECTL_VER=1.25.3
+ARG KUBECTL_VER=1.25.4
 
 RUN curl -sL https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VER}/bin/${ARCH}/kubectl \
     -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl && \
     kubectl version --client=true
 
 FROM alpine:3.16 as flux-cli
-
-# Create minimal nsswitch.conf file to prioritize the usage of /etc/hosts over DNS queries.
-# https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-354316460
-RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
 
 RUN apk add --no-cache ca-certificates
 


### PR DESCRIPTION
Changes:
- Remove nsswitch.conf creation as it's now included in [Alpine 3.16](https://git.alpinelinux.org/aports/commit/?id=348653a9ba0701e8e968b3344e72313a9ef334e4)
- Update kubectl version to 1.25.4