### PR TITLE
tests: only provide template values when used

### DIFF
--- a/cmd/flux/build_artifact_test.go
+++ b/cmd/flux/build_artifact_test.go
@@ -54,7 +54,7 @@ data:
 			tmpFile, err := saveReaderToFile(strings.NewReader(tt.string))
 			g.Expect(err).To(BeNil())
 
-			defer os.Remove(tmpFile)
+			t.Cleanup(func() { _ = os.Remove(tmpFile) })
 
 			b, err := os.ReadFile(tmpFile)
 			if tt.expectErr {

--- a/cmd/flux/build_kustomization_test.go
+++ b/cmd/flux/build_kustomization_test.go
@@ -171,8 +171,7 @@ spec:
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	defer os.Remove("./testdata/build-kustomization/podinfo.yaml")
+	t.Cleanup(func() { _ = os.Remove("./testdata/build-kustomization/podinfo.yaml") })
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/flux/diff_kustomization_test.go
+++ b/cmd/flux/diff_kustomization_test.go
@@ -109,7 +109,9 @@ func TestDiffKustomization(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.objectFile != "" {
-				resourceManager.ApplyAll(context.Background(), createObjectFromFile(tt.objectFile, tmpl, t), ssa.DefaultApplyOptions())
+				if _, err := resourceManager.ApplyAll(context.Background(), createObjectFromFile(tt.objectFile, tmpl, t), ssa.DefaultApplyOptions()); err != nil {
+					t.Error(err)
+				}
 			}
 			cmd := cmdTestCase{
 				args:   tt.args + " -n " + tmpl["fluxns"],

--- a/cmd/flux/export_test.go
+++ b/cmd/flux/export_test.go
@@ -8,78 +8,92 @@ import (
 )
 
 func TestExport(t *testing.T) {
+	namespace := allocateNamespace("flux-system")
+
+	objectFile := "testdata/export/objects.yaml"
+	tmpl := map[string]string{
+		"fluxns": namespace,
+	}
+	testEnv.CreateObjectFile(objectFile, tmpl, t)
+
 	cases := []struct {
 		name       string
 		arg        string
 		goldenFile string
+		tmpl       map[string]string
 	}{
 		{
 			"alert-provider",
 			"export alert-provider slack",
 			"testdata/export/provider.yaml",
+			tmpl,
 		},
 		{
 			"alert",
 			"export alert flux-system",
 			"testdata/export/alert.yaml",
+			tmpl,
 		},
 		{
 			"image policy",
 			"export image policy flux-system",
 			"testdata/export/image-policy.yaml",
+			tmpl,
 		},
 		{
 			"image repository",
 			"export image repository flux-system",
 			"testdata/export/image-repo.yaml",
+			tmpl,
 		},
 		{
 			"image update",
 			"export image update flux-system",
 			"testdata/export/image-update.yaml",
+			tmpl,
 		},
 		{
 			"source git",
 			"export source git flux-system",
 			"testdata/export/git-repo.yaml",
+			tmpl,
 		},
 		{
 			"source helm",
 			"export source helm flux-system",
 			"testdata/export/helm-repo.yaml",
+			tmpl,
 		},
 		{
 			"receiver",
 			"export receiver flux-system",
 			"testdata/export/receiver.yaml",
+			tmpl,
 		},
 		{
 			"kustomization",
 			"export kustomization flux-system",
 			"testdata/export/ks.yaml",
+			tmpl,
 		},
 		{
 			"helmrelease",
 			"export helmrelease flux-system",
 			"testdata/export/helm-release.yaml",
+			tmpl,
 		},
 		{
 			"bucket",
 			"export source bucket flux-system",
 			"testdata/export/bucket.yaml",
+			tmpl,
 		},
 	}
-
-	objectFile := "testdata/export/objects.yaml"
-	tmpl := map[string]string{
-		"fluxns": allocateNamespace("flux-system"),
-	}
-	testEnv.CreateObjectFile(objectFile, tmpl, t)
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			cmd := cmdTestCase{
-				args:   tt.arg + " -n=" + tmpl["fluxns"],
+				args:   tt.arg + " -n=" + namespace,
 				assert: assertGoldenTemplateFile(tt.goldenFile, tmpl),
 			}
 

--- a/cmd/flux/helmrelease_test.go
+++ b/cmd/flux/helmrelease_test.go
@@ -23,7 +23,7 @@ import "testing"
 
 func TestHelmReleaseFromGit(t *testing.T) {
 	namespace := allocateNamespace("thrfg")
-	del, err := setupTestNamespace(namespace)
+	del, err := execSetupTestNamespace(namespace)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/flux/helmrelease_test.go
+++ b/cmd/flux/helmrelease_test.go
@@ -22,51 +22,61 @@ package main
 import "testing"
 
 func TestHelmReleaseFromGit(t *testing.T) {
-	cases := []struct {
-		args       string
-		goldenFile string
-	}{
-		{
-			"create source git thrfg --url=https://github.com/stefanprodan/podinfo --branch=main --tag=6.0.0",
-			"testdata/helmrelease/create_source_git.golden",
-		},
-		{
-			"create helmrelease thrfg --source=GitRepository/thrfg --chart=./charts/podinfo",
-			"testdata/helmrelease/create_helmrelease_from_git.golden",
-		},
-		{
-			"get helmrelease thrfg",
-			"testdata/helmrelease/get_helmrelease_from_git.golden",
-		},
-		{
-			"reconcile helmrelease thrfg --with-source",
-			"testdata/helmrelease/reconcile_helmrelease_from_git.golden",
-		},
-		{
-			"suspend helmrelease thrfg",
-			"testdata/helmrelease/suspend_helmrelease_from_git.golden",
-		},
-		{
-			"resume helmrelease thrfg",
-			"testdata/helmrelease/resume_helmrelease_from_git.golden",
-		},
-		{
-			"delete helmrelease thrfg --silent",
-			"testdata/helmrelease/delete_helmrelease_from_git.golden",
-		},
-	}
-
 	namespace := allocateNamespace("thrfg")
 	del, err := setupTestNamespace(namespace)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer del()
+	t.Cleanup(del)
+
+	tmpl := map[string]string{"ns": namespace}
+
+	cases := []struct {
+		args       string
+		goldenFile string
+		tmpl       map[string]string
+	}{
+		{
+			"create source git thrfg --url=https://github.com/stefanprodan/podinfo --branch=main --tag=6.0.0",
+			"testdata/helmrelease/create_source_git.golden",
+			nil,
+		},
+		{
+			"create helmrelease thrfg --source=GitRepository/thrfg --chart=./charts/podinfo",
+			"testdata/helmrelease/create_helmrelease_from_git.golden",
+			nil,
+		},
+		{
+			"get helmrelease thrfg",
+			"testdata/helmrelease/get_helmrelease_from_git.golden",
+			nil,
+		},
+		{
+			"reconcile helmrelease thrfg --with-source",
+			"testdata/helmrelease/reconcile_helmrelease_from_git.golden",
+			tmpl,
+		},
+		{
+			"suspend helmrelease thrfg",
+			"testdata/helmrelease/suspend_helmrelease_from_git.golden",
+			tmpl,
+		},
+		{
+			"resume helmrelease thrfg",
+			"testdata/helmrelease/resume_helmrelease_from_git.golden",
+			tmpl,
+		},
+		{
+			"delete helmrelease thrfg --silent",
+			"testdata/helmrelease/delete_helmrelease_from_git.golden",
+			tmpl,
+		},
+	}
 
 	for _, tc := range cases {
 		cmd := cmdTestCase{
 			args:   tc.args + " -n=" + namespace,
-			assert: assertGoldenTemplateFile(tc.goldenFile, map[string]string{"ns": namespace}),
+			assert: assertGoldenTemplateFile(tc.goldenFile, tc.tmpl),
 		}
 		cmd.runTestCmd(t)
 	}

--- a/cmd/flux/image_test.go
+++ b/cmd/flux/image_test.go
@@ -22,6 +22,13 @@ package main
 import "testing"
 
 func TestImageScanning(t *testing.T) {
+	namespace := allocateNamespace("tis")
+	del, err := setupTestNamespace(namespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(del)
+
 	cases := []struct {
 		args       string
 		goldenFile string
@@ -47,13 +54,6 @@ func TestImageScanning(t *testing.T) {
 			"testdata/image/get_image_policy_regex.golden",
 		},
 	}
-
-	namespace := allocateNamespace("tis")
-	del, err := setupTestNamespace(namespace)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer del()
 
 	for _, tc := range cases {
 		cmd := cmdTestCase{

--- a/cmd/flux/image_test.go
+++ b/cmd/flux/image_test.go
@@ -23,7 +23,7 @@ import "testing"
 
 func TestImageScanning(t *testing.T) {
 	namespace := allocateNamespace("tis")
-	del, err := setupTestNamespace(namespace)
+	del, err := execSetupTestNamespace(namespace)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/flux/install_test.go
+++ b/cmd/flux/install_test.go
@@ -25,9 +25,7 @@ func TestInstall(t *testing.T) {
 	// Given that this test uses an invalid namespace, it ensures
 	// to restore whatever value it had previously.
 	currentNamespace := *kubeconfigArgs.Namespace
-	defer func() {
-		*kubeconfigArgs.Namespace = currentNamespace
-	}()
+	t.Cleanup(func() { *kubeconfigArgs.Namespace = currentNamespace })
 
 	tests := []struct {
 		name   string

--- a/cmd/flux/kustomization_test.go
+++ b/cmd/flux/kustomization_test.go
@@ -22,51 +22,61 @@ package main
 import "testing"
 
 func TestKustomizationFromGit(t *testing.T) {
-	cases := []struct {
-		args       string
-		goldenFile string
-	}{
-		{
-			"create source git tkfg --url=https://github.com/stefanprodan/podinfo --branch=main --tag=6.0.0",
-			"testdata/kustomization/create_source_git.golden",
-		},
-		{
-			"create kustomization tkfg --source=tkfg --path=./deploy/overlays/dev --prune=true --interval=5m --health-check=Deployment/frontend.dev --health-check=Deployment/backend.dev --health-check-timeout=3m",
-			"testdata/kustomization/create_kustomization_from_git.golden",
-		},
-		{
-			"get kustomization tkfg",
-			"testdata/kustomization/get_kustomization_from_git.golden",
-		},
-		{
-			"reconcile kustomization tkfg --with-source",
-			"testdata/kustomization/reconcile_kustomization_from_git.golden",
-		},
-		{
-			"suspend kustomization tkfg",
-			"testdata/kustomization/suspend_kustomization_from_git.golden",
-		},
-		{
-			"resume kustomization tkfg",
-			"testdata/kustomization/resume_kustomization_from_git.golden",
-		},
-		{
-			"delete kustomization tkfg --silent",
-			"testdata/kustomization/delete_kustomization_from_git.golden",
-		},
-	}
-
 	namespace := allocateNamespace("tkfg")
 	del, err := setupTestNamespace(namespace)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer del()
+	t.Cleanup(del)
+
+	tmpl := map[string]string{"ns": namespace}
+
+	cases := []struct {
+		args       string
+		goldenFile string
+		tmpl       map[string]string
+	}{
+		{
+			"create source git tkfg --url=https://github.com/stefanprodan/podinfo --branch=main --tag=6.0.0",
+			"testdata/kustomization/create_source_git.golden",
+			nil,
+		},
+		{
+			"create kustomization tkfg --source=tkfg --path=./deploy/overlays/dev --prune=true --interval=5m --health-check=Deployment/frontend.dev --health-check=Deployment/backend.dev --health-check-timeout=3m",
+			"testdata/kustomization/create_kustomization_from_git.golden",
+			nil,
+		},
+		{
+			"get kustomization tkfg",
+			"testdata/kustomization/get_kustomization_from_git.golden",
+			nil,
+		},
+		{
+			"reconcile kustomization tkfg --with-source",
+			"testdata/kustomization/reconcile_kustomization_from_git.golden",
+			tmpl,
+		},
+		{
+			"suspend kustomization tkfg",
+			"testdata/kustomization/suspend_kustomization_from_git.golden",
+			tmpl,
+		},
+		{
+			"resume kustomization tkfg",
+			"testdata/kustomization/resume_kustomization_from_git.golden",
+			tmpl,
+		},
+		{
+			"delete kustomization tkfg --silent",
+			"testdata/kustomization/delete_kustomization_from_git.golden",
+			tmpl,
+		},
+	}
 
 	for _, tc := range cases {
 		cmd := cmdTestCase{
 			args:   tc.args + " -n=" + namespace,
-			assert: assertGoldenTemplateFile(tc.goldenFile, map[string]string{"ns": namespace}),
+			assert: assertGoldenTemplateFile(tc.goldenFile, tc.tmpl),
 		}
 		cmd.runTestCmd(t)
 	}

--- a/cmd/flux/kustomization_test.go
+++ b/cmd/flux/kustomization_test.go
@@ -23,7 +23,7 @@ import "testing"
 
 func TestKustomizationFromGit(t *testing.T) {
 	namespace := allocateNamespace("tkfg")
-	del, err := setupTestNamespace(namespace)
+	del, err := execSetupTestNamespace(namespace)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/flux/main_e2e_test.go
+++ b/cmd/flux/main_e2e_test.go
@@ -65,7 +65,7 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-func setupTestNamespace(namespace string) (func(), error) {
+func execSetupTestNamespace(namespace string) (func(), error) {
 	kubectlArgs := []string{"create", "namespace", namespace}
 	_, err := utils.ExecKubectlCommand(context.TODO(), utils.ModeStderrOS, *kubeconfigArgs.KubeConfig, *kubeconfigArgs.Context, kubectlArgs...)
 	if err != nil {

--- a/cmd/flux/source_oci_test.go
+++ b/cmd/flux/source_oci_test.go
@@ -24,47 +24,56 @@ import (
 )
 
 func TestSourceOCI(t *testing.T) {
-	cases := []struct {
-		args       string
-		goldenFile string
-	}{
-		{
-			"create source oci thrfg --url=oci://ghcr.io/stefanprodan/manifests/podinfo --tag=6.1.6 --interval 10m",
-			"testdata/oci/create_source_oci.golden",
-		},
-		{
-			"get source oci thrfg",
-			"testdata/oci/get_oci.golden",
-		},
-		{
-			"reconcile source oci thrfg",
-			"testdata/oci/reconcile_oci.golden",
-		},
-		{
-			"suspend source oci thrfg",
-			"testdata/oci/suspend_oci.golden",
-		},
-		{
-			"resume source oci thrfg",
-			"testdata/oci/resume_oci.golden",
-		},
-		{
-			"delete source oci thrfg --silent",
-			"testdata/oci/delete_oci.golden",
-		},
-	}
-
 	namespace := allocateNamespace("oci-test")
 	del, err := setupTestNamespace(namespace)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer del()
+	t.Cleanup(del)
+
+	tmpl := map[string]string{"ns": namespace}
+
+	cases := []struct {
+		args       string
+		goldenFile string
+		tmpl       map[string]string
+	}{
+		{
+			"create source oci thrfg --url=oci://ghcr.io/stefanprodan/manifests/podinfo --tag=6.1.6 --interval 10m",
+			"testdata/oci/create_source_oci.golden",
+			nil,
+		},
+		{
+			"get source oci thrfg",
+			"testdata/oci/get_oci.golden",
+			nil,
+		},
+		{
+			"reconcile source oci thrfg",
+			"testdata/oci/reconcile_oci.golden",
+			tmpl,
+		},
+		{
+			"suspend source oci thrfg",
+			"testdata/oci/suspend_oci.golden",
+			tmpl,
+		},
+		{
+			"resume source oci thrfg",
+			"testdata/oci/resume_oci.golden",
+			tmpl,
+		},
+		{
+			"delete source oci thrfg --silent",
+			"testdata/oci/delete_oci.golden",
+			tmpl,
+		},
+	}
 
 	for _, tc := range cases {
 		cmd := cmdTestCase{
 			args:   tc.args + " -n=" + namespace,
-			assert: assertGoldenTemplateFile(tc.goldenFile, map[string]string{"ns": namespace}),
+			assert: assertGoldenTemplateFile(tc.goldenFile, tc.tmpl),
 		}
 		cmd.runTestCmd(t)
 	}

--- a/cmd/flux/source_oci_test.go
+++ b/cmd/flux/source_oci_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestSourceOCI(t *testing.T) {
 	namespace := allocateNamespace("oci-test")
-	del, err := setupTestNamespace(namespace)
+	del, err := execSetupTestNamespace(namespace)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -20,7 +20,6 @@ limitations under the License.
 package utils
 
 import (
-	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -135,16 +134,9 @@ func TestExtractCRDs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create temporary directory to write the result in.
-			dir, err := os.MkdirTemp("", "flux-TestExtractCRDs")
-			if err != nil {
-				t.Fatalf("failed to create temporary directory: %v", err)
-			}
-			defer os.RemoveAll(dir)
-
-			outManifestPath := filepath.Join(dir, "crds.yaml")
+			outManifestPath := filepath.Join(t.TempDir(), "crds.yaml")
 			inManifestPath := filepath.Join("testdata", tt.inManifestFile)
-			if err = ExtractCRDs(inManifestPath, outManifestPath); (err != nil) != tt.expectErr {
+			if err := ExtractCRDs(inManifestPath, outManifestPath); (err != nil) != tt.expectErr {
 				t.Errorf("ExtractCRDs() error = %v, expectErr %v", err, tt.expectErr)
 			}
 		})


### PR DESCRIPTION
As otherwise the `.golden` values can not be automatically updated using
`-update` as documented in `CONTRIBUTING.md`.

Also ensure we do not use `defer` but rather `t.Cleanup` in tests, as
this will always be called even if e.g. `t.Fatal` abruptly stops the
test.

Also fixed some other minor things I ran into, and filled issues for the
things that are beyond reach of time I have available.