### PR TITLE
Add `flux events` command 

### DIFF
--- a/cmd/flux/events.go
+++ b/cmd/flux/events.go
@@ -127,9 +127,9 @@ func eventsCmdRun(cmd *cobra.Command, args []string) error {
 	rows, err := getRows(ctx, kubeclient, clientListOpts, refListOpts, showNamespace)
 	if len(rows) == 0 {
 		if eventArgs.allNamespaces {
-			logger.Failuref("No flux events found.")
+			logger.Failuref("No events found.")
 		} else {
-			logger.Failuref("No flux events found in %s namespace.\n", *kubeconfigArgs.Namespace)
+			logger.Failuref("No events found in %s namespace.", *kubeconfigArgs.Namespace)
 		}
 
 		return nil

--- a/cmd/flux/events.go
+++ b/cmd/flux/events.go
@@ -39,7 +39,7 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	helmv2beta1 "github.com/fluxcd/helm-controller/api/v2beta1"
+	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
 	autov1 "github.com/fluxcd/image-automation-controller/api/v1beta1"
 	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1beta2"
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
@@ -268,7 +268,10 @@ func getHeaders(showNs bool) []string {
 	return headers
 }
 
-var fluxKinds = []string{"GitRepository", "HelmRepository", "OCIRepository", "Bucket", "HelmChart", "Kustomization", "HelmRelease", "Alert", "Provider", "ImageRepository", "ImagePolicy", "ImageUpdateAutomation"}
+var fluxKinds = []string{sourcev1.GitRepositoryKind, sourcev1.HelmRepositoryKind, sourcev1.OCIRepositoryKind,
+	sourcev1.BucketKind, sourcev1.HelmChartKind, kustomizev1.KustomizationKind, helmv2.HelmReleaseKind,
+	notificationv1.AlertKind, notificationv1.ProviderKind, imagev1.ImageRepositoryKind, imagev1.ImagePolicyKind,
+	autov1.ImageUpdateAutomationKind}
 
 func getEventRow(e corev1.Event, showNs bool) []string {
 	var row []string
@@ -370,9 +373,9 @@ func getGroupVersionAndRef(kind, name, ns string) (refInfo, error) {
 			crossNamespaced: true,
 			field:           []string{"spec", "sourceRef"},
 		}, nil
-	case helmv2beta1.HelmReleaseKind:
+	case helmv2.HelmReleaseKind:
 		return refInfo{
-			gv:              helmv2beta1.GroupVersion,
+			gv:              helmv2.GroupVersion,
 			crossNamespaced: true,
 			otherRefs:       []string{fmt.Sprintf("HelmChart/%s-%s", ns, name)},
 			field:           []string{"spec", "chart", "spec", "sourceRef"},

--- a/cmd/flux/events.go
+++ b/cmd/flux/events.go
@@ -1,0 +1,490 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+Copyright 2023 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/duration"
+	"k8s.io/apimachinery/pkg/watch"
+	runtimeresource "k8s.io/cli-runtime/pkg/resource"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	helmv2beta1 "github.com/fluxcd/helm-controller/api/v2beta1"
+	autov1 "github.com/fluxcd/image-automation-controller/api/v1beta1"
+	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1beta2"
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
+	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta2"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
+
+	"github.com/fluxcd/flux2/internal/utils"
+	"github.com/fluxcd/flux2/pkg/printers"
+)
+
+var eventsCmd = &cobra.Command{
+	Use:   "events",
+	Short: "Display Kubernetes events for Flux resources",
+	Long:  "The events sub-command shows Kubernetes events from Flux resources",
+	Example: ` # Display events for flux resources in default namespace
+	flux events -n default
+	
+	# Display events for flux resources in all namespaces
+	flux events -A
+
+	# Display events for flux resources
+	flux events --for Kustomization/podinfo
+`,
+	RunE: eventsCmdRun,
+}
+
+type eventFlags struct {
+	allNamespaces bool
+	watch         bool
+	forSelector   string
+	filterTypes   []string
+}
+
+var eventArgs eventFlags
+
+func init() {
+	eventsCmd.Flags().BoolVarP(&eventArgs.allNamespaces, "all-namespaces", "A", false,
+		"display events from Flux resources across all namespaces")
+	eventsCmd.Flags().BoolVarP(&eventArgs.watch, "watch", "w", false,
+		"indicate if the events should be streamed")
+	eventsCmd.Flags().StringVar(&eventArgs.forSelector, "for", "",
+		"get events for a particular object")
+	eventsCmd.Flags().StringSliceVar(&eventArgs.filterTypes, "types", []string{}, "filter events for certain types")
+	rootCmd.AddCommand(eventsCmd)
+}
+
+func eventsCmdRun(cmd *cobra.Command, args []string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	kubeclient, err := utils.KubeClient(kubeconfigArgs, kubeclientOptions)
+	if err != nil {
+		return err
+	}
+
+	namespace := *kubeconfigArgs.Namespace
+	if eventArgs.allNamespaces {
+		namespace = ""
+	}
+
+	var diffRefNs bool
+	clientListOpts := getListOpt(namespace, eventArgs.forSelector)
+	var refListOpts [][]client.ListOption
+	if eventArgs.forSelector != "" {
+		refs, err := getObjectRef(ctx, kubeclient, eventArgs.forSelector, *kubeconfigArgs.Namespace)
+		if err != nil {
+			return err
+		}
+
+		for _, ref := range refs {
+			kind, name, refNs := utils.ParseObjectKindNameNamespace(ref)
+			if refNs != namespace {
+				diffRefNs = true
+			}
+			refSelector := fmt.Sprintf("%s/%s", kind, name)
+			refListOpts = append(refListOpts, getListOpt(refNs, refSelector))
+		}
+	}
+
+	showNamespace := namespace == "" || diffRefNs
+	if eventArgs.watch {
+		return eventsCmdWatchRun(ctx, kubeclient, clientListOpts, refListOpts, showNamespace)
+	}
+
+	rows, err := getRows(ctx, kubeclient, clientListOpts, refListOpts, showNamespace)
+	if len(rows) == 0 {
+		if eventArgs.allNamespaces {
+			logger.Failuref("No flux events found.")
+		} else {
+			logger.Failuref("No flux events found in %s namespace.\n", *kubeconfigArgs.Namespace)
+		}
+
+		return nil
+	}
+	headers := getHeaders(showNamespace)
+	err = printers.TablePrinter(headers).Print(cmd.OutOrStdout(), rows)
+	return err
+}
+
+func getRows(ctx context.Context, kubeclient client.Client, clientListOpts []client.ListOption, refListOpts [][]client.ListOption, showNs bool) ([][]string, error) {
+	el := &corev1.EventList{}
+	if err := addEventsToList(ctx, kubeclient, el, clientListOpts); err != nil {
+		return nil, err
+	}
+
+	for _, refOpts := range refListOpts {
+		if err := addEventsToList(ctx, kubeclient, el, refOpts); err != nil {
+			return nil, err
+		}
+	}
+
+	sort.Sort(SortableEvents(el.Items))
+
+	var rows [][]string
+	for _, item := range el.Items {
+		if filterEvent(item) {
+			continue
+		}
+		rows = append(rows, getEventRow(item, showNs))
+	}
+
+	return rows, nil
+}
+
+func addEventsToList(ctx context.Context, kubeclient client.Client, el *corev1.EventList, clientListOpts []client.ListOption) error {
+	listOpts := &metav1.ListOptions{}
+	err := runtimeresource.FollowContinue(listOpts,
+		func(options metav1.ListOptions) (runtime.Object, error) {
+			newEvents := &corev1.EventList{}
+			err := kubeclient.List(ctx, newEvents, clientListOpts...)
+			if err != nil {
+				return nil, fmt.Errorf("error getting events: %w", err)
+			}
+			el.Items = append(el.Items, newEvents.Items...)
+			return newEvents, nil
+		})
+
+	return err
+}
+
+func getListOpt(namespace, selector string) []client.ListOption {
+	clientListOpts := []client.ListOption{client.Limit(cmdutil.DefaultChunkSize), client.InNamespace(namespace)}
+	if selector != "" {
+		kind, name := utils.ParseObjectKindName(selector)
+		sel := fields.AndSelectors(
+			fields.OneTermEqualSelector("involvedObject.kind", kind),
+			fields.OneTermEqualSelector("involvedObject.name", name))
+		clientListOpts = append(clientListOpts, client.MatchingFieldsSelector{Selector: sel})
+	}
+
+	return clientListOpts
+}
+
+func eventsCmdWatchRun(ctx context.Context, kubeclient client.WithWatch, listOpts []client.ListOption, refListOpts [][]client.ListOption, showNs bool) error {
+	event := &corev1.EventList{}
+	eventWatch, err := kubeclient.Watch(ctx, event, listOpts...)
+	if err != nil {
+		return err
+	}
+	defer eventWatch.Stop()
+
+	firstIteration := true
+
+	handleEvent := func(e watch.Event) error {
+		if e.Type == watch.Deleted {
+			return nil
+		}
+
+		event, ok := e.Object.(*corev1.Event)
+		if !ok {
+			return nil
+		}
+		if filterEvent(*event) {
+			return nil
+		}
+		rows := getEventRow(*event, showNs)
+		var hdr []string
+		if firstIteration {
+			hdr = getHeaders(showNs)
+			firstIteration = false
+		}
+		err = printers.TablePrinter(hdr).Print(os.Stdout, [][]string{rows})
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	for _, refOpts := range refListOpts {
+		refEventWatch, err := kubeclient.Watch(ctx, event, refOpts...)
+		if err != nil {
+			return err
+		}
+		defer refEventWatch.Stop()
+		go receiveEventChan(ctx, refEventWatch, handleEvent)
+	}
+
+	return receiveEventChan(ctx, eventWatch, handleEvent)
+
+}
+
+func receiveEventChan(ctx context.Context, eventWatch watch.Interface, f func(e watch.Event) error) error {
+	for {
+		select {
+		case e, ok := <-eventWatch.ResultChan():
+			if !ok {
+				return nil
+			}
+			err := f(e)
+			if err != nil {
+				return err
+			}
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+func getHeaders(showNs bool) []string {
+	headers := []string{"Last seen", "Type", "Reason", "Object", "Message"}
+	if showNs {
+		headers = append(namespaceHeader, headers...)
+	}
+
+	return headers
+}
+
+var fluxKinds = []string{"GitRepository", "HelmRepository", "OCIRepository", "Bucket", "HelmChart", "Kustomization", "HelmRelease", "Alert", "Provider", "ImageRepository", "ImagePolicy", "ImageUpdateAutomation"}
+
+func getEventRow(e corev1.Event, showNs bool) []string {
+	var row []string
+	if showNs {
+		row = []string{e.Namespace}
+	}
+	row = append(row, getLastSeen(e), e.Type, e.Reason, fmt.Sprintf("%s/%s", e.InvolvedObject.Kind, e.InvolvedObject.Name), e.Message)
+
+	return row
+}
+
+// getObjectRef is used to get the metadata of a resource that the selector(in the format <kind/name>) references.
+// It returns an empty string if the resource doesn't reference any resource
+// and a string with the format `<kind>/<name>.<namespace>` if it does.
+func getObjectRef(ctx context.Context, kubeclient client.Client, selector string, ns string) ([]string, error) {
+	kind, name := utils.ParseObjectKindName(selector)
+	ref, err := getGroupVersionAndRef(kind, name, ns)
+	if err != nil {
+		return nil, fmt.Errorf("error getting groupversion: %w", err)
+	}
+
+	// the resource has no source ref
+	if len(ref.field) == 0 {
+		return nil, nil
+	}
+
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Kind:    kind,
+		Version: ref.gv.Version,
+		Group:   ref.gv.Group,
+	})
+	objName := types.NamespacedName{
+		Namespace: ns,
+		Name:      name,
+	}
+
+	err = kubeclient.Get(ctx, objName, obj)
+	if err != nil {
+		return nil, err
+	}
+
+	var ok bool
+	refKind := ref.kind
+	if refKind == "" {
+		kindField := append(ref.field, "kind")
+		refKind, ok, err = unstructured.NestedString(obj.Object, kindField...)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, fmt.Errorf("field '%s' for '%s' not found", strings.Join(kindField, "."), objName)
+		}
+	}
+
+	nameField := append(ref.field, "name")
+	refName, ok, err := unstructured.NestedString(obj.Object, nameField...)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("field '%s' for '%s' not found", strings.Join(nameField, "."), objName)
+	}
+
+	var allRefs []string
+	refNamespace := ns
+	if ref.crossNamespaced {
+		namespaceField := append(ref.field, "namespace")
+		namespace, ok, err := unstructured.NestedString(obj.Object, namespaceField...)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			refNamespace = namespace
+		}
+	}
+
+	allRefs = append(allRefs, fmt.Sprintf("%s/%s.%s", refKind, refName, refNamespace))
+	for _, ref := range ref.otherRefs {
+		allRefs = append(allRefs, fmt.Sprintf("%s.%s", ref, refNamespace))
+	}
+
+	return allRefs, nil
+}
+
+type refInfo struct {
+	gv              schema.GroupVersion
+	kind            string
+	crossNamespaced bool
+	otherRefs       []string
+	field           []string
+}
+
+func getGroupVersionAndRef(kind, name, ns string) (refInfo, error) {
+	switch kind {
+	case kustomizev1.KustomizationKind:
+		return refInfo{
+			gv:              kustomizev1.GroupVersion,
+			crossNamespaced: true,
+			field:           []string{"spec", "sourceRef"},
+		}, nil
+	case helmv2beta1.HelmReleaseKind:
+		return refInfo{
+			gv:              helmv2beta1.GroupVersion,
+			crossNamespaced: true,
+			otherRefs:       []string{fmt.Sprintf("HelmChart/%s-%s", ns, name)},
+			field:           []string{"spec", "chart", "spec", "sourceRef"},
+		}, nil
+	case notificationv1.AlertKind:
+		return refInfo{
+			gv:              notificationv1.GroupVersion,
+			kind:            notificationv1.ProviderKind,
+			crossNamespaced: false,
+			field:           []string{"spec", "providerRef"},
+		}, nil
+	case notificationv1.ReceiverKind,
+		notificationv1.ProviderKind:
+		return refInfo{
+			gv: notificationv1.GroupVersion,
+		}, nil
+	case imagev1.ImagePolicyKind:
+		return refInfo{
+			gv:              imagev1.GroupVersion,
+			kind:            imagev1.ImageRepositoryKind,
+			crossNamespaced: true,
+			field:           []string{"spec", "imageRepositoryRef"},
+		}, nil
+	case sourcev1.GitRepositoryKind, sourcev1.HelmChartKind, sourcev1.BucketKind,
+		sourcev1.HelmRepositoryKind, sourcev1.OCIRepositoryKind:
+		return refInfo{gv: sourcev1.GroupVersion}, nil
+	case autov1.ImageUpdateAutomationKind:
+		return refInfo{gv: autov1.GroupVersion}, nil
+	case imagev1.ImageRepositoryKind:
+		return refInfo{gv: imagev1.GroupVersion}, nil
+	default:
+		return refInfo{}, fmt.Errorf("'%s' is not a flux kind", kind)
+	}
+}
+
+func filterEvent(e corev1.Event) bool {
+	if !utils.ContainsItemString(fluxKinds, e.InvolvedObject.Kind) {
+		return true
+	}
+
+	if len(eventArgs.filterTypes) > 0 {
+		_, equal := utils.ContainsEqualFoldItemString(eventArgs.filterTypes, e.Type)
+		if !equal {
+			return true
+		}
+	}
+
+	return false
+}
+
+// The functions below are copied from: https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/events/events.go#L347
+
+// SortableEvents implements sort.Interface for []api.Event by time
+type SortableEvents []corev1.Event
+
+func (list SortableEvents) Len() int {
+	return len(list)
+}
+
+func (list SortableEvents) Swap(i, j int) {
+	list[i], list[j] = list[j], list[i]
+}
+
+// Return the time that should be used for sorting, which can come from
+// various places in corev1.Event.
+func eventTime(event corev1.Event) time.Time {
+	if event.Series != nil {
+		return event.Series.LastObservedTime.Time
+	}
+	if !event.LastTimestamp.Time.IsZero() {
+		return event.LastTimestamp.Time
+	}
+	return event.EventTime.Time
+}
+
+func (list SortableEvents) Less(i, j int) bool {
+	return eventTime(list[i]).Before(eventTime(list[j]))
+}
+
+func getLastSeen(e corev1.Event) string {
+	var interval string
+	firstTimestampSince := translateMicroTimestampSince(e.EventTime)
+	if e.EventTime.IsZero() {
+		firstTimestampSince = translateTimestampSince(e.FirstTimestamp)
+	}
+	if e.Series != nil {
+		interval = fmt.Sprintf("%s (x%d over %s)", translateMicroTimestampSince(e.Series.LastObservedTime), e.Series.Count, firstTimestampSince)
+	} else if e.Count > 1 {
+		interval = fmt.Sprintf("%s (x%d over %s)", translateTimestampSince(e.LastTimestamp), e.Count, firstTimestampSince)
+	} else {
+		interval = firstTimestampSince
+	}
+
+	return interval
+}
+
+// translateMicroTimestampSince returns the elapsed time since timestamp in
+// human-readable approximation.
+func translateMicroTimestampSince(timestamp metav1.MicroTime) string {
+	if timestamp.IsZero() {
+		return "<unknown>"
+	}
+
+	return duration.HumanDuration(time.Since(timestamp.Time))
+}
+
+// translateTimestampSince returns the elapsed time since timestamp in
+// human-readable approximation.
+func translateTimestampSince(timestamp metav1.Time) string {
+	if timestamp.IsZero() {
+		return "<unknown>"
+	}
+
+	return duration.HumanDuration(time.Since(timestamp.Time))
+}

--- a/cmd/flux/events_test.go
+++ b/cmd/flux/events_test.go
@@ -1,0 +1,411 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+Copyright 2023 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/fluxcd/flux2/internal/utils"
+	helmv2beta1 "github.com/fluxcd/helm-controller/api/v2beta1"
+	autov1 "github.com/fluxcd/image-automation-controller/api/v1beta1"
+	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1beta2"
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
+	notificationv1 "github.com/fluxcd/notification-controller/api/v1beta2"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	"github.com/fluxcd/pkg/ssa"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var objects = `
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: flux-system
+  namespace: flux-system
+spec:
+  interval: 5m0s
+  path: ./infrastructure/
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: podinfo
+  namespace: default
+spec:
+  interval: 5m0s
+  path: ./infrastructure/
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: GitRepository
+metadata:
+  name: flux-system
+  namespace: flux-system
+spec:
+  interval: 5m0s
+  ref:
+    branch: main
+  secretRef:
+    name: flux-system
+  timeout: 1m0s
+  url: ssh://git@github.com/example/repo
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: podinfo
+  namespace: default
+spec:
+  chart:
+    spec:
+      chart: podinfo
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: podinfo
+        namespace: flux-system
+      version: '*'
+  interval: 5m0s
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: podinfo
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  url: https://stefanprodan.github.io/podinfo
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmChart
+metadata:
+  name: default-podinfo
+  namespace: flux-system
+spec:
+  chart: podinfo
+  interval: 1m0s
+  reconcileStrategy: ChartVersion
+  sourceRef:
+    kind: HelmRepository
+    name: podinfo-chart
+  version: '*'
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta2
+kind: Alert
+metadata:
+  name: webapp
+  namespace: flux-system
+spec:
+  eventSeverity: info
+  eventSources:
+  - kind: GitRepository
+    name: '*'
+  providerRef:
+    name: slack
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta2
+kind: Provider
+metadata:
+  name: slack
+  namespace: flux-system
+spec:
+  address: https://hooks.slack.com/services/mock
+  type: slack
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: podinfo
+  namespace: default
+spec:
+  imageRepositoryRef:
+    name: acr-podinfo
+    namespace: flux-system
+  policy:
+    semver:
+      range: 5.0.x
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: flux-system`
+
+func Test_getObjectRef(t *testing.T) {
+	g := NewWithT(t)
+	objs, err := ssa.ReadObjects(strings.NewReader(objects))
+	g.Expect(err).To(Not(HaveOccurred()))
+
+	builder := fake.NewClientBuilder().WithScheme(getScheme())
+	for _, obj := range objs {
+		builder = builder.WithObjects(obj)
+	}
+	c := builder.Build()
+
+	tests := []struct {
+		name      string
+		selector  string
+		namespace string
+		want      []string
+		wantErr   bool
+	}{
+		{
+			name:      "Source Ref for Kustomization",
+			selector:  "Kustomization/flux-system",
+			namespace: "flux-system",
+			want:      []string{"GitRepository/flux-system.flux-system"},
+		},
+		{
+			name:      "Crossnamespace Source Ref for Kustomization",
+			selector:  "Kustomization/podinfo",
+			namespace: "default",
+			want:      []string{"GitRepository/flux-system.flux-system"},
+		},
+		{
+			name:      "Source Ref for HelmRelease",
+			selector:  "HelmRelease/podinfo",
+			namespace: "default",
+			want:      []string{"HelmRepository/podinfo.flux-system", "HelmChart/default-podinfo.flux-system"},
+		},
+		{
+			name:      "Source Ref for Alert",
+			selector:  "Alert/webapp",
+			namespace: "flux-system",
+			want:      []string{"Provider/slack.flux-system"},
+		},
+		{
+			name:      "Source Ref for ImagePolicy",
+			selector:  "ImagePolicy/podinfo",
+			namespace: "default",
+			want:      []string{"ImageRepository/acr-podinfo.flux-system"},
+		},
+		{
+			name:      "Empty Ref for Provider",
+			selector:  "Provider/slack",
+			namespace: "flux-system",
+			want:      nil,
+		},
+		{
+			name:     "Non flux resource",
+			selector: "Namespace/flux-system",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got, err := getObjectRef(context.Background(), c, tt.selector, tt.namespace)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+
+			g.Expect(err).To(Not(HaveOccurred()))
+			g.Expect(got).To(Equal(tt.want))
+		})
+	}
+}
+
+func Test_getRows(t *testing.T) {
+	g := NewWithT(t)
+	objs, err := ssa.ReadObjects(strings.NewReader(objects))
+	g.Expect(err).To(Not(HaveOccurred()))
+
+	builder := fake.NewClientBuilder().WithScheme(getScheme())
+	for _, obj := range objs {
+		builder = builder.WithObjects(obj)
+	}
+	eventList := &corev1.EventList{}
+	for _, obj := range objs {
+		infoEvent := createEvent(obj, eventv1.EventSeverityInfo, "Info Message", "Info Reason")
+		warningEvent := createEvent(obj, eventv1.EventSeverityError, "Error Message", "Error Reason")
+		eventList.Items = append(eventList.Items, infoEvent, warningEvent)
+	}
+	builder = builder.WithLists(eventList)
+	builder.WithIndex(&corev1.Event{}, "involvedObject.kind/name", kindNameIndexer)
+	c := builder.Build()
+
+	tests := []struct {
+		name        string
+		selector    string
+		refSelector string
+		namespace   string
+		refNs       string
+		expected    [][]string
+	}{
+		{
+			name:      "events from all namespaces",
+			selector:  "",
+			namespace: "",
+			expected: [][]string{
+				{"default", "<unknown>", "error", "Error Reason", "HelmRelease/podinfo", "Error Message"},
+				{"default", "<unknown>", "info", "Info Reason", "HelmRelease/podinfo", "Info Message"},
+				{"default", "<unknown>", "error", "Error Reason", "ImagePolicy/podinfo", "Error Message"},
+				{"default", "<unknown>", "info", "Info Reason", "ImagePolicy/podinfo", "Info Message"},
+				{"default", "<unknown>", "error", "Error Reason", "Kustomization/podinfo", "Error Message"},
+				{"default", "<unknown>", "info", "Info Reason", "Kustomization/podinfo", "Info Message"},
+				{"flux-system", "<unknown>", "error", "Error Reason", "Alert/webapp", "Error Message"},
+				{"flux-system", "<unknown>", "info", "Info Reason", "Alert/webapp", "Info Message"},
+				{"flux-system", "<unknown>", "error", "Error Reason", "GitRepository/flux-system", "Error Message"},
+				{"flux-system", "<unknown>", "info", "Info Reason", "GitRepository/flux-system", "Info Message"},
+				{"flux-system", "<unknown>", "error", "Error Reason", "HelmChart/default-podinfo", "Error Message"},
+				{"flux-system", "<unknown>", "info", "Info Reason", "HelmChart/default-podinfo", "Info Message"},
+				{"flux-system", "<unknown>", "error", "Error Reason", "HelmRepository/podinfo", "Error Message"},
+				{"flux-system", "<unknown>", "info", "Info Reason", "HelmRepository/podinfo", "Info Message"},
+				{"flux-system", "<unknown>", "error", "Error Reason", "Kustomization/flux-system", "Error Message"},
+				{"flux-system", "<unknown>", "info", "Info Reason", "Kustomization/flux-system", "Info Message"},
+				{"flux-system", "<unknown>", "error", "Error Reason", "Provider/slack", "Error Message"},
+				{"flux-system", "<unknown>", "info", "Info Reason", "Provider/slack", "Info Message"},
+			},
+		},
+		{
+			name:      "events from default namespaces",
+			selector:  "",
+			namespace: "default",
+			expected: [][]string{
+				{"<unknown>", "error", "Error Reason", "HelmRelease/podinfo", "Error Message"},
+				{"<unknown>", "info", "Info Reason", "HelmRelease/podinfo", "Info Message"},
+				{"<unknown>", "error", "Error Reason", "ImagePolicy/podinfo", "Error Message"},
+				{"<unknown>", "info", "Info Reason", "ImagePolicy/podinfo", "Info Message"},
+				{"<unknown>", "error", "Error Reason", "Kustomization/podinfo", "Error Message"},
+				{"<unknown>", "info", "Info Reason", "Kustomization/podinfo", "Info Message"},
+			},
+		},
+		{
+			name:      "Kustomization with crossnamespaced GitRepository",
+			selector:  "Kustomization/podinfo",
+			namespace: "default",
+			expected: [][]string{
+				{"default", "<unknown>", "error", "Error Reason", "Kustomization/podinfo", "Error Message"},
+				{"default", "<unknown>", "info", "Info Reason", "Kustomization/podinfo", "Info Message"},
+				{"flux-system", "<unknown>", "error", "Error Reason", "GitRepository/flux-system", "Error Message"},
+				{"flux-system", "<unknown>", "info", "Info Reason", "GitRepository/flux-system", "Info Message"},
+			},
+		},
+		{
+			name:      "HelmRelease with crossnamespaced HelmRepository",
+			selector:  "HelmRelease/podinfo",
+			namespace: "default",
+			expected: [][]string{
+				{"default", "<unknown>", "error", "Error Reason", "HelmRelease/podinfo", "Error Message"},
+				{"default", "<unknown>", "info", "Info Reason", "HelmRelease/podinfo", "Info Message"},
+				{"flux-system", "<unknown>", "error", "Error Reason", "HelmRepository/podinfo", "Error Message"},
+				{"flux-system", "<unknown>", "info", "Info Reason", "HelmRepository/podinfo", "Info Message"},
+				{"flux-system", "<unknown>", "error", "Error Reason", "HelmChart/default-podinfo", "Error Message"},
+				{"flux-system", "<unknown>", "info", "Info Reason", "HelmChart/default-podinfo", "Info Message"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			var refs []string
+			var refNs, refKind, refName string
+			if tt.selector != "" {
+				refs, err = getObjectRef(context.Background(), c, tt.selector, tt.namespace)
+				g.Expect(err).To(Not(HaveOccurred()))
+			}
+
+			g.Expect(err).To(Not(HaveOccurred()))
+
+			clientOpts := getTestListOpt(tt.namespace, tt.selector)
+			var refOpts [][]client.ListOption
+			for _, ref := range refs {
+				refKind, refName, refNs = utils.ParseObjectKindNameNamespace(ref)
+				refSelector := fmt.Sprintf("%s/%s", refKind, refName)
+				refOpts = append(refOpts, getTestListOpt(refNs, refSelector))
+			}
+
+			showNs := tt.namespace == "" || (refNs != "" && refNs != tt.namespace)
+			rows, err := getRows(context.Background(), c, clientOpts, refOpts, showNs)
+			g.Expect(err).To(Not(HaveOccurred()))
+			g.Expect(rows).To(Equal(tt.expected))
+		})
+	}
+}
+
+func getTestListOpt(namespace, selector string) []client.ListOption {
+	clientListOpts := []client.ListOption{client.Limit(cmdutil.DefaultChunkSize), client.InNamespace(namespace)}
+	if selector != "" {
+		sel := fields.OneTermEqualSelector("involvedObject.kind/name", selector)
+		clientListOpts = append(clientListOpts, client.MatchingFieldsSelector{Selector: sel})
+	}
+
+	return clientListOpts
+}
+
+func getScheme() *runtime.Scheme {
+	newscheme := runtime.NewScheme()
+	corev1.AddToScheme(newscheme)
+	kustomizev1.AddToScheme(newscheme)
+	helmv2beta1.AddToScheme(newscheme)
+	notificationv1.AddToScheme(newscheme)
+	imagev1.AddToScheme(newscheme)
+	autov1.AddToScheme(newscheme)
+	sourcev1.AddToScheme(newscheme)
+
+	return newscheme
+}
+
+func createEvent(obj client.Object, eventType, msg, reason string) corev1.Event {
+	return corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: obj.GetNamespace(),
+			// name of event needs to be unique so fak
+			Name: obj.GetNamespace() + obj.GetNamespace() + obj.GetObjectKind().GroupVersionKind().Kind + eventType,
+		},
+		Reason:  reason,
+		Message: msg,
+		Type:    eventType,
+		InvolvedObject: corev1.ObjectReference{
+			Kind:      obj.GetObjectKind().GroupVersionKind().Kind,
+			Namespace: obj.GetNamespace(),
+			Name:      obj.GetName(),
+		},
+	}
+}
+
+func kindNameIndexer(obj client.Object) []string {
+	e, ok := obj.(*corev1.Event)
+	if !ok {
+		panic(fmt.Sprintf("Expected a Event, got %T", e))
+	}
+
+	return []string{fmt.Sprintf("%s/%s", e.InvolvedObject.Kind, e.InvolvedObject.Name)}
+}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/fluxcd/image-reflector-controller/api v0.26.0
 	github.com/fluxcd/kustomize-controller/api v0.35.0
 	github.com/fluxcd/notification-controller/api v0.33.0
+	github.com/fluxcd/pkg/apis/event v0.4.1
 	github.com/fluxcd/pkg/apis/meta v0.19.1
 	github.com/fluxcd/pkg/git v0.11.0
 	github.com/fluxcd/pkg/git/gogit v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -211,6 +211,8 @@ github.com/fluxcd/notification-controller/api v0.33.0 h1:iVnIGDfkpVuzcILSGwi//Q3
 github.com/fluxcd/notification-controller/api v0.33.0/go.mod h1:0IyWy0J6+z1TbijVQjFx1gWQDOzXaRfzV2NClfjHZPk=
 github.com/fluxcd/pkg/apis/acl v0.1.0 h1:EoAl377hDQYL3WqanWCdifauXqXbMyFuK82NnX6pH4Q=
 github.com/fluxcd/pkg/apis/acl v0.1.0/go.mod h1:zfEZzz169Oap034EsDhmCAGgnWlcWmIObZjYMusoXS8=
+github.com/fluxcd/pkg/apis/event v0.4.1 h1:63wP8NM/uA4680F4Ft8q8/0rJivX90i7FmMkRvUI8Is=
+github.com/fluxcd/pkg/apis/event v0.4.1/go.mod h1:LHT1ZsbMrcHwCHQCaFtQviQBZwhMOAbTUPK6+KgBkFo=
 github.com/fluxcd/pkg/apis/kustomize v0.8.1 h1:uRH9xVDJfSBGIiL6PIhkguHvf2Nme6uTWX+RX1iZznc=
 github.com/fluxcd/pkg/apis/kustomize v0.8.1/go.mod h1:TBem+2mHp6Ib7XD1fmzDkoUnBzx07wSzIYo6BVx3XAc=
 github.com/fluxcd/pkg/apis/meta v0.19.1 h1:fCI5CnTXpAqr67UlaI9q0H+OztMKB5kDTr6xV6vlAo0=


### PR DESCRIPTION
This pull request closes #3618 

```
$ flux events
LAST SEEN               TYPE    REASON                  OBJECT                          MESSAGE                                                                                                       
60m                     Normal  ReconciliationSucceeded Kustomization/flux-system       Reconciliation finished in 1.51342644s, next run in 10m0s                                                    
53m (x20 over 19h)      Normal  ArtifactUpToDate        HelmChart/flux-system-ww-gitops artifact up-to-date with remote revision: '4.0.14'                                                           
50m                     Normal  ReconciliationSucceeded Kustomization/flux-system       Reconciliation finished in 1.568797687s, next run in 10m0s                                                   
40m                     Normal  ReconciliationSucceeded Kustomization/flux-system       Reconciliation finished in 1.521790217s, next run in 10m0s                                                   
30m                     Normal  ReconciliationSucceeded Kustomization/flux-system       Reconciliation finished in 1.634660693s, next run in 10m0s                                                   
20m                     Normal  ReconciliationSucceeded Kustomization/flux-system       Reconciliation finished in 1.52127281s, next run in 10m0s                                                    
10m                     Normal  ReconciliationSucceeded Kustomization/flux-system       Reconciliation finished in 1.628969204s, next run in 10m0s                                                   
3m30s (x120 over 19h)   Normal  Succeeded               Provider/slack                  Reconciliation finished, next run in 10m0s                                                                   
3m8s (x240 over 19h)    Normal  info                    ImagePolicy/podinfo-acr         Latest image tag for 'asia-southeast1-docker.pkg.dev/dx-somtoxhi/podinfo/podinfo' resolved to: v6.0.1        
2m31s (x328 over 19h)   Warning error                   ImagePolicy/podinfo             Cannot determine latest tag for policy: unable to determine latest version from provided list                
2m30s (x923 over 15h)   Normal  GitOperationSucceeded   GitRepository/flux-system       no changes since last reconcilation: observed revision 'main@sha1:3d86db5afdf2adacd4feb5fb95e8866be5517482'  
91s (x596 over 19h)     Normal  GitOperationSucceeded   GitRepository/podinfo           no changes since last reconcilation: observed revision 'master@sha1:1abc44f0d8dd6cd9df76090ea4ad694b70e03ee4'
15s                     Normal  ReconciliationSucceeded Kustomization/flux-system       Reconciliation finished in 1.519954174s, next run in 10m0s 
```

Filter by resource
```
$ flux events --for Kustomization/flux-system
LAST SEEN               TYPE    REASON                  OBJECT                          MESSAGE                                                                                                     
51m                     Normal  ReconciliationSucceeded Kustomization/flux-system       Reconciliation finished in 1.568797687s, next run in 10m0s                                                  
41m                     Normal  ReconciliationSucceeded Kustomization/flux-system       Reconciliation finished in 1.521790217s, next run in 10m0s                                                  
31m                     Normal  ReconciliationSucceeded Kustomization/flux-system       Reconciliation finished in 1.634660693s, next run in 10m0s                                                  
21m                     Normal  ReconciliationSucceeded Kustomization/flux-system       Reconciliation finished in 1.52127281s, next run in 10m0s                                                   
11m                     Normal  ReconciliationSucceeded Kustomization/flux-system       Reconciliation finished in 1.628969204s, next run in 10m0s                                                  
3m31s (x923 over 15h)   Normal  GitOperationSucceeded   GitRepository/flux-system       no changes since last reconcilation: observed revision 'main@sha1:3d86db5afdf2adacd4feb5fb95e8866be5517482' 
76s                     Normal  ReconciliationSucceeded Kustomization/flux-system       Reconciliation finished in 1.519954174s, next run in 10m0s 
```
