### PR TITLE
Fix path on `flux push`

### DIFF
--- a/cmd/flux/build_artifact.go
+++ b/cmd/flux/build_artifact.go
@@ -72,7 +72,7 @@ func buildArtifactCmdRun(cmd *cobra.Command, args []string) error {
 	path := buildArtifactArgs.path
 	var err error
 	if buildArtifactArgs.path == "-" {
-		path, err = saveStdinToFile()
+		path, err = saveReaderToFile(os.Stdin)
 		if err != nil {
 			return err
 		}
@@ -95,8 +95,8 @@ func buildArtifactCmdRun(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func saveStdinToFile() (string, error) {
-	b, err := io.ReadAll(bufio.NewReader(os.Stdin))
+func saveReaderToFile(reader io.Reader) (string, error) {
+	b, err := io.ReadAll(bufio.NewReader(reader))
 	if err != nil {
 		return "", err
 	}
@@ -106,8 +106,9 @@ func saveStdinToFile() (string, error) {
 		return "", fmt.Errorf("unable to create temp dir for stdin")
 	}
 
-	_, err = f.Write(b)
-	if err != nil {
+	defer f.Close()
+
+	if _, err := f.Write(b); err != nil {
 		return "", fmt.Errorf("error writing stdin to file: %w", err)
 	}
 

--- a/cmd/flux/build_artifact_test.go
+++ b/cmd/flux/build_artifact_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func Test_saveReaderToFile(t *testing.T) {
+	g := NewWithT(t)
+
+	testString := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: myapp
+data:
+  foo: bar`
+
+	tests := []struct {
+		name      string
+		string    string
+		expectErr bool
+	}{
+		{
+			name:   "yaml",
+			string: testString,
+		},
+		{
+			name:   "yaml with carriage return",
+			string: testString + "\r\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpFile, err := saveReaderToFile(strings.NewReader(tt.string))
+			g.Expect(err).To(BeNil())
+
+			defer os.Remove(tmpFile)
+
+			b, err := os.ReadFile(tmpFile)
+			if tt.expectErr {
+				g.Expect(err).To(Not(BeNil()))
+				return
+			}
+
+			g.Expect(err).To(BeNil())
+			g.Expect(string(b)).To(BeEquivalentTo(testString))
+		})
+
+	}
+}


### PR DESCRIPTION
Fixes bug introduced by https://github.com/fluxcd/flux2/pull/3389 where the path for the build cmd was used in the error message.

Also moves code for saving stdin to file before check for path

Signed-off-by: Somtochi Onyekwere <somtochionyekwere@gmail.com>