### PR TITLE
rbac: Add view and edit aggregated cluster roles

### DIFF
--- a/manifests/bases/helm-controller/kustomization.yaml
+++ b/manifests/bases/helm-controller/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
 - account.yaml
 transformers:
 - labels.yaml
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/manifests/bases/image-automation-controller/kustomization.yaml
+++ b/manifests/bases/image-automation-controller/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
 - account.yaml
 transformers:
 - labels.yaml
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/manifests/bases/image-reflector-controller/kustomization.yaml
+++ b/manifests/bases/image-reflector-controller/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
 - account.yaml
 transformers:
 - labels.yaml
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/manifests/bases/kustomize-controller/kustomization.yaml
+++ b/manifests/bases/kustomize-controller/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
 - account.yaml
 transformers:
 - labels.yaml
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/manifests/bases/notification-controller/kustomization.yaml
+++ b/manifests/bases/notification-controller/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
 - account.yaml
 transformers:
 - labels.yaml
-patchesJson6902:
+patches:
   - target:
       group: apps
       version: v1

--- a/manifests/bases/source-controller/kustomization.yaml
+++ b/manifests/bases/source-controller/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
 - account.yaml
 transformers:
 - labels.yaml
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/manifests/rbac/edit.yaml
+++ b/manifests/rbac/edit.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: flux-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups:
+      - notification.toolkit.fluxcd.io
+      - source.toolkit.fluxcd.io
+      - helm.toolkit.fluxcd.io
+      - image.toolkit.fluxcd.io
+      - kustomize.toolkit.fluxcd.io
+    resources: ["*"]
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update

--- a/manifests/rbac/kustomization.yaml
+++ b/manifests/rbac/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 resources:
   - controller.yaml
   - reconciler.yaml
+  - edit.yaml
+  - view.yaml

--- a/manifests/rbac/view.yaml
+++ b/manifests/rbac/view.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: flux-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+  - apiGroups:
+      - notification.toolkit.fluxcd.io
+      - source.toolkit.fluxcd.io
+      - helm.toolkit.fluxcd.io
+      - image.toolkit.fluxcd.io
+      - kustomize.toolkit.fluxcd.io
+    resources: ["*"]
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
This PR adds two cluster roles which grant the Kubernetes `view`, `edit` and `admin` roles access to Flux custom resources. 

Fix: https://github.com/fluxcd/flux2/issues/2409
Fix: #3572
Ref: https://github.com/fluxcd/kustomize-controller/issues/762