### PR TITLE
Fix GitHub Action

### DIFF
--- a/action/action.yml
+++ b/action/action.yml
@@ -36,9 +36,8 @@ runs:
             # Ref: https://github.com/fluxcd/flux2/issues/3509#issuecomment-1400820992
             VERSION_SLUG=$(curl https://api.github.com/repos/fluxcd/flux2/releases/latest --silent --location | grep tag_name)
           fi
+          VERSION=$(echo "${VERSION_SLUG}" | sed -E 's/.*"([^"]+)".*/\1/' | cut -c 2-)
         fi
-
-        VERSION=$(echo "${VERSION_SLUG}" | sed -E 's/.*"([^"]+)".*/\1/' | cut -c 2-)
 
         BIN_URL="https://github.com/fluxcd/flux2/releases/download/v${VERSION}/flux_${VERSION}_linux_${ARCH}.tar.gz"
         curl --silent --fail --location "${BIN_URL}" --output /tmp/flux.tar.gz


### PR DESCRIPTION
There is one more issue, I had not tested with the `version:` parameter, and there is a logic inversion.

If `VERSION` is passed in, then we should not overwrite it.