### PR TITLE
Update prometheus-community helm repo due to the suspension of OCI builds

### DIFF
--- a/manifests/monitoring/kube-prometheus-stack/release.yaml
+++ b/manifests/monitoring/kube-prometheus-stack/release.yaml
@@ -11,8 +11,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: prometheus-community
-      verify:
-        provider: cosign
       interval: 60m
   install:
     crds: Create

--- a/manifests/monitoring/kube-prometheus-stack/repository.yaml
+++ b/manifests/monitoring/kube-prometheus-stack/repository.yaml
@@ -4,5 +4,6 @@ metadata:
   name: prometheus-community
 spec:
   interval: 120m
-  type: oci
-  url: oci://ghcr.io/prometheus-community/charts
+  # OCI builds for kube-prometheus-stack have been temporarily disabled (see https://github.com/prometheus-community/helm-charts/issues/2940).
+  type: default
+  url: https://prometheus-community.github.io/helm-charts


### PR DESCRIPTION
### Proposed changes

This PR updates the `HelmRepository` to use the official non-OCI repository. We also disable chart verification for the "kube-prometheus-stack" `HelmChart` since it requires an OCI repository.

###  Reasoning

The "prometheus-community" developers have disabled OCI builds for now (see https://github.com/prometheus-community/helm-charts/pull/2841).