### PR TITLE
Improvements to Flux GitHub Action

### DIFF
--- a/action/README.md
+++ b/action/README.md
@@ -35,6 +35,18 @@ You can download a specific version with:
           version: 0.32.0
 ```
 
+You can also authentication to the GitHub API using a secret
+
+```yaml
+    steps:
+      - name: Setup Flux CLI
+        uses: fluxcd/flux2/action@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+This is useful if you are seeing failures on shared runners, those failures are usually API limits being hit.
+
 ### Automate Flux updates
 
 Example workflow for updating Flux's components generated with `flux bootstrap --path=clusters/production`:

--- a/action/README.md
+++ b/action/README.md
@@ -35,7 +35,7 @@ You can download a specific version with:
           version: 0.32.0
 ```
 
-You can also authentication to the GitHub API using a secret
+You can also authentication to the GitHub API using GitHub Action's `GITHUB_TOKEN`. For more information on this secrets, please see [about the github token secret](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret)
 
 ```yaml
     steps:

--- a/action/README.md
+++ b/action/README.md
@@ -62,7 +62,7 @@ jobs:
             --export > ./clusters/production/flux-system/gotk-components.yaml
 
           VERSION="$(flux -v)"
-          echo "::set-output name=flux_version::$VERSION"
+          echo "flux_version=$VERSION" >> $GITHUB_OUTPUT
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:

--- a/action/README.md
+++ b/action/README.md
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Flux CLI
         uses: fluxcd/flux2/action@main
       - name: Check for updates
@@ -76,7 +76,7 @@ jobs:
           VERSION="$(flux -v)"
           echo "flux_version=$VERSION" >> $GITHUB_OUTPUT
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         with:
             token: ${{ secrets.GITHUB_TOKEN }}
             branch: update-flux
@@ -189,7 +189,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Flux CLI
         uses: fluxcd/flux2/action@main
       - name: Setup Kubernetes Kind

--- a/action/action.yml
+++ b/action/action.yml
@@ -15,6 +15,9 @@ inputs:
   bindir:
     description: "Optional location of the Flux binary. Will not use sudo if set. Updates System Path."
     required: false
+  token:
+    description: "GitHub Token used to authentication against the API (generally only needed to prevent quota limit errors)"
+    required: false
 runs:
   using: composite
   steps:
@@ -23,9 +26,14 @@ runs:
       run: |
         ARCH=${{ inputs.arch }}
         VERSION=${{ inputs.version }}
+        TOKEN=${{ inputs.token }}
+
+        if [ -n $TOKEN ]; then
+          TOKEN=(-H "Authorization: token $TOKEN")
+        fi
 
         if [ -z $VERSION ]; then
-          VERSION=$(curl https://api.github.com/repos/fluxcd/flux2/releases/latest -sL | grep tag_name | sed -E 's/.*"([^"]+)".*/\1/' | cut -c 2-)
+          VERSION=$(curl https://api.github.com/repos/fluxcd/flux2/releases/latest -sL "${TOKEN[@]}" | grep tag_name | sed -E 's/.*"([^"]+)".*/\1/' | cut -c 2-)
         fi
 
         BIN_URL="https://github.com/fluxcd/flux2/releases/download/v${VERSION}/flux_${VERSION}_linux_${ARCH}.tar.gz"


### PR DESCRIPTION
## Overview

- Adds auth to curl command for GitHub API (optional)
- Adds example for token passing to documentation
- Updates documentation to not use `set-output` as it has been deprecated.

## Background

I've been witnessing more and more failed flux update action runs and several other workflows I have that make calls to `api.github.com` as best as I have been able to determine while debugging is that due to the workflows running on shared runners, and either an uptick in API calls or a change in the GitHub API backend on API interactions from workers, anonymous API limits are being hit more frequently which results in a 403 and failed `curl` command run.

The fix for me has been to pass a token through using the default `${{ secrets.GITHUB_TOKEN }}` to the curl command such that the API calls  are authenticated, this token gets it's own set of limits.

Fix: https://github.com/fluxcd/flux2/issues/3455