### PR TITLE
Update implementation history of RFC-0003 and RFC-0005

### DIFF
--- a/rfcs/0003-kubernetes-oci/README.md
+++ b/rfcs/0003-kubernetes-oci/README.md
@@ -4,7 +4,7 @@
 
 **Creation date:** 2022-03-31
 
-**Last update:** 2023-02-10
+**Last update:** 2023-02-20
 
 ## Summary
 
@@ -469,3 +469,4 @@ The feature is enabled by default.
 * **2022-08-11** First implementation released with [flux2 v0.32.0](https://github.com/fluxcd/flux2/releases/tag/v0.32.0)
 * **2022-08-29** Select layer by OCI media type released with [flux2 v0.33.0](https://github.com/fluxcd/flux2/releases/tag/v0.33.0)
 * **2022-09-29** Verifying OCI artifacts with Cosign released with [flux2 v0.35.0](https://github.com/fluxcd/flux2/releases/tag/v0.35.0)
+* **2023-02-20** Custom OCI media types released with [flux2 v0.40.0](https://github.com/fluxcd/flux2/releases/tag/v0.40.0)

--- a/rfcs/0005-artifact-revision-and-digest/README.md
+++ b/rfcs/0005-artifact-revision-and-digest/README.md
@@ -1,10 +1,10 @@
 # RFC-0005 Artifact `Revision` format and introduction of `Digest`
 
-**Status:** implementable
+**Status:** implemented
 
 **Creation date:** 2022-10-20
 
-**Last update:** 2022-11-16
+**Last update:** 2023-02-20
 
 ## Summary
 
@@ -350,12 +350,7 @@ the field is removed.
 
 ## Implementation History
 
-<!--
-Major milestones in the lifecycle of the RFC such as:
-- The first Flux release where an initial version of the RFC was available.
-- The version of Flux where the RFC graduated to general availability.
-- The version of Flux where the RFC was retired or superseded.
--->
+* **2023-02-20** First implementation released with [flux2 v0.40.0](https://github.com/fluxcd/flux2/releases/tag/v0.40.0)
 
 [BLAKE3]: https://github.com/BLAKE3-team/BLAKE3
 [digest-spec]: https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests


### PR DESCRIPTION
Changes:
- Mark RFC-0005 as implemented and add implementation history
- Add custom OCI media types to implementation history of RFC-0003