### PR TITLE
Fix fluxcd/flux2/action (finally)

### DIFF
--- a/action/action.yml
+++ b/action/action.yml
@@ -33,7 +33,7 @@ runs:
         fi
 
         if [ -z "${VERSION}" ]; then
-          VERSION=$(curl https://api.github.com/repos/fluxcd/flux2/releases/latest -sL "${TOKEN[@]}" | grep tag_name | sed -E 's/.*"([^"]+)".*/\1/' | cut -c 2-)
+          VERSION=$(curl https://api.github.com/repos/fluxcd/flux2/releases/latest -sL ${TOKEN[@]} | grep tag_name | sed -E 's/.*"([^"]+)".*/\1/' | cut -c 2-)
         fi
 
         BIN_URL="https://github.com/fluxcd/flux2/releases/download/v${VERSION}/flux_${VERSION}_linux_${ARCH}.tar.gz"


### PR DESCRIPTION
Fix #3509 

I have a tester pointed at my local version to be extra sure, sorry there is one more error in that script which we did not see because we were not expecting the context as `set -e` (which I guess all github runners are, and that makes sense.)

Adding quotes here in the original version of this script, when the `TOKEN` variable is empty you get:

```
curl https://api.github.com/repos/fluxcd/flux2/releases/latest -sL ''
```

(ref:
https://github.com/kingdonb/bootstrap-repo/actions/runs/3991169408/jobs/6845685491#step:3:31 )

That does curl twice, once for the URL provided and again for the empty string, which results in curl returning error code 3 "malformed URL" which results in the script aborting, again whenever the user fails to provide a `token`.

The script should mostly work with occasional rate limiting only when the token isn't present. See #3509 for more details.