### PR TITLE
feat: add reconcile source chart command

### DIFF
--- a/cmd/flux/reconcile_helmrelease.go
+++ b/cmd/flux/reconcile_helmrelease.go
@@ -17,11 +17,12 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/types"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
-	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	sourcev1b2 "github.com/fluxcd/source-controller/api/v1beta2"
 )
 
@@ -63,28 +64,20 @@ func (obj helmReleaseAdapter) reconcileSource() bool {
 	return rhrArgs.syncHrWithSource
 }
 
-func (obj helmReleaseAdapter) getSource() (reconcileCommand, types.NamespacedName) {
-	var cmd reconcileCommand
-	switch obj.Spec.Chart.Spec.SourceRef.Kind {
-	case sourcev1b2.HelmRepositoryKind:
-		cmd = reconcileCommand{
-			apiType: helmRepositoryType,
-			object:  helmRepositoryAdapter{&sourcev1b2.HelmRepository{}},
-		}
-	case sourcev1.GitRepositoryKind:
-		cmd = reconcileCommand{
-			apiType: gitRepositoryType,
-			object:  gitRepositoryAdapter{&sourcev1.GitRepository{}},
-		}
-	case sourcev1b2.BucketKind:
-		cmd = reconcileCommand{
-			apiType: bucketType,
-			object:  bucketAdapter{&sourcev1b2.Bucket{}},
-		}
+func (obj helmReleaseAdapter) getSource() (reconcileSource, types.NamespacedName) {
+	cmd := reconcileWithSourceCommand{
+		apiType: helmChartType,
+		object:  helmChartAdapter{&sourcev1b2.HelmChart{}},
+		force:   true,
+	}
+
+	ns := obj.Spec.Chart.Spec.SourceRef.Namespace
+	if ns == "" {
+		ns = obj.Namespace
 	}
 
 	return cmd, types.NamespacedName{
-		Name:      obj.Spec.Chart.Spec.SourceRef.Name,
-		Namespace: obj.Spec.Chart.Spec.SourceRef.Namespace,
+		Name:      fmt.Sprintf("%s-%s", obj.Namespace, obj.Name),
+		Namespace: ns,
 	}
 }

--- a/cmd/flux/reconcile_kustomization.go
+++ b/cmd/flux/reconcile_kustomization.go
@@ -63,7 +63,7 @@ func (obj kustomizationAdapter) reconcileSource() bool {
 	return rksArgs.syncKsWithSource
 }
 
-func (obj kustomizationAdapter) getSource() (reconcileCommand, types.NamespacedName) {
+func (obj kustomizationAdapter) getSource() (reconcileSource, types.NamespacedName) {
 	var cmd reconcileCommand
 	switch obj.Spec.SourceRef.Kind {
 	case sourcev1b2.OCIRepositoryKind:

--- a/cmd/flux/reconcile_source_chart.go
+++ b/cmd/flux/reconcile_source_chart.go
@@ -18,27 +18,70 @@ package main
 
 import (
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/types"
 
-	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
+	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	sourcev1b2 "github.com/fluxcd/source-controller/api/v1beta2"
 )
 
 var reconcileSourceHelmChartCmd = &cobra.Command{
 	Use:   "chart [name]",
 	Short: "Reconcile a HelmChart source",
-	Long:  `The reconcile source command triggers a reconciliation of a HelmCHart resource and waits for it to finish.`,
+	Long:  `The reconcile source command triggers a reconciliation of a HelmChart resource and waits for it to finish.`,
 	Example: `  # Trigger a reconciliation for an existing source
-  flux reconcile source chart podinfo`,
-	ValidArgsFunction: resourceNamesCompletionFunc(sourcev1.GroupVersion.WithKind(sourcev1.HelmChartKind)),
-	RunE: reconcileCommand{
+  flux reconcile source chart podinfo
+ 
+  # Trigger a reconciliation of the HelmCharts's source and apply changes
+  flux reconcile helmchart podinfo --with-source`,
+	ValidArgsFunction: resourceNamesCompletionFunc(helmv2.GroupVersion.WithKind(helmv2.HelmReleaseKind)),
+	RunE: reconcileWithSourceCommand{
 		apiType: helmChartType,
-		object:  helmChartAdapter{&sourcev1.HelmChart{}},
+		object:  helmChartAdapter{&sourcev1b2.HelmChart{}},
 	}.run,
 }
 
 func init() {
+	reconcileSourceHelmChartCmd.Flags().BoolVar(&rhcArgs.syncHrWithSource, "with-source", false, "reconcile HelmChart source")
 	reconcileSourceCmd.AddCommand(reconcileSourceHelmChartCmd)
 }
 
 func (obj helmChartAdapter) lastHandledReconcileRequest() string {
 	return obj.Status.GetLastHandledReconcileRequest()
+}
+
+type reconcileHelmChartFlags struct {
+	syncHrWithSource bool
+}
+
+var rhcArgs reconcileHelmChartFlags
+
+func (obj helmChartAdapter) reconcileSource() bool {
+	return rhcArgs.syncHrWithSource
+}
+
+func (obj helmChartAdapter) getSource() (reconcileSource, types.NamespacedName) {
+	var cmd reconcileCommand
+	switch obj.Spec.SourceRef.Kind {
+	case sourcev1b2.HelmRepositoryKind:
+		cmd = reconcileCommand{
+			apiType: helmRepositoryType,
+			object:  helmRepositoryAdapter{&sourcev1b2.HelmRepository{}},
+		}
+	case sourcev1.GitRepositoryKind:
+		cmd = reconcileCommand{
+			apiType: gitRepositoryType,
+			object:  gitRepositoryAdapter{&sourcev1.GitRepository{}},
+		}
+	case sourcev1b2.BucketKind:
+		cmd = reconcileCommand{
+			apiType: bucketType,
+			object:  bucketAdapter{&sourcev1b2.Bucket{}},
+		}
+	}
+
+	return cmd, types.NamespacedName{
+		Name:      obj.Spec.SourceRef.Name,
+		Namespace: obj.Namespace,
+	}
 }

--- a/cmd/flux/reconcile_source_chart.go
+++ b/cmd/flux/reconcile_source_chart.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2020 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+
+	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
+)
+
+var reconcileSourceHelmChartCmd = &cobra.Command{
+	Use:   "chart [name]",
+	Short: "Reconcile a HelmChart source",
+	Long:  `The reconcile source command triggers a reconciliation of a HelmCHart resource and waits for it to finish.`,
+	Example: `  # Trigger a reconciliation for an existing source
+  flux reconcile source chart podinfo`,
+	ValidArgsFunction: resourceNamesCompletionFunc(sourcev1.GroupVersion.WithKind(sourcev1.HelmChartKind)),
+	RunE: reconcileCommand{
+		apiType: helmChartType,
+		object:  helmChartAdapter{&sourcev1.HelmChart{}},
+	}.run,
+}
+
+func init() {
+	reconcileSourceCmd.AddCommand(reconcileSourceHelmChartCmd)
+}
+
+func (obj helmChartAdapter) lastHandledReconcileRequest() string {
+	return obj.Status.GetLastHandledReconcileRequest()
+}

--- a/cmd/flux/reconcile_with_source.go
+++ b/cmd/flux/reconcile_with_source.go
@@ -18,12 +18,17 @@ type reconcileWithSource interface {
 	adapter
 	reconcilable
 	reconcileSource() bool
-	getSource() (reconcileCommand, types.NamespacedName)
+	getSource() (reconcileSource, types.NamespacedName)
+}
+
+type reconcileSource interface {
+	run(cmd *cobra.Command, args []string) error
 }
 
 type reconcileWithSourceCommand struct {
 	apiType
 	object reconcileWithSource
+	force  bool
 }
 
 func (reconcile reconcileWithSourceCommand) run(cmd *cobra.Command, args []string) error {
@@ -54,7 +59,7 @@ func (reconcile reconcileWithSourceCommand) run(cmd *cobra.Command, args []strin
 		return fmt.Errorf("resource is suspended")
 	}
 
-	if reconcile.object.reconcileSource() {
+	if reconcile.object.reconcileSource() || reconcile.force {
 		reconcileCmd, nsName := reconcile.object.getSource()
 		nsCopy := *kubeconfigArgs.Namespace
 		if nsName.Namespace != "" {

--- a/cmd/flux/testdata/helmrelease/reconcile_helmrelease_from_git.golden
+++ b/cmd/flux/testdata/helmrelease/reconcile_helmrelease_from_git.golden
@@ -2,6 +2,10 @@
 ✔ GitRepository annotated
 ◎ waiting for GitRepository reconciliation
 ✔ fetched revision 6.3.5@sha1:67e2c98a60dc92283531412a9e604dd4bae005a9
+► annotating HelmChart {{ .ns }}-thrfg in {{ .ns }} namespace
+✔ HelmChart annotated
+◎ waiting for HelmChart reconciliation
+✔ fetched revision 6.3.5
 ► annotating HelmRelease thrfg in {{ .ns }} namespace
 ✔ HelmRelease annotated
 ◎ waiting for HelmRelease reconciliation


### PR DESCRIPTION
## Current situation
Reconciling helm charts which are configured as semver are not reconciled via reconcile hr. 
This is because the HelmChart does not get annotated.

More details are found here:
* https://github.com/fluxcd/flux2/pull/3660
* https://github.com/fluxcd/flux2/issues/3656

## Proposal
This pr adds a new command `reconcile source chart` which also supports the --source flag for the referencing repository.
`reconcile hr --with-source` now supports annotating the entire source tree for a HelmRelease: Repository => Chart => Release.

This pr supersedes #3660.
Fixes #3656