### PR TITLE
Update CLI commands to Notification API v1beta2

### DIFF
--- a/cmd/flux/alert.go
+++ b/cmd/flux/alert.go
@@ -19,7 +19,7 @@ package main
 import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta1"
+	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta2"
 )
 
 // notificationv1.Alert

--- a/cmd/flux/alert_provider.go
+++ b/cmd/flux/alert_provider.go
@@ -19,7 +19,7 @@ package main
 import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta1"
+	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta2"
 )
 
 // notificationv1.Provider

--- a/cmd/flux/create_alert.go
+++ b/cmd/flux/create_alert.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta1"
+	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta2"
 	"github.com/fluxcd/pkg/apis/meta"
 
 	"github.com/fluxcd/flux2/internal/utils"

--- a/cmd/flux/create_alertprovider.go
+++ b/cmd/flux/create_alertprovider.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta1"
+	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta2"
 	"github.com/fluxcd/pkg/apis/meta"
 
 	"github.com/fluxcd/flux2/internal/utils"

--- a/cmd/flux/create_receiver.go
+++ b/cmd/flux/create_receiver.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta1"
+	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta2"
 	"github.com/fluxcd/pkg/apis/meta"
 
 	"github.com/fluxcd/flux2/internal/utils"

--- a/cmd/flux/delete_alert.go
+++ b/cmd/flux/delete_alert.go
@@ -19,7 +19,7 @@ package main
 import (
 	"github.com/spf13/cobra"
 
-	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta1"
+	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta2"
 )
 
 var deleteAlertCmd = &cobra.Command{

--- a/cmd/flux/delete_alertprovider.go
+++ b/cmd/flux/delete_alertprovider.go
@@ -19,7 +19,7 @@ package main
 import (
 	"github.com/spf13/cobra"
 
-	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta1"
+	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta2"
 )
 
 var deleteAlertProviderCmd = &cobra.Command{

--- a/cmd/flux/delete_receiver.go
+++ b/cmd/flux/delete_receiver.go
@@ -19,7 +19,7 @@ package main
 import (
 	"github.com/spf13/cobra"
 
-	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta1"
+	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta2"
 )
 
 var deleteReceiverCmd = &cobra.Command{

--- a/cmd/flux/export_alert.go
+++ b/cmd/flux/export_alert.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta1"
+	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta2"
 )
 
 var exportAlertCmd = &cobra.Command{

--- a/cmd/flux/export_alertprovider.go
+++ b/cmd/flux/export_alertprovider.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta1"
+	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta2"
 )
 
 var exportAlertProviderCmd = &cobra.Command{

--- a/cmd/flux/export_receiver.go
+++ b/cmd/flux/export_receiver.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta1"
+	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta2"
 )
 
 var exportReceiverCmd = &cobra.Command{

--- a/cmd/flux/get_alert.go
+++ b/cmd/flux/get_alert.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta1"
+	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta2"
 )
 
 var getAlertCmd = &cobra.Command{

--- a/cmd/flux/get_alertprovider.go
+++ b/cmd/flux/get_alertprovider.go
@@ -22,7 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta1"
+	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta2"
 )
 
 var getAlertProviderCmd = &cobra.Command{

--- a/cmd/flux/get_all.go
+++ b/cmd/flux/get_all.go
@@ -23,7 +23,7 @@ import (
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
-	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta1"
+	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta2"
 )
 
 var getAllCmd = &cobra.Command{

--- a/cmd/flux/get_receiver.go
+++ b/cmd/flux/get_receiver.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta1"
+	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta2"
 )
 
 var getReceiverCmd = &cobra.Command{

--- a/cmd/flux/receiver.go
+++ b/cmd/flux/receiver.go
@@ -19,7 +19,7 @@ package main
 import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta1"
+	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta2"
 )
 
 // notificationv1.Receiver

--- a/cmd/flux/reconcile.go
+++ b/cmd/flux/reconcile.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/fluxcd/notification-controller/api/v1beta1"
+	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta2"
 	"github.com/fluxcd/pkg/apis/meta"
 
 	"github.com/fluxcd/flux2/internal/utils"
@@ -111,7 +111,7 @@ func (reconcile reconcileCommand) run(cmd *cobra.Command, args []string) error {
 	}
 	logger.Successf("%s annotated", reconcile.kind)
 
-	if reconcile.kind == v1beta1.AlertKind || reconcile.kind == v1beta1.ReceiverKind {
+	if reconcile.kind == notificationv1.AlertKind || reconcile.kind == notificationv1.ReceiverKind {
 		if err = wait.PollImmediate(rootArgs.pollInterval, rootArgs.timeout,
 			isReconcileReady(ctx, kubeClient, namespacedName, reconcile.object)); err != nil {
 			return err

--- a/cmd/flux/reconcile_alert.go
+++ b/cmd/flux/reconcile_alert.go
@@ -19,7 +19,7 @@ package main
 import (
 	"github.com/spf13/cobra"
 
-	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta1"
+	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta2"
 )
 
 var reconcileAlertCmd = &cobra.Command{

--- a/cmd/flux/reconcile_alertprovider.go
+++ b/cmd/flux/reconcile_alertprovider.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta1"
+	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta2"
 	"github.com/fluxcd/pkg/apis/meta"
 
 	"github.com/fluxcd/flux2/internal/utils"

--- a/cmd/flux/reconcile_receiver.go
+++ b/cmd/flux/reconcile_receiver.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta1"
+	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta2"
 	"github.com/fluxcd/pkg/apis/meta"
 
 	"github.com/fluxcd/flux2/internal/utils"

--- a/cmd/flux/resume_alert.go
+++ b/cmd/flux/resume_alert.go
@@ -19,7 +19,7 @@ package main
 import (
 	"github.com/spf13/cobra"
 
-	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta1"
+	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta2"
 )
 
 var resumeAlertCmd = &cobra.Command{

--- a/cmd/flux/resume_receiver.go
+++ b/cmd/flux/resume_receiver.go
@@ -19,7 +19,7 @@ package main
 import (
 	"github.com/spf13/cobra"
 
-	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta1"
+	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta2"
 )
 
 var resumeReceiverCmd = &cobra.Command{

--- a/cmd/flux/suspend_alert.go
+++ b/cmd/flux/suspend_alert.go
@@ -19,7 +19,7 @@ package main
 import (
 	"github.com/spf13/cobra"
 
-	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta1"
+	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta2"
 )
 
 var suspendAlertCmd = &cobra.Command{

--- a/cmd/flux/suspend_receiver.go
+++ b/cmd/flux/suspend_receiver.go
@@ -19,7 +19,7 @@ package main
 import (
 	"github.com/spf13/cobra"
 
-	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta1"
+	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta2"
 )
 
 var suspendReceiverCmd = &cobra.Command{

--- a/cmd/flux/testdata/export/alert.yaml
+++ b/cmd/flux/testdata/export/alert.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: notification.toolkit.fluxcd.io/v1beta1
+apiVersion: notification.toolkit.fluxcd.io/v1beta2
 kind: Alert
 metadata:
   name: flux-system

--- a/cmd/flux/testdata/export/objects.yaml
+++ b/cmd/flux/testdata/export/objects.yaml
@@ -4,7 +4,7 @@ kind: Namespace
 metadata:
   name: {{ .fluxns }}
 ---
-apiVersion: notification.toolkit.fluxcd.io/v1beta1
+apiVersion: notification.toolkit.fluxcd.io/v1beta2
 kind: Provider
 metadata:
   name: slack
@@ -14,7 +14,7 @@ spec:
   channel: 'A channel with spacess'
   address: https://hooks.slack.com/services/mock
 ---
-apiVersion: notification.toolkit.fluxcd.io/v1beta1
+apiVersion: notification.toolkit.fluxcd.io/v1beta2
 kind: Alert
 metadata:
   name: flux-system
@@ -97,7 +97,7 @@ spec:
   interval: 5m
   prune: true
 ---
-apiVersion: notification.toolkit.fluxcd.io/v1beta1
+apiVersion: notification.toolkit.fluxcd.io/v1beta2
 kind: Receiver
 metadata:
   name: flux-system

--- a/cmd/flux/testdata/export/provider.yaml
+++ b/cmd/flux/testdata/export/provider.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: notification.toolkit.fluxcd.io/v1beta1
+apiVersion: notification.toolkit.fluxcd.io/v1beta2
 kind: Provider
 metadata:
   name: slack
@@ -7,5 +7,6 @@ metadata:
 spec:
   address: https://hooks.slack.com/services/mock
   channel: A channel with spacess
+  interval: 10m0s
   type: slack
 

--- a/cmd/flux/testdata/export/receiver.yaml
+++ b/cmd/flux/testdata/export/receiver.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: notification.toolkit.fluxcd.io/v1beta1
+apiVersion: notification.toolkit.fluxcd.io/v1beta2
 kind: Receiver
 metadata:
   name: flux-system
@@ -8,6 +8,7 @@ spec:
   events:
   - ping
   - push
+  interval: 10m0s
   resources:
   - kind: GitRepository
     name: flux-system

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -45,7 +45,7 @@ import (
 	imageautov1 "github.com/fluxcd/image-automation-controller/api/v1beta1"
 	imagereflectv1 "github.com/fluxcd/image-reflector-controller/api/v1beta1"
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
-	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta1"
+	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta2"
 	"github.com/fluxcd/pkg/apis/meta"
 	runclient "github.com/fluxcd/pkg/runtime/client"
 	"github.com/fluxcd/pkg/version"

--- a/pkg/uninstall/uninstall.go
+++ b/pkg/uninstall/uninstall.go
@@ -34,7 +34,7 @@ import (
 	autov1 "github.com/fluxcd/image-automation-controller/api/v1beta1"
 	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1beta1"
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
-	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta1"
+	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
 )
 

--- a/rfcs/0001-authorization/README.md
+++ b/rfcs/0001-authorization/README.md
@@ -109,8 +109,8 @@ fields that are not restricted to the namespace of the containing object, listed
 |                                                | `.spec.targetNamespace` | This gives the namespace into which a Helm chart is installed (note: using impersonation) |
 |                                                | `.spec.storageNamespace` | This gives the namespace in which the record of a Helm install is created (note: using impersonation) |
 |                                                | `.spec.chart.spec.sourceRef` | This is a reference (in the created `HelmChart` object) that can include a namespace |
-| **`alerts.notification.toolkit.fluxcd.io/v1beta1`** | `.spec.eventSources` | Items are references that can include a namespace |
-| **`receivers.notification.toolkit.fluxcd.io/v1beta1`** | `.spec.resources` | Items in this field are references that can include a namespace |
+| **`alerts.notification.toolkit.fluxcd.io/v1beta2`** | `.spec.eventSources` | Items are references that can include a namespace |
+| **`receivers.notification.toolkit.fluxcd.io/v1beta2`** | `.spec.resources` | Items in this field are references that can include a namespace |
 | **`imagepolicies.image.toolkit.fluxcd.io/v1beta1`** | `.spec.imageRepositoryRef` | This reference can include a namespace[1] |
 
 [1] This particular cross-namespace reference is subject to additional access control; see "Access

--- a/tests/azure/azure_test.go
+++ b/tests/azure/azure_test.go
@@ -52,7 +52,7 @@ import (
 	automationv1beta1 "github.com/fluxcd/image-automation-controller/api/v1beta1"
 	reflectorv1beta1 "github.com/fluxcd/image-reflector-controller/api/v1beta1"
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
-	notiv1beta1 "github.com/fluxcd/notification-controller/api/v1beta1"
+	notiv1beta1 "github.com/fluxcd/notification-controller/api/v1beta2"
 	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
 	"github.com/fluxcd/pkg/apis/meta"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"

--- a/tests/azure/go.mod
+++ b/tests/azure/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/fluxcd/image-automation-controller/api v0.28.0
 	github.com/fluxcd/image-reflector-controller/api v0.23.1
 	github.com/fluxcd/kustomize-controller/api v0.32.0
-	github.com/fluxcd/notification-controller/api v0.30.0
+	github.com/fluxcd/notification-controller/api v0.30.1
 	github.com/fluxcd/pkg/apis/event v0.2.0
 	github.com/fluxcd/pkg/apis/meta v0.18.0
 	github.com/fluxcd/pkg/git v0.7.0

--- a/tests/azure/go.sum
+++ b/tests/azure/go.sum
@@ -136,8 +136,8 @@ github.com/fluxcd/image-reflector-controller/api v0.23.1 h1:ysYzSDhFV5JPzrhTnyab
 github.com/fluxcd/image-reflector-controller/api v0.23.1/go.mod h1:uomyKK0ZWFOsG40wqmCJvIN8OpAiPKFteXe+cdhB/Z0=
 github.com/fluxcd/kustomize-controller/api v0.32.0 h1:5QGLV5xRI8S3tUFJNV+vVzy/pdl0d6Ua0AccWwGRKfs=
 github.com/fluxcd/kustomize-controller/api v0.32.0/go.mod h1:t2pqIe1SMzdZIAG/aietrg3XpRXmpcubf0uxDJOryEA=
-github.com/fluxcd/notification-controller/api v0.30.0 h1:m8wEBtPFcO9ZMSO0NLuONhIKDsiPFJ4ys3JYs4jlvCE=
-github.com/fluxcd/notification-controller/api v0.30.0/go.mod h1:Ve4SE6jeiGlyItvHa7/UpTPOVC6ac5K76Frv1P7hqLw=
+github.com/fluxcd/notification-controller/api v0.30.1 h1:7523fRatqKJPeZcJsR7D0PW/h5ND/DeNgHLzEfOFmA0=
+github.com/fluxcd/notification-controller/api v0.30.1/go.mod h1:Ve4SE6jeiGlyItvHa7/UpTPOVC6ac5K76Frv1P7hqLw=
 github.com/fluxcd/pkg/apis/acl v0.1.0 h1:EoAl377hDQYL3WqanWCdifauXqXbMyFuK82NnX6pH4Q=
 github.com/fluxcd/pkg/apis/acl v0.1.0/go.mod h1:zfEZzz169Oap034EsDhmCAGgnWlcWmIObZjYMusoXS8=
 github.com/fluxcd/pkg/apis/event v0.2.0 h1:cmAtkZfoEaNVYegI4SFM8XstdRAil3O9AoP+8fpbR34=

--- a/tests/azure/util_test.go
+++ b/tests/azure/util_test.go
@@ -44,7 +44,7 @@ import (
 	automationv1beta1 "github.com/fluxcd/image-automation-controller/api/v1beta1"
 	reflectorv1beta1 "github.com/fluxcd/image-reflector-controller/api/v1beta1"
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
-	notiv1beta1 "github.com/fluxcd/notification-controller/api/v1beta1"
+	notiv1beta1 "github.com/fluxcd/notification-controller/api/v1beta2"
 	"github.com/fluxcd/pkg/apis/meta"
 	"github.com/fluxcd/pkg/git"
 	"github.com/fluxcd/pkg/git/gogit"


### PR DESCRIPTION
Update the Notification API version so that the Flux CLI can work with v1beta2.