### PR TITLE
Disable drift detection for kube-prometheus-stack webhooks

### DIFF
--- a/manifests/monitoring/kube-prometheus-stack/release.yaml
+++ b/manifests/monitoring/kube-prometheus-stack/release.yaml
@@ -6,7 +6,7 @@ spec:
   interval: 5m
   chart:
     spec:
-      version: "41.x"
+      version: "45.x"
       chart: kube-prometheus-stack
       sourceRef:
         kind: HelmRepository
@@ -31,3 +31,21 @@ spec:
         podMonitorSelector:
           matchLabels:
             app.kubernetes.io/component: monitoring
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              # Ignore these objects from Flux diff as they are mutated from chart hooks
+              kind: (ValidatingWebhookConfiguration|MutatingWebhookConfiguration)
+              name: kube-prometheus-stack-admission
+            patch: |
+              - op: add
+                path: /metadata/annotations/helm.toolkit.fluxcd.io~1driftDetection
+                value: disabled
+          - target:
+              # Ignore these objects from Flux diff as they are mutated at apply time but not at dry-run time
+              kind: PrometheusRule
+            patch: |
+              - op: add
+                path: /metadata/annotations/helm.toolkit.fluxcd.io~1driftDetection
+                value: disabled


### PR DESCRIPTION
Changes to the kube-prometheus-stack HelmRelease:
- update the chart to v45.x
- Disable [Flux drift detection](https://fluxcd.io/flux/cheatsheets/bootstrap/#enable-helm-drift-detection) for webhooks and rules