### PR TITLE
Add GITHUB_TOKEN  to Flux GitHub Action

### DIFF
--- a/action/README.md
+++ b/action/README.md
@@ -35,6 +35,20 @@ You can download a specific version with:
           version: 0.32.0
 ```
 
+You can also authenticate against the GitHub API using GitHub Actions' `GITHUB_TOKEN` secret.
+
+For more information, please [read about the GitHub token secret](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret).
+
+```yaml
+    steps:
+      - name: Setup Flux CLI
+        uses: fluxcd/flux2/action@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+This is useful if you are seeing failures on shared runners, those failures are usually API limits being hit.
+
 ### Automate Flux updates
 
 Example workflow for updating Flux's components generated with `flux bootstrap --path=clusters/production`:
@@ -52,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Flux CLI
         uses: fluxcd/flux2/action@main
       - name: Check for updates
@@ -62,9 +76,9 @@ jobs:
             --export > ./clusters/production/flux-system/gotk-components.yaml
 
           VERSION="$(flux -v)"
-          echo "::set-output name=flux_version::$VERSION"
+          echo "flux_version=$VERSION" >> $GITHUB_OUTPUT
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         with:
             token: ${{ secrets.GITHUB_TOKEN }}
             branch: update-flux
@@ -177,7 +191,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Flux CLI
         uses: fluxcd/flux2/action@main
       - name: Setup Kubernetes Kind

--- a/action/action.yml
+++ b/action/action.yml
@@ -15,6 +15,9 @@ inputs:
   bindir:
     description: "Optional location of the Flux binary. Will not use sudo if set. Updates System Path."
     required: false
+  token:
+    description: "GitHub Token used to authentication against the API (generally only needed to prevent quota limit errors)"
+    required: false
 runs:
   using: composite
   steps:
@@ -23,9 +26,14 @@ runs:
       run: |
         ARCH=${{ inputs.arch }}
         VERSION=${{ inputs.version }}
+        TOKEN=${{ inputs.token }}
+
+        if [ -n $TOKEN ]; then
+          TOKEN=(-H "Authorization: token $TOKEN")
+        fi
 
         if [ -z $VERSION ]; then
-          VERSION=$(curl https://api.github.com/repos/fluxcd/flux2/releases/latest -sL | grep tag_name | sed -E 's/.*"([^"]+)".*/\1/' | cut -c 2-)
+          VERSION=$(curl https://api.github.com/repos/fluxcd/flux2/releases/latest -sL "${TOKEN[@]}" | grep tag_name | sed -E 's/.*"([^"]+)".*/\1/' | cut -c 2-)
         fi
 
         BIN_URL="https://github.com/fluxcd/flux2/releases/download/v${VERSION}/flux_${VERSION}_linux_${ARCH}.tar.gz"


### PR DESCRIPTION
Hello, the PR in #3474 is still blocked

I'm going to rebase and squash, but here's a reference to the original commit I made which adds just one change to the existing PR is:

* fac19820
to make the review easier, you might want to check that one first.

* c7a48769
* is 15385220 rebased against the current main branch without any other changes

I noticed that this doesn't only affect flux update job which runs hourly, but can even impact GitHub actions jobs that embed the "install flux" action inline!

Trying to get this unblocked, I've added the one suggestion from https://github.com/fluxcd/flux2/pull/3474#discussion_r1067178730 rebased and resubmitted this PR so that it can merge.

I'm going to go ahead and pre-emptively squash all the commits, as well, to simplify the merge.

Fix: https://github.com/fluxcd/flux2/issues/3455