### PR TITLE
fix misleading messaging when using `-A` flag

### DIFF
--- a/cmd/flux/get.go
+++ b/cmd/flux/get.go
@@ -163,9 +163,16 @@ func (get getCommand) run(cmd *cobra.Command, args []string) error {
 
 	if get.list.len() == 0 {
 		if len(args) > 0 {
-			logger.Failuref("%s object '%s' not found in '%s' namespace", get.kind, args[0], *kubeconfigArgs.Namespace)
+			logger.Failuref("%s object '%s' not found in %s namespace",
+				get.kind,
+				args[0],
+				namespaceNameOrAny(getArgs.allNamespaces, *kubeconfigArgs.Namespace),
+			)
 		} else if !getAll {
-			logger.Failuref("no %s objects found in %s namespace", get.kind, *kubeconfigArgs.Namespace)
+			logger.Failuref("no %s objects found in %s namespace",
+				get.kind,
+				namespaceNameOrAny(getArgs.allNamespaces, *kubeconfigArgs.Namespace),
+			)
 		}
 		return nil
 	}
@@ -190,6 +197,13 @@ func (get getCommand) run(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func namespaceNameOrAny(allNamespaces bool, namespaceName string) string {
+	if allNamespaces {
+		return "any"
+	}
+	return fmt.Sprintf("%q", namespaceName)
 }
 
 func getRowsToPrint(getAll bool, list summarisable) ([][]string, error) {


### PR DESCRIPTION
Before:

```
$ flux get source git -A
✗ no GitRepository objects found in flux-system namespace
```

After:

```
$ flux get source git -A
✗ no GitRepository objects found in any namespace
```

closes #3530 