### PR TITLE
fix(install-script): support $GITHUB_TOKEN

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -9,6 +9,10 @@ To install the latest release run:
 curl -s https://raw.githubusercontent.com/fluxcd/flux2/main/install/flux.sh | sudo bash
 ```
 
+**Note**: You may export an env `GITHUB_TOKEN` which is a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+to avoid running into Github API rate limiting while executing the install script.
+This is recommended if you execute the install script multiple times within the same rate limting window.
+
 The install script does the following:
 * attempts to detect your OS
 * downloads and unpacks the release tar file in a temporary directory

--- a/install/README.md
+++ b/install/README.md
@@ -9,9 +9,8 @@ To install the latest release run:
 curl -s https://raw.githubusercontent.com/fluxcd/flux2/main/install/flux.sh | sudo bash
 ```
 
-**Note**: You may export an env `GITHUB_TOKEN` which is a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
-to avoid running into Github API rate limiting while executing the install script.
-This is recommended if you execute the install script multiple times within the same rate limting window.
+**Note**: You may want to export the `GITHUB_TOKEN` environment variable using a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+to avoid GitHub API rate-limiting errors if executing the install script repeatedly during a short time frame.
 
 The install script does the following:
 * attempts to detect your OS

--- a/install/flux.sh
+++ b/install/flux.sh
@@ -112,10 +112,10 @@ download() {
 
     case $DOWNLOADER in
         curl)
-            curl -o "$1" -sfL "$2"
+            curl -u user:$GITHUB_TOKEN -o "$1" -sfL "$2"
             ;;
         wget)
-            wget -qO "$1" "$2"
+            wget --auth-no-challenge --user=user --password=$GITHUB_TOKEN -qO "$1" "$2"
             ;;
         *)
             fatal "Incorrect executable '${DOWNLOADER}'"


### PR DESCRIPTION
I use the install script in our ci pipeline which happen to be executed quite frequently. 
We started to run into gh ratelimiting because of this script.

```
Run curl -s https://raw.githubusercontent.com/fluxcd/flux2/main/install/flux.sh | sudo bash
[INFO]  Downloading metadata https://api.github.com/repos/fluxcd/flux2/releases/latest
Error: Process completed with exit code 22.
```

This fix adds support for $GITHUB_TOKEN. If its not set it would just be an anonymous request as it was before.