### PR TITLE
Update Alpine to v3.17 and kubectl to v1.26.1 in flux-cli image

### DIFF
--- a/.github/workflows/e2e-bootstrap.yaml
+++ b/.github/workflows/e2e-bootstrap.yaml
@@ -29,10 +29,11 @@ jobs:
         with:
           go-version: 1.19.x
       - name: Setup Kubernetes
-        uses: engineerd/setup-kind@aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0 # v0.5.0
+        uses: helm/kind-action@d8ccf8fb623ce1bb360ae2f45f323d9d5c5e9f00 # v1.5.0
         with:
-          version: v0.16.0
-          image: kindest/node:v1.25.2@sha256:9be91e9e9cdf116809841fc77ebdb8845443c4c72fe5218f3ae9eb57fdb4bace
+          version: v0.17.0
+          cluster_name: kind
+          node_image: kindest/node:v1.25.2
       - name: Setup Kustomize
         uses: fluxcd/pkg//actions/kustomize@main
       - name: Build

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -33,11 +33,12 @@ jobs:
         with:
           go-version: 1.19.x
       - name: Setup Kubernetes
-        uses: engineerd/setup-kind@aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0 # v0.5.0
+        uses: helm/kind-action@d8ccf8fb623ce1bb360ae2f45f323d9d5c5e9f00 # v1.5.0
         with:
-          version: v0.11.1
-          image: kindest/node:v1.23.13
+          version: v0.17.0
+          cluster_name: kind
           config: .github/kind/config.yaml # disable KIND-net
+          node_image: kindest/node:v1.23.13
       - name: Setup Calico for network policy
         run: |
           kubectl apply -f https://docs.projectcalico.org/v3.20/manifests/calico.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM alpine:3.16 as builder
+FROM alpine:3.17 as builder
 
 RUN apk add --no-cache ca-certificates curl
 
 ARG ARCH=linux/amd64
-ARG KUBECTL_VER=1.25.4
+ARG KUBECTL_VER=1.26.1
 
 RUN curl -sL https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VER}/bin/${ARCH}/kubectl \
     -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl && \
     kubectl version --client=true
 
-FROM alpine:3.16 as flux-cli
+FROM alpine:3.17 as flux-cli
 
 RUN apk add --no-cache ca-certificates
 


### PR DESCRIPTION
This PR updates Alpine and kubectl in the flux-cli Dockefile. In addition it replaces the `engineerd/setup-kind` GH Action with `helm/kind-action` in CI, ref: https://github.com/fluxcd/flux2/issues/3399.