### PR TITLE
fix: Avoid printing an extra newline when exporting resources

### DIFF
--- a/cmd/flux/export.go
+++ b/cmd/flux/export.go
@@ -122,5 +122,6 @@ func printExport(export interface{}) error {
 func resourceToString(data []byte) string {
 	data = bytes.Replace(data, []byte("  creationTimestamp: null\n"), []byte(""), 1)
 	data = bytes.Replace(data, []byte("status: {}\n"), []byte(""), 1)
+	data = bytes.TrimSpace(data)
 	return string(data)
 }

--- a/cmd/flux/testdata/create_source_git/export.golden
+++ b/cmd/flux/testdata/create_source_git/export.golden
@@ -12,4 +12,3 @@ spec:
   ref:
     branch: master
   url: https://github.com/stefanprodan/podinfo
-

--- a/cmd/flux/testdata/create_source_helm/https.golden
+++ b/cmd/flux/testdata/create_source_helm/https.golden
@@ -7,4 +7,3 @@ metadata:
 spec:
   interval: 5m0s
   url: https://stefanprodan.github.io/charts/podinfo
-

--- a/cmd/flux/testdata/create_source_helm/oci-with-secret.golden
+++ b/cmd/flux/testdata/create_source_helm/oci-with-secret.golden
@@ -10,4 +10,3 @@ spec:
     name: creds
   type: oci
   url: oci://ghcr.io/stefanprodan/charts/podinfo
-

--- a/cmd/flux/testdata/create_source_helm/oci.golden
+++ b/cmd/flux/testdata/create_source_helm/oci.golden
@@ -8,4 +8,3 @@ spec:
   interval: 5m0s
   type: oci
   url: oci://ghcr.io/stefanprodan/charts/podinfo
-

--- a/cmd/flux/testdata/export/alert.yaml
+++ b/cmd/flux/testdata/export/alert.yaml
@@ -14,4 +14,3 @@ spec:
   providerRef:
     name: slack
   summary: Slacktest Notification
-

--- a/cmd/flux/testdata/export/bucket.yaml
+++ b/cmd/flux/testdata/export/bucket.yaml
@@ -11,4 +11,3 @@ spec:
   provider: aws
   region: us-east-1
   timeout: 30s
-

--- a/cmd/flux/testdata/export/git-repo.yaml
+++ b/cmd/flux/testdata/export/git-repo.yaml
@@ -13,4 +13,3 @@ spec:
     name: flux-system
   timeout: 1m0s
   url: ssh://git@github.com/example/repo
-

--- a/cmd/flux/testdata/export/helm-release.yaml
+++ b/cmd/flux/testdata/export/helm-release.yaml
@@ -15,4 +15,3 @@ spec:
         namespace: {{ .fluxns }}
       version: '*'
   interval: 5m0s
-

--- a/cmd/flux/testdata/export/helm-repo.yaml
+++ b/cmd/flux/testdata/export/helm-repo.yaml
@@ -9,4 +9,3 @@ spec:
   provider: generic
   timeout: 1m0s
   url: https://stefanprodan.github.io/podinfo
-

--- a/cmd/flux/testdata/export/image-policy.yaml
+++ b/cmd/flux/testdata/export/image-policy.yaml
@@ -10,4 +10,3 @@ spec:
   policy:
     semver:
       range: 5.0.x
-

--- a/cmd/flux/testdata/export/image-repo.yaml
+++ b/cmd/flux/testdata/export/image-repo.yaml
@@ -10,4 +10,3 @@ spec:
   image: ghcr.io/test/podinfo
   interval: 1m0s
   provider: generic
-

--- a/cmd/flux/testdata/export/image-update.yaml
+++ b/cmd/flux/testdata/export/image-update.yaml
@@ -17,4 +17,3 @@ spec:
   update:
     path: ./clusters/my-cluster
     strategy: Setters
-

--- a/cmd/flux/testdata/export/ks.yaml
+++ b/cmd/flux/testdata/export/ks.yaml
@@ -11,4 +11,3 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
-

--- a/cmd/flux/testdata/export/provider.yaml
+++ b/cmd/flux/testdata/export/provider.yaml
@@ -8,4 +8,3 @@ spec:
   address: https://hooks.slack.com/services/mock
   channel: A channel with spacess
   type: slack
-

--- a/cmd/flux/testdata/export/receiver.yaml
+++ b/cmd/flux/testdata/export/receiver.yaml
@@ -15,4 +15,3 @@ spec:
   secretRef:
     name: webhook-token
   type: github
-

--- a/cmd/flux/testdata/oci/export.golden
+++ b/cmd/flux/testdata/oci/export.golden
@@ -9,4 +9,3 @@ spec:
   ref:
     tag: 6.3.5
   url: oci://ghcr.io/stefanprodan/manifests/podinfo
-

--- a/cmd/flux/testdata/oci/export_with_secret.golden
+++ b/cmd/flux/testdata/oci/export_with_secret.golden
@@ -11,4 +11,3 @@ spec:
   secretRef:
     name: creds
   url: oci://ghcr.io/stefanprodan/manifests/podinfo
-


### PR DESCRIPTION
Closes #3593 

Following Hidde's hint, the change in this PR should prevent extra newlines from being printed. This affects both the `flux export ..` command and the `--export` flag used in other Flux commands.

Also tested with
```
flux export .. >> export.yaml
flux export .. >> export.yaml
```
and it no longer produces a newline between resources in the same file.
