### PR TITLE
Fix dry-run still loading kubeconfig issue

### DIFF
--- a/cmd/flux/build_kustomization.go
+++ b/cmd/flux/build_kustomization.go
@@ -88,12 +88,22 @@ func buildKsCmdRun(cmd *cobra.Command, args []string) (err error) {
 		}
 	}
 
-	builder, err := build.NewBuilder(name, buildKsArgs.path,
-		build.WithClientConfig(kubeconfigArgs, kubeclientOptions),
-		build.WithTimeout(rootArgs.timeout),
-		build.WithKustomizationFile(buildKsArgs.kustomizationFile),
-		build.WithDryRun(buildKsArgs.dryRun),
-	)
+	var builder *build.Builder
+	if buildKsArgs.dryRun {
+		builder, err = build.NewBuilder(name, buildKsArgs.path,
+			build.WithTimeout(rootArgs.timeout),
+			build.WithKustomizationFile(buildKsArgs.kustomizationFile),
+			build.WithDryRun(buildKsArgs.dryRun),
+			build.WithNamespace(*kubeconfigArgs.Namespace),
+		)
+	} else {
+		builder, err = build.NewBuilder(name, buildKsArgs.path,
+			build.WithClientConfig(kubeconfigArgs, kubeclientOptions),
+			build.WithTimeout(rootArgs.timeout),
+			build.WithKustomizationFile(buildKsArgs.kustomizationFile),
+		)
+	}
+
 	if err != nil {
 		return err
 	}

--- a/cmd/flux/testdata/build-kustomization/delete-service/hpa.yaml
+++ b/cmd/flux/testdata/build-kustomization/delete-service/hpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: podinfo

--- a/cmd/flux/testdata/build-kustomization/podinfo-result.yaml
+++ b/cmd/flux/testdata/build-kustomization/podinfo-result.yaml
@@ -77,7 +77,7 @@ spec:
             cpu: 100m
             memory: 64Mi
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   labels:

--- a/cmd/flux/testdata/build-kustomization/podinfo-without-service-result.yaml
+++ b/cmd/flux/testdata/build-kustomization/podinfo-without-service-result.yaml
@@ -77,7 +77,7 @@ spec:
             cpu: 100m
             memory: 64Mi
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   labels:

--- a/cmd/flux/testdata/build-kustomization/podinfo/hpa.yaml
+++ b/cmd/flux/testdata/build-kustomization/podinfo/hpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: podinfo

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -139,6 +139,14 @@ func WithClientConfig(rcg *genericclioptions.ConfigFlags, clientOpts *runclient.
 	}
 }
 
+// WithNamespace sets the namespace
+func WithNamespace(namespace string) BuilderOptionFunc {
+	return func(b *Builder) error {
+		b.namespace = namespace
+		return nil
+	}
+}
+
 // WithDryRun sets the dry-run flag
 func WithDryRun(dryRun bool) BuilderOptionFunc {
 	return func(b *Builder) error {


### PR DESCRIPTION
fixes #3411 

If this is implemented, it will not assume that access to a `kubeconfig` is guaranteed even if just for retrieving configured namespace.

Signed-off-by: Soule BA <soule@weave.works>