### PR TITLE
docs: Add permissions to update workflow

### DIFF
--- a/action/README.md
+++ b/action/README.md
@@ -61,6 +61,10 @@ on:
   schedule:
     - cron: "0 * * * *"
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   components:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The default of `GITHUB_TOKEN` permissions [has changed to read-only](https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/), for Flux to update itself the GitHub workflow must now explicitly set write permissions.