### PR TITLE
check: Show the latest stored version of CRDs

### DIFF
--- a/cmd/flux/check.go
+++ b/cmd/flux/check.go
@@ -242,8 +242,9 @@ func crdsCheck() bool {
 		}
 
 		for _, crd := range list.Items {
-			if len(crd.Status.StoredVersions) > 0 {
-				logger.Successf(crd.Name + "/" + crd.Status.StoredVersions[0])
+			versions := crd.Status.StoredVersions
+			if len(versions) > 0 {
+				logger.Successf(crd.Name + "/" + versions[len(versions)-1])
 			} else {
 				ok = false
 				logger.Failuref("no stored versions for %s", crd.Name)


### PR DESCRIPTION
After a CRD version upgrade, Kubernetes keeps the old version in the `crd.Status.StoredVersions` so we need to display the last entry in the array otherwise the `flux check` command confuses users by showing the oldest version.

Ref: https://github.com/fluxcd/notification-controller/pull/455#issuecomment-1363667686