### PR TITLE
Update GitHub Action workflows

### DIFF
--- a/.github/workflows/e2e-arm64.yaml
+++ b/.github/workflows/e2e-arm64.yaml
@@ -19,9 +19,9 @@ jobs:
         KUBERNETES_VERSION: [ 1.23.13, 1.24.7, 1.25.3 ]
     steps:
       - name: Checkout
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Setup Go
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version: 1.20.x
       - name: Prepare

--- a/.github/workflows/e2e-arm64.yaml
+++ b/.github/workflows/e2e-arm64.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         # Keep this list up-to-date with https://endoflife.date/kubernetes
-        KUBERNETES_VERSION: [ 1.23.13, 1.24.7, 1.25.3 ]
+        KUBERNETES_VERSION: [ 1.24.11, 1.25.7, 1.26.2 ]
     steps:
       - name: Checkout
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0

--- a/.github/workflows/e2e-azure.yaml
+++ b/.github/workflows/e2e-azure.yaml
@@ -15,16 +15,16 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Restore Go cache
-        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0
+        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # v3.2.6
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go1.20-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go1.20-
       - name: Setup Go
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version: 1.20.x
       - name: Setup Flux CLI

--- a/.github/workflows/e2e-bootstrap.yaml
+++ b/.github/workflows/e2e-bootstrap.yaml
@@ -16,16 +16,16 @@ jobs:
     if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Restore Go cache
-        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0
+        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # v3.2.6
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go1.20-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go1.20-
       - name: Setup Go
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version: 1.20.x
       - name: Setup Kubernetes
@@ -35,7 +35,7 @@ jobs:
           cluster_name: kind
           node_image: kindest/node:v1.25.2
       - name: Setup Kustomize
-        uses: fluxcd/pkg//actions/kustomize@main
+        uses: fluxcd/pkg/actions/kustomize@main
       - name: Build
         run: |
           make cmd/flux/.manifests.done

--- a/.github/workflows/e2e-bootstrap.yaml
+++ b/.github/workflows/e2e-bootstrap.yaml
@@ -33,7 +33,10 @@ jobs:
         with:
           version: v0.17.0
           cluster_name: kind
-          node_image: kindest/node:v1.25.2
+          # The versions below should target the newest Kubernetes version
+          # Keep this up-to-date with https://endoflife.date/kubernetes
+          node_image: kindest/node:v1.26.0
+          kubectl_version: v1.26.2
       - name: Setup Kustomize
         uses: fluxcd/pkg/actions/kustomize@main
       - name: Build

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -20,16 +20,16 @@ jobs:
           - 5000:5000
     steps:
       - name: Checkout
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Restore Go cache
-        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0
+        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # v3.2.6
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go1.20-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go1.20-
       - name: Setup Go
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version: 1.20.x
       - name: Setup Kubernetes
@@ -44,7 +44,7 @@ jobs:
           kubectl apply -f https://docs.projectcalico.org/v3.20/manifests/calico.yaml
           kubectl -n kube-system set env daemonset/calico-node FELIX_IGNORELOOSERPF=true
       - name: Setup Kustomize
-        uses: fluxcd/pkg//actions/kustomize@main
+        uses: fluxcd/pkg/actions/kustomize@main
       - name: Run tests
         run: make test
       - name: Run e2e tests

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -38,10 +38,13 @@ jobs:
           version: v0.17.0
           cluster_name: kind
           config: .github/kind/config.yaml # disable KIND-net
-          node_image: kindest/node:v1.23.13
+          # The versions below should target the newest Kubernetes version
+          # Keep this up-to-date with https://endoflife.date/kubernetes
+          node_image: kindest/node:v1.26.0
+          kubectl_version: v1.26.2
       - name: Setup Calico for network policy
         run: |
-          kubectl apply -f https://docs.projectcalico.org/v3.20/manifests/calico.yaml
+          kubectl apply -f https://docs.projectcalico.org/v3.25/manifests/calico.yaml
           kubectl -n kube-system set env daemonset/calico-node FELIX_IGNORELOOSERPF=true
       - name: Setup Kustomize
         uses: fluxcd/pkg/actions/kustomize@main

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -81,12 +81,12 @@ jobs:
         run: |
           /tmp/flux create source git podinfo \
             --url https://github.com/stefanprodan/podinfo  \
-            --tag-semver=">=3.2.3"
+            --tag-semver=">=6.3.5"
       - name: flux create source git export apply
         run: |
           /tmp/flux create source git podinfo-export \
             --url https://github.com/stefanprodan/podinfo  \
-            --tag-semver=">=3.2.3" \
+            --tag-semver=">=6.3.5" \
             --export | kubectl apply -f -
           /tmp/flux delete source git podinfo-export --silent
       - name: flux get sources git
@@ -143,7 +143,7 @@ jobs:
             --target-namespace=default \
             --source=HelmRepository/podinfo.flux-system \
             --chart=podinfo \
-            --chart-version=">4.0.0 <5.0.0"
+            --chart-version=">6.0.0 <7.0.0"
       - name: flux create helmrelease --source=GitRepository/podinfo
         run: |
           /tmp/flux create hr podinfo-git \
@@ -187,11 +187,11 @@ jobs:
         run: |
           /tmp/flux create source oci podinfo-oci \
             --url oci://ghcr.io/stefanprodan/manifests/podinfo \
-            --tag-semver 6.1.x \
+            --tag-semver 6.3.x \
             --interval 10m
           /tmp/flux create kustomization podinfo-oci \
             --source=OCIRepository/podinfo-oci \
-            --path="./kustomize" \
+            --path="./" \
             --prune=true \
             --interval=5m \
             --target-namespace=default \
@@ -212,7 +212,7 @@ jobs:
           /tmp/flux -n apps create hr podinfo-helm \
             --source=HelmRepository/podinfo \
             --chart=podinfo \
-            --chart-version="5.0.x" \
+            --chart-version="6.3.x" \
             --service-account=dev-team
       - name: flux2-kustomize-helm-example
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,32 +16,32 @@ jobs:
       packages: write # needed for ghcr access
     steps:
       - name: Checkout
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Unshallow
         run: git fetch --prune --unshallow
       - name: Setup Go
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version: 1.20.x
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2
+        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
       - name: Setup Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@f03ac48505955848960e80bbb68046aa35c7b9e7  # v2
+        uses: docker/setup-buildx-action@f03ac48505955848960e80bbb68046aa35c7b9e7  # v2.4.1
       - name: Setup Syft
         uses: anchore/sbom-action/download-syft@07978da4bdb4faa726e52dfc6b1bed63d4b56479 # v0.13.3
       - name: Setup Cosign
-        uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b # v2.8.1
+        uses: sigstore/cosign-installer@c3667d99424e7e6047999fb6246c0da843953c65 # v3.0.1
       - name: Setup Kustomize
-        uses: fluxcd/pkg//actions/kustomize@main
+        uses: fluxcd/pkg/actions/kustomize@main
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
         with:
           registry: ghcr.io
           username: fluxcdbot
           password: ${{ secrets.GHCR_TOKEN }}
       - name: Login to Docker Hub
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a  # v2
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a  # v2.1.0
         with:
           username: fluxcdbot
           password: ${{ secrets.DOCKER_FLUXCD_PASSWORD }}
@@ -54,7 +54,7 @@ jobs:
         run: |
           kustomize build manifests/crds > all-crds.yaml
       - name: Generate OpenAPI JSON schemas from CRDs
-        uses: fluxcd/pkg//actions/crdjsonschema@main
+        uses: fluxcd/pkg/actions/crdjsonschema@main
         with:
           crd: all-crds.yaml
           output: schemas
@@ -73,7 +73,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@f82d6c1c344bcacabba2c841718984797f664a6b # v3
+        uses: goreleaser/goreleaser-action@f82d6c1c344bcacabba2c841718984797f664a6b # v4.2.0
         with:
           version: latest
           args: release --release-notes=output/notes.md --skip-validate
@@ -88,7 +88,7 @@ jobs:
       id-token: write
       packages: write
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Setup Kustomize
         uses: fluxcd/pkg/actions/kustomize@main
       - name: Setup Flux CLI
@@ -99,13 +99,13 @@ jobs:
           VERSION=$(flux version --client | awk '{ print $NF }')
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
       - name: Login to GHCR
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
         with:
           registry: ghcr.io
           username: fluxcdbot
           password: ${{ secrets.GHCR_TOKEN }}
       - name: Login to DockerHub
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
         with:
           username: fluxcdbot
           password: ${{ secrets.DOCKER_FLUXCD_PASSWORD }}
@@ -133,13 +133,13 @@ jobs:
           --path="./flux-system" \
           --source=${{ github.repositoryUrl }} \
           --revision="${{ github.ref_name }}@sha1:${{ github.sha }}"
-      - uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b # v2.8.1
+      - uses: sigstore/cosign-installer@c3667d99424e7e6047999fb6246c0da843953c65 # v3.0.1
       - name: Sign manifests
         env:
           COSIGN_EXPERIMENTAL: 1
         run: |
-          cosign sign ghcr.io/fluxcd/flux-manifests:${{ steps.prep.outputs.version }}
-          cosign sign docker.io/fluxcd/flux-manifests:${{ steps.prep.outputs.version }}
+          cosign sign --yes ghcr.io/fluxcd/flux-manifests:${{ steps.prep.outputs.version }}
+          cosign sign --yes docker.io/fluxcd/flux-manifests:${{ steps.prep.outputs.version }}
       - name: Tag manifests
         run: |
           flux tag artifact oci://ghcr.io/fluxcd/flux-manifests:${{ steps.prep.outputs.version }} \

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor != 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Run FOSSA scan and upload build data
-        uses: fossa-contrib/fossa-action@6728dc6fe9a068c648d080c33829ffbe56565023 # v1
+        uses: fossa-contrib/fossa-action@6728dc6fe9a068c648d080c33829ffbe56565023 # v2.0.0
         with:
           # FOSSA Push-Only API Token
           fossa-api-key: 5ee8bf422db1471e0bcf2bcb289185de
@@ -31,11 +31,11 @@ jobs:
       security-events: write
     if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.actor != 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Setup Kustomize
-        uses: fluxcd/pkg//actions/kustomize@main
+        uses: fluxcd/pkg/actions/kustomize@main
       - name: Setup Go
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version: 1.20.x
       - name: Download modules and build manifests
@@ -50,7 +50,7 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@32dc499307d133bb5085bae78498c0ac2cf762d5 # v2
+        uses: github/codeql-action/upload-sarif@32dc499307d133bb5085bae78498c0ac2cf762d5 # v2.2.5
         with:
           sarif_file: snyk.sarif
 
@@ -61,16 +61,16 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Set up Go
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version: 1.20.x
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@32dc499307d133bb5085bae78498c0ac2cf762d5 # v2
+        uses: github/codeql-action/init@32dc499307d133bb5085bae78498c0ac2cf762d5 # v2.2.5
         with:
           languages: go
       - name: Autobuild
-        uses: github/codeql-action/autobuild@32dc499307d133bb5085bae78498c0ac2cf762d5 # v2
+        uses: github/codeql-action/autobuild@32dc499307d133bb5085bae78498c0ac2cf762d5 # v2.2.5
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@32dc499307d133bb5085bae78498c0ac2cf762d5 # v2
+        uses: github/codeql-action/analyze@32dc499307d133bb5085bae78498c0ac2cf762d5 # v2.2.5

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -18,9 +18,9 @@ jobs:
       pull-requests: write
     steps:
       - name: Check out code
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Setup Go
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version: 1.20.x
       - name: Update component versions
@@ -81,7 +81,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 # v4
+        uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 # v4.2.3
         with:
           token: ${{ secrets.BOT_GITHUB_TOKEN }}
           commit-message: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -65,6 +65,7 @@ signs:
     certificate: '${artifact}.pem'
     args:
       - sign-blob
+      - "--yes"
       - '--output-certificate=${certificate}'
       - '--output-signature=${signature}'
       - '${artifact}'
@@ -175,6 +176,7 @@ docker_signs:
       - COSIGN_EXPERIMENTAL=1
     args:
       - sign
+      - "--yes"
       - '${artifact}'
     artifacts: all
     output: true

--- a/cmd/flux/create_source_oci_test.go
+++ b/cmd/flux/create_source_oci_test.go
@@ -38,12 +38,12 @@ func TestCreateSourceOCI(t *testing.T) {
 		},
 		{
 			name:       "export manifest",
-			args:       "create source oci podinfo --url=oci://ghcr.io/stefanprodan/manifests/podinfo --tag=6.1.6 --interval 10m --export",
+			args:       "create source oci podinfo --url=oci://ghcr.io/stefanprodan/manifests/podinfo --tag=6.3.5 --interval 10m --export",
 			assertFunc: assertGoldenFile("./testdata/oci/export.golden"),
 		},
 		{
 			name:       "export manifest with secret",
-			args:       "create source oci podinfo --url=oci://ghcr.io/stefanprodan/manifests/podinfo --tag=6.1.6 --interval 10m --secret-ref=creds --export",
+			args:       "create source oci podinfo --url=oci://ghcr.io/stefanprodan/manifests/podinfo --tag=6.3.5 --interval 10m --secret-ref=creds --export",
 			assertFunc: assertGoldenFile("./testdata/oci/export_with_secret.golden"),
 		},
 	}

--- a/cmd/flux/helmrelease_test.go
+++ b/cmd/flux/helmrelease_test.go
@@ -37,7 +37,7 @@ func TestHelmReleaseFromGit(t *testing.T) {
 		tmpl       map[string]string
 	}{
 		{
-			"create source git thrfg --url=https://github.com/stefanprodan/podinfo --branch=main --tag=6.0.0",
+			"create source git thrfg --url=https://github.com/stefanprodan/podinfo --branch=main --tag=6.3.5",
 			"testdata/helmrelease/create_source_git.golden",
 			nil,
 		},

--- a/cmd/flux/kustomization_test.go
+++ b/cmd/flux/kustomization_test.go
@@ -37,7 +37,7 @@ func TestKustomizationFromGit(t *testing.T) {
 		tmpl       map[string]string
 	}{
 		{
-			"create source git tkfg --url=https://github.com/stefanprodan/podinfo --branch=main --tag=6.0.0",
+			"create source git tkfg --url=https://github.com/stefanprodan/podinfo --branch=main --tag=6.3.5",
 			"testdata/kustomization/create_source_git.golden",
 			nil,
 		},

--- a/cmd/flux/source_oci_test.go
+++ b/cmd/flux/source_oci_test.go
@@ -39,7 +39,7 @@ func TestSourceOCI(t *testing.T) {
 		tmpl       map[string]string
 	}{
 		{
-			"create source oci thrfg --url=oci://ghcr.io/stefanprodan/manifests/podinfo --tag=6.1.6 --interval 10m",
+			"create source oci thrfg --url=oci://ghcr.io/stefanprodan/manifests/podinfo --tag=6.3.5 --interval 10m",
 			"testdata/oci/create_source_oci.golden",
 			nil,
 		},

--- a/cmd/flux/testdata/helmrelease/create_helmrelease_from_git.golden
+++ b/cmd/flux/testdata/helmrelease/create_helmrelease_from_git.golden
@@ -3,4 +3,4 @@
 ✔ HelmRelease created
 ◎ waiting for HelmRelease reconciliation
 ✔ HelmRelease thrfg is ready
-✔ applied revision 6.0.0
+✔ applied revision 6.3.5

--- a/cmd/flux/testdata/helmrelease/create_source_git.golden
+++ b/cmd/flux/testdata/helmrelease/create_source_git.golden
@@ -3,4 +3,4 @@
 ✔ GitRepository source created
 ◎ waiting for GitRepository source reconciliation
 ✔ GitRepository source reconciliation completed
-✔ fetched revision: 6.0.0@sha1:627d5c4bb67b77185f37e31d734b085019ff2951
+✔ fetched revision: 6.3.5@sha1:67e2c98a60dc92283531412a9e604dd4bae005a9

--- a/cmd/flux/testdata/helmrelease/get_helmrelease_from_git.golden
+++ b/cmd/flux/testdata/helmrelease/get_helmrelease_from_git.golden
@@ -1,2 +1,2 @@
 NAME 	REVISION	SUSPENDED	READY	MESSAGE                          
-thrfg	6.0.0   	False    	True 	Release reconciliation succeeded	
+thrfg	6.3.5   	False    	True 	Release reconciliation succeeded	

--- a/cmd/flux/testdata/helmrelease/reconcile_helmrelease_from_git.golden
+++ b/cmd/flux/testdata/helmrelease/reconcile_helmrelease_from_git.golden
@@ -1,8 +1,8 @@
 ► annotating GitRepository thrfg in {{ .ns }} namespace
 ✔ GitRepository annotated
 ◎ waiting for GitRepository reconciliation
-✔ fetched revision 6.0.0@sha1:627d5c4bb67b77185f37e31d734b085019ff2951
+✔ fetched revision 6.3.5@sha1:67e2c98a60dc92283531412a9e604dd4bae005a9
 ► annotating HelmRelease thrfg in {{ .ns }} namespace
 ✔ HelmRelease annotated
 ◎ waiting for HelmRelease reconciliation
-✔ applied revision 6.0.0
+✔ applied revision 6.3.5

--- a/cmd/flux/testdata/helmrelease/resume_helmrelease_from_git.golden
+++ b/cmd/flux/testdata/helmrelease/resume_helmrelease_from_git.golden
@@ -2,4 +2,4 @@
 ✔ helmrelease resumed
 ◎ waiting for HelmRelease reconciliation
 ✔ HelmRelease reconciliation completed
-✔ applied revision 6.0.0
+✔ applied revision 6.3.5

--- a/cmd/flux/testdata/kustomization/create_kustomization_from_git.golden
+++ b/cmd/flux/testdata/kustomization/create_kustomization_from_git.golden
@@ -3,4 +3,4 @@
 ✔ Kustomization created
 ◎ waiting for Kustomization reconciliation
 ✔ Kustomization tkfg is ready
-✔ applied revision 6.0.0@sha1:627d5c4bb67b77185f37e31d734b085019ff2951
+✔ applied revision 6.3.5@sha1:67e2c98a60dc92283531412a9e604dd4bae005a9

--- a/cmd/flux/testdata/kustomization/create_source_git.golden
+++ b/cmd/flux/testdata/kustomization/create_source_git.golden
@@ -3,4 +3,4 @@
 ✔ GitRepository source created
 ◎ waiting for GitRepository source reconciliation
 ✔ GitRepository source reconciliation completed
-✔ fetched revision: 6.0.0@sha1:627d5c4bb67b77185f37e31d734b085019ff2951
+✔ fetched revision: 6.3.5@sha1:67e2c98a60dc92283531412a9e604dd4bae005a9

--- a/cmd/flux/testdata/kustomization/get_kustomization_from_git.golden
+++ b/cmd/flux/testdata/kustomization/get_kustomization_from_git.golden
@@ -1,2 +1,2 @@
 NAME	REVISION           	SUSPENDED	READY	MESSAGE                               
-tkfg	6.0.0@sha1:627d5c4b	False    	True 	Applied revision: 6.0.0@sha1:627d5c4b	
+tkfg	6.3.5@sha1:67e2c98a	False    	True 	Applied revision: 6.3.5@sha1:67e2c98a	

--- a/cmd/flux/testdata/kustomization/reconcile_kustomization_from_git.golden
+++ b/cmd/flux/testdata/kustomization/reconcile_kustomization_from_git.golden
@@ -1,8 +1,8 @@
 ► annotating GitRepository tkfg in {{ .ns }} namespace
 ✔ GitRepository annotated
 ◎ waiting for GitRepository reconciliation
-✔ fetched revision 6.0.0@sha1:627d5c4bb67b77185f37e31d734b085019ff2951
+✔ fetched revision 6.3.5@sha1:67e2c98a60dc92283531412a9e604dd4bae005a9
 ► annotating Kustomization tkfg in {{ .ns }} namespace
 ✔ Kustomization annotated
 ◎ waiting for Kustomization reconciliation
-✔ applied revision 6.0.0@sha1:627d5c4bb67b77185f37e31d734b085019ff2951
+✔ applied revision 6.3.5@sha1:67e2c98a60dc92283531412a9e604dd4bae005a9

--- a/cmd/flux/testdata/kustomization/resume_kustomization_from_git.golden
+++ b/cmd/flux/testdata/kustomization/resume_kustomization_from_git.golden
@@ -2,4 +2,4 @@
 ✔ kustomization resumed
 ◎ waiting for Kustomization reconciliation
 ✔ Kustomization reconciliation completed
-✔ applied revision 6.0.0@sha1:627d5c4bb67b77185f37e31d734b085019ff2951
+✔ applied revision 6.3.5@sha1:67e2c98a60dc92283531412a9e604dd4bae005a9

--- a/cmd/flux/testdata/oci/create_source_oci.golden
+++ b/cmd/flux/testdata/oci/create_source_oci.golden
@@ -2,4 +2,4 @@
 ✔ OCIRepository created
 ◎ waiting for OCIRepository reconciliation
 ✔ OCIRepository reconciliation completed
-✔ fetched revision: 6.1.6@sha256:dbdb109711ffb3be77504d2670dbe13c24dd63d8d7f1fb489d350e5bfe930dd3
+✔ fetched revision: 6.3.5@sha256:6c959c51ccbb952e5fe4737563338a0aaf975675dcf812912cf09e5463181871

--- a/cmd/flux/testdata/oci/export.golden
+++ b/cmd/flux/testdata/oci/export.golden
@@ -7,6 +7,6 @@ metadata:
 spec:
   interval: 10m0s
   ref:
-    tag: 6.1.6
+    tag: 6.3.5
   url: oci://ghcr.io/stefanprodan/manifests/podinfo
 

--- a/cmd/flux/testdata/oci/export_with_secret.golden
+++ b/cmd/flux/testdata/oci/export_with_secret.golden
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 10m0s
   ref:
-    tag: 6.1.6
+    tag: 6.3.5
   secretRef:
     name: creds
   url: oci://ghcr.io/stefanprodan/manifests/podinfo

--- a/cmd/flux/testdata/oci/get_oci.golden
+++ b/cmd/flux/testdata/oci/get_oci.golden
@@ -1,2 +1,2 @@
 NAME 	REVISION             	SUSPENDED	READY	MESSAGE                                            
-thrfg	6.1.6@sha256:dbdb1097	False    	True 	stored artifact for digest '6.1.6@sha256:dbdb1097'	
+thrfg	6.3.5@sha256:6c959c51	False    	True 	stored artifact for digest '6.3.5@sha256:6c959c51'	

--- a/cmd/flux/testdata/oci/reconcile_oci.golden
+++ b/cmd/flux/testdata/oci/reconcile_oci.golden
@@ -1,4 +1,4 @@
 ► annotating OCIRepository thrfg in {{ .ns }} namespace
 ✔ OCIRepository annotated
 ◎ waiting for OCIRepository reconciliation
-✔ fetched revision 6.1.6@sha256:dbdb109711ffb3be77504d2670dbe13c24dd63d8d7f1fb489d350e5bfe930dd3
+✔ fetched revision 6.3.5@sha256:6c959c51ccbb952e5fe4737563338a0aaf975675dcf812912cf09e5463181871

--- a/cmd/flux/testdata/oci/resume_oci.golden
+++ b/cmd/flux/testdata/oci/resume_oci.golden
@@ -2,4 +2,4 @@
 ✔ source oci resumed
 ◎ waiting for OCIRepository reconciliation
 ✔ OCIRepository reconciliation completed
-✔ fetched revision 6.1.6@sha256:dbdb109711ffb3be77504d2670dbe13c24dd63d8d7f1fb489d350e5bfe930dd3
+✔ fetched revision 6.3.5@sha256:6c959c51ccbb952e5fe4737563338a0aaf975675dcf812912cf09e5463181871

--- a/cmd/flux/testdata/trace/deployment.golden
+++ b/cmd/flux/testdata/trace/deployment.golden
@@ -5,17 +5,17 @@ Status:         Managed by Flux
 ---
 HelmRelease:    podinfo
 Namespace:      {{ .ns }}
-Revision:       6.0.0
+Revision:       6.3.5
 Status:         Last reconciled at {{ .helmReleaseLastReconcile }}
 Message:        Release reconciliation succeeded
 ---
 HelmChart:      podinfo-podinfo
 Namespace:      {{ .fluxns }}
 Chart:          podinfo
-Version:        6.0.0
-Revision:       6.0.0
+Version:        6.3.5
+Revision:       6.3.5
 Status:         Last reconciled at {{ .helmChartLastReconcile }}
-Message:        Fetched revision: 6.0.0
+Message:        Fetched revision: 6.3.5
 ---
 HelmRepository: podinfo
 Namespace:      {{ .fluxns }}

--- a/cmd/flux/testdata/trace/deployment.yaml
+++ b/cmd/flux/testdata/trace/deployment.yaml
@@ -59,8 +59,8 @@ status:
     status: "True"
     type: Ready
   helmChart: {{ .fluxns }}/podinfo-podinfo
-  lastAppliedRevision: 6.0.0
-  lastAttemptedRevision: 6.0.0
+  lastAppliedRevision: 6.3.5
+  lastAttemptedRevision: 6.3.5
   lastAttemptedValuesChecksum: c31db75d05b7515eba2eef47bd71038c74b2e531
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta1
@@ -73,18 +73,18 @@ spec:
   sourceRef:
     kind: HelmRepository
     name: podinfo
-  version: 6.0.0
+  version: 6.3.5
   interval: 5m
 status:
   artifact:
     checksum: cf13ba96773d9a879cd052c86e73199b3f96c854
     lastUpdateTime: "2021-08-01T04:42:55Z"
-    revision: 6.0.0
+    revision: 6.3.5
     path: "example"
     url: "example"
   conditions:
   - lastTransitionTime: "2021-07-16T15:32:09Z"
-    message: 'Fetched revision: 6.0.0'
+    message: 'Fetched revision: 6.3.5'
     reason: ChartPullSucceeded
     status: "True"
     type: Ready

--- a/cmd/flux/testdata/trace/helmrelease-oci.yaml
+++ b/cmd/flux/testdata/trace/helmrelease-oci.yaml
@@ -34,8 +34,8 @@ status:
     status: "True"
     type: Ready
   helmChart: {{ .fluxns }}/podinfo-podinfo
-  lastAppliedRevision: 6.0.0
-  lastAttemptedRevision: 6.0.0
+  lastAppliedRevision: 6.3.5
+  lastAttemptedRevision: 6.3.5
   lastAttemptedValuesChecksum: c31db75d05b7515eba2eef47bd71038c74b2e531
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta2

--- a/cmd/flux/testdata/trace/helmrelease.yaml
+++ b/cmd/flux/testdata/trace/helmrelease.yaml
@@ -34,8 +34,8 @@ status:
     status: "True"
     type: Ready
   helmChart: {{ .fluxns }}/podinfo-podinfo
-  lastAppliedRevision: 6.0.0
-  lastAttemptedRevision: 6.0.0
+  lastAppliedRevision: 6.3.5
+  lastAttemptedRevision: 6.3.5
   lastAttemptedValuesChecksum: c31db75d05b7515eba2eef47bd71038c74b2e531
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta1


### PR DESCRIPTION
Part of #3663. Plus as a bonus:

- All the things required to keep Dependabot injecting exact versions for SHA references.
- Update of Kubernetes versions which seemed outdated.