### PR TITLE
add a preview note for all non-bootstrap commands

### DIFF
--- a/cmd/flux/build.go
+++ b/cmd/flux/build.go
@@ -23,7 +23,7 @@ import (
 var buildCmd = &cobra.Command{
 	Use:   "build",
 	Short: "Build a flux resource",
-	Long:  "The build command is used to build flux resources.",
+	Long:  `The build command is used to build flux resources.`,
 }
 
 func init() {

--- a/cmd/flux/build_artifact.go
+++ b/cmd/flux/build_artifact.go
@@ -33,7 +33,8 @@ import (
 var buildArtifactCmd = &cobra.Command{
 	Use:   "artifact",
 	Short: "Build artifact",
-	Long:  `The build artifact command creates a tgz file with the manifests from the given directory or a single manifest file.`,
+	Long: withPreviewNote(`The build artifact command creates a tgz file with the manifests
+from the given directory or a single manifest file.`),
 	Example: `  # Build the given manifests directory into an artifact
   flux build artifact --path ./path/to/local/manifests --output ./path/to/artifact.tgz
 

--- a/cmd/flux/check.go
+++ b/cmd/flux/check.go
@@ -39,8 +39,8 @@ import (
 var checkCmd = &cobra.Command{
 	Use:   "check",
 	Short: "Check requirements and installation",
-	Long: `The check command will perform a series of checks to validate that
-the local environment is configured correctly and if the installed components are healthy.`,
+	Long: withPreviewNote(`The check command will perform a series of checks to validate that
+the local environment is configured correctly and if the installed components are healthy.`),
 	Example: `  # Run pre-installation checks
   flux check --pre
 

--- a/cmd/flux/completion.go
+++ b/cmd/flux/completion.go
@@ -31,7 +31,7 @@ import (
 var completionCmd = &cobra.Command{
 	Use:   "completion",
 	Short: "Generates completion scripts for various shells",
-	Long:  "The completion sub-command generates completion scripts for various shells",
+	Long:  `The completion sub-command generates completion scripts for various shells.`,
 }
 
 func init() {

--- a/cmd/flux/completion_bash.go
+++ b/cmd/flux/completion_bash.go
@@ -25,6 +25,7 @@ import (
 var completionBashCmd = &cobra.Command{
 	Use:   "bash",
 	Short: "Generates bash completion scripts",
+	Long:  `The completion sub-command generates completion scripts for bash.`,
 	Example: `To load completion run
 
 . <(flux completion bash)

--- a/cmd/flux/completion_fish.go
+++ b/cmd/flux/completion_fish.go
@@ -25,6 +25,7 @@ import (
 var completionFishCmd = &cobra.Command{
 	Use:   "fish",
 	Short: "Generates fish completion scripts",
+	Long:  `The completion sub-command generates completion scripts for fish.`,
 	Example: `To configure your fish shell to load completions for each session write this script to your completions dir:
 
 flux completion fish > ~/.config/fish/completions/flux.fish

--- a/cmd/flux/completion_powershell.go
+++ b/cmd/flux/completion_powershell.go
@@ -25,6 +25,7 @@ import (
 var completionPowerShellCmd = &cobra.Command{
 	Use:   "powershell",
 	Short: "Generates powershell completion scripts",
+	Long:  `The completion sub-command generates completion scripts for powershell.`,
 	Example: `To load completion run
 
 . <(flux completion powershell)

--- a/cmd/flux/completion_zsh.go
+++ b/cmd/flux/completion_zsh.go
@@ -26,6 +26,7 @@ import (
 var completionZshCmd = &cobra.Command{
 	Use:   "zsh",
 	Short: "Generates zsh completion scripts",
+	Long:  `The completion sub-command generates completion scripts for zsh.`,
 	Example: `To load completion run
 
 . <(flux completion zsh)

--- a/cmd/flux/create.go
+++ b/cmd/flux/create.go
@@ -36,7 +36,7 @@ import (
 var createCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create or update sources and resources",
-	Long:  "The create sub-commands generate sources and resources.",
+	Long:  `The create sub-commands generate sources and resources.`,
 }
 
 type createFlags struct {

--- a/cmd/flux/create_alert.go
+++ b/cmd/flux/create_alert.go
@@ -38,7 +38,7 @@ import (
 var createAlertCmd = &cobra.Command{
 	Use:   "alert [name]",
 	Short: "Create or update a Alert resource",
-	Long:  "The create alert command generates a Alert resource.",
+	Long:  withPreviewNote(`The create alert command generates a Alert resource.`),
 	Example: `  # Create an Alert for kustomization events
   flux create alert \
   --event-severity info \

--- a/cmd/flux/create_alertprovider.go
+++ b/cmd/flux/create_alertprovider.go
@@ -37,7 +37,7 @@ import (
 var createAlertProviderCmd = &cobra.Command{
 	Use:   "alert-provider [name]",
 	Short: "Create or update a Provider resource",
-	Long:  "The create alert-provider command generates a Provider resource.",
+	Long:  withPreviewNote(`The create alert-provider command generates a Provider resource.`),
 	Example: `  # Create a Provider for a Slack channel
   flux create alert-provider slack \
   --type slack \

--- a/cmd/flux/create_helmrelease.go
+++ b/cmd/flux/create_helmrelease.go
@@ -46,7 +46,7 @@ var createHelmReleaseCmd = &cobra.Command{
 	Use:     "helmrelease [name]",
 	Aliases: []string{"hr"},
 	Short:   "Create or update a HelmRelease resource",
-	Long:    "The helmrelease create command generates a HelmRelease resource for a given HelmRepository source.",
+	Long:    withPreviewNote(`The helmrelease create command generates a HelmRelease resource for a given HelmRepository source.`),
 	Example: `  # Create a HelmRelease with a chart from a HelmRepository source
   flux create hr podinfo \
     --interval=10m \

--- a/cmd/flux/create_image.go
+++ b/cmd/flux/create_image.go
@@ -20,14 +20,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const createImageLong = `The create image sub-commands work with image automation objects; that is,
-object controlling updates to git based on e.g., new container images
-being available.`
-
 var createImageCmd = &cobra.Command{
 	Use:   "image",
 	Short: "Create or update resources dealing with image automation",
-	Long:  createImageLong,
+	Long: `The create image sub-commands work with image automation objects;
+that is, object controlling updates to git based on e.g., new container images
+being available.`,
 }
 
 func init() {

--- a/cmd/flux/create_image_policy.go
+++ b/cmd/flux/create_image_policy.go
@@ -34,12 +34,12 @@ import (
 var createImagePolicyCmd = &cobra.Command{
 	Use:   "policy [name]",
 	Short: "Create or update an ImagePolicy object",
-	Long: `The create image policy command generates an ImagePolicy resource.
+	Long: withPreviewNote(`The create image policy command generates an ImagePolicy resource.
 An ImagePolicy object calculates a "latest image" given an image
 repository and a policy, e.g., semver.
 
 The image that sorts highest according to the policy is recorded in
-the status of the object.`,
+the status of the object.`),
 	Example: `  # Create an ImagePolicy to select the latest stable release
   flux create image policy podinfo \
     --image-ref=podinfo \

--- a/cmd/flux/create_image_repository.go
+++ b/cmd/flux/create_image_repository.go
@@ -32,8 +32,8 @@ import (
 var createImageRepositoryCmd = &cobra.Command{
 	Use:   "repository [name]",
 	Short: "Create or update an ImageRepository object",
-	Long: `The create image repository command generates an ImageRepository resource.
-An ImageRepository object specifies an image repository to scan.`,
+	Long: withPreviewNote(`The create image repository command generates an ImageRepository resource.
+An ImageRepository object specifies an image repository to scan.`),
 	Example: `  # Create an ImageRepository object to scan the alpine image repository:
   flux create image repository alpine-repo --image alpine --interval 20m
 

--- a/cmd/flux/create_image_update.go
+++ b/cmd/flux/create_image_update.go
@@ -29,9 +29,9 @@ import (
 var createImageUpdateCmd = &cobra.Command{
 	Use:   "update [name]",
 	Short: "Create or update an ImageUpdateAutomation object",
-	Long: `The create image update command generates an ImageUpdateAutomation resource.
+	Long: withPreviewNote(`The create image update command generates an ImageUpdateAutomation resource.
 An ImageUpdateAutomation object specifies an automated update to images
-mentioned in YAMLs in a git repository.`,
+mentioned in YAMLs in a git repository.`),
 	Example: `  # Configure image updates for the main repository created by flux bootstrap
   flux create image update flux-system \
     --git-repo-ref=flux-system \

--- a/cmd/flux/create_kustomization.go
+++ b/cmd/flux/create_kustomization.go
@@ -42,7 +42,7 @@ var createKsCmd = &cobra.Command{
 	Use:     "kustomization [name]",
 	Aliases: []string{"ks"},
 	Short:   "Create or update a Kustomization resource",
-	Long:    "The create command generates a Kustomization resource for a given source.",
+	Long:    `The create command generates a Kustomization resource for a given source.`,
 	Example: `  # Create a Kustomization resource from a source at a given path
   flux create kustomization kyverno \
     --source=GitRepository/kyverno \

--- a/cmd/flux/create_receiver.go
+++ b/cmd/flux/create_receiver.go
@@ -37,7 +37,7 @@ import (
 var createReceiverCmd = &cobra.Command{
 	Use:   "receiver [name]",
 	Short: "Create or update a Receiver resource",
-	Long:  "The create receiver command generates a Receiver resource.",
+	Long:  `The create receiver command generates a Receiver resource.`,
 	Example: `  # Create a Receiver
   flux create receiver github-receiver \
 	--type github \

--- a/cmd/flux/create_secret.go
+++ b/cmd/flux/create_secret.go
@@ -29,7 +29,7 @@ import (
 var createSecretCmd = &cobra.Command{
 	Use:   "secret",
 	Short: "Create or update Kubernetes secrets",
-	Long:  "The create source sub-commands generate Kubernetes secrets specific to Flux.",
+	Long:  `The create source sub-commands generate Kubernetes secrets specific to Flux.`,
 }
 
 func init() {

--- a/cmd/flux/create_secret_git.go
+++ b/cmd/flux/create_secret_git.go
@@ -36,8 +36,10 @@ var createSecretGitCmd = &cobra.Command{
 	Use:   "git [name]",
 	Short: "Create or update a Kubernetes secret for Git authentication",
 	Long: `The create secret git command generates a Kubernetes secret with Git credentials.
-For Git over SSH, the host and SSH keys are automatically generated and stored in the secret.
-For Git over HTTP/S, the provided basic authentication credentials or bearer authentication token are stored in the secret.`,
+For Git over SSH, the host and SSH keys are automatically generated and stored
+in the secret.
+For Git over HTTP/S, the provided basic authentication credentials or bearer
+authentication token are stored in the secret.`,
 	Example: `  # Create a Git SSH authentication secret using an ECDSA P-521 curve public key
 
   flux create secret git podinfo-auth \

--- a/cmd/flux/create_secret_helm.go
+++ b/cmd/flux/create_secret_helm.go
@@ -32,7 +32,7 @@ import (
 var createSecretHelmCmd = &cobra.Command{
 	Use:   "helm [name]",
 	Short: "Create or update a Kubernetes secret for Helm repository authentication",
-	Long:  `The create secret helm command generates a Kubernetes secret with basic authentication credentials.`,
+	Long:  withPreviewNote(`The create secret helm command generates a Kubernetes secret with basic authentication credentials.`),
 	Example: ` # Create a Helm authentication secret on disk and encrypt it with Mozilla SOPS
   flux create secret helm repo-auth \
     --namespace=my-namespace \

--- a/cmd/flux/create_secret_oci.go
+++ b/cmd/flux/create_secret_oci.go
@@ -31,7 +31,7 @@ import (
 var createSecretOCICmd = &cobra.Command{
 	Use:   "oci [name]",
 	Short: "Create or update a Kubernetes image pull secret",
-	Long:  `The create secret oci command generates a Kubernetes secret that can be used for OCIRepository authentication`,
+	Long:  withPreviewNote(`The create secret oci command generates a Kubernetes secret that can be used for OCIRepository authentication`),
 	Example: `  # Create an OCI authentication secret on disk and encrypt it with Mozilla SOPS
   flux create secret oci podinfo-auth \
     --url=ghcr.io \

--- a/cmd/flux/create_secret_tls.go
+++ b/cmd/flux/create_secret_tls.go
@@ -33,7 +33,7 @@ import (
 var createSecretTLSCmd = &cobra.Command{
 	Use:   "tls [name]",
 	Short: "Create or update a Kubernetes secret with TLS certificates",
-	Long:  `The create secret tls command generates a Kubernetes secret with certificates for use with TLS.`,
+	Long:  withPreviewNote(`The create secret tls command generates a Kubernetes secret with certificates for use with TLS.`),
 	Example: ` # Create a TLS secret on disk and encrypt it with Mozilla SOPS.
   # Files are expected to be PEM-encoded.
   flux create secret tls certs \

--- a/cmd/flux/create_source.go
+++ b/cmd/flux/create_source.go
@@ -25,7 +25,7 @@ import (
 var createSourceCmd = &cobra.Command{
 	Use:   "source",
 	Short: "Create or update sources",
-	Long:  "The create source sub-commands generate sources.",
+	Long:  `The create source sub-commands generate sources.`,
 }
 
 type createSourceFlags struct {

--- a/cmd/flux/create_source_bucket.go
+++ b/cmd/flux/create_source_bucket.go
@@ -42,8 +42,8 @@ import (
 var createSourceBucketCmd = &cobra.Command{
 	Use:   "bucket [name]",
 	Short: "Create or update a Bucket source",
-	Long: `The create source bucket command generates a Bucket resource and waits for it to be downloaded.
-For Buckets with static authentication, the credentials are stored in a Kubernetes secret.`,
+	Long: withPreviewNote(`The create source bucket command generates a Bucket resource and waits for it to be downloaded.
+For Buckets with static authentication, the credentials are stored in a Kubernetes secret.`),
 	Example: `  # Create a source for a Bucket using static authentication
   flux create source bucket podinfo \
 	--bucket-name=podinfo \

--- a/cmd/flux/create_source_helm.go
+++ b/cmd/flux/create_source_helm.go
@@ -42,8 +42,8 @@ import (
 var createSourceHelmCmd = &cobra.Command{
 	Use:   "helm [name]",
 	Short: "Create or update a HelmRepository source",
-	Long: `The create source helm command generates a HelmRepository resource and waits for it to fetch the index.
-For private Helm repositories, the basic authentication credentials are stored in a Kubernetes secret.`,
+	Long: withPreviewNote(`The create source helm command generates a HelmRepository resource and waits for it to fetch the index.
+For private Helm repositories, the basic authentication credentials are stored in a Kubernetes secret.`),
 	Example: `  # Create a source for an HTTPS public Helm repository
   flux create source helm podinfo \
     --url=https://stefanprodan.github.io/podinfo \

--- a/cmd/flux/create_source_oci.go
+++ b/cmd/flux/create_source_oci.go
@@ -40,7 +40,7 @@ import (
 var createSourceOCIRepositoryCmd = &cobra.Command{
 	Use:   "oci [name]",
 	Short: "Create or update an OCIRepository",
-	Long:  `The create source oci command generates an OCIRepository resource and waits for it to be ready.`,
+	Long:  withPreviewNote(`The create source oci command generates an OCIRepository resource and waits for it to be ready.`),
 	Example: `  # Create an OCIRepository for a public container image
   flux create source oci podinfo \
     --url=oci://ghcr.io/stefanprodan/manifests/podinfo \

--- a/cmd/flux/create_tenant.go
+++ b/cmd/flux/create_tenant.go
@@ -37,8 +37,8 @@ import (
 var createTenantCmd = &cobra.Command{
 	Use:   "tenant",
 	Short: "Create or update a tenant",
-	Long: `The create tenant command generates namespaces, service accounts and role bindings to limit the
-reconcilers scope to the tenant namespaces.`,
+	Long: withPreviewNote(`The create tenant command generates namespaces, service accounts and role bindings to limit the
+reconcilers scope to the tenant namespaces.`),
 	Example: `  # Create a tenant with access to a namespace 
   flux create tenant dev-team \
     --with-namespace=frontend \

--- a/cmd/flux/delete.go
+++ b/cmd/flux/delete.go
@@ -30,7 +30,7 @@ import (
 var deleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: "Delete sources and resources",
-	Long:  "The delete sub-commands delete sources and resources.",
+	Long:  `The delete sub-commands delete sources and resources.`,
 }
 
 type deleteFlags struct {

--- a/cmd/flux/delete_alert.go
+++ b/cmd/flux/delete_alert.go
@@ -25,7 +25,7 @@ import (
 var deleteAlertCmd = &cobra.Command{
 	Use:   "alert [name]",
 	Short: "Delete a Alert resource",
-	Long:  "The delete alert command removes the given Alert from the cluster.",
+	Long:  withPreviewNote("The delete alert command removes the given Alert from the cluster."),
 	Example: `  # Delete an Alert and the Kubernetes resources created by it
   flux delete alert main`,
 	ValidArgsFunction: resourceNamesCompletionFunc(notificationv1.GroupVersion.WithKind(notificationv1.AlertKind)),

--- a/cmd/flux/delete_alertprovider.go
+++ b/cmd/flux/delete_alertprovider.go
@@ -25,7 +25,7 @@ import (
 var deleteAlertProviderCmd = &cobra.Command{
 	Use:   "alert-provider [name]",
 	Short: "Delete a Provider resource",
-	Long:  "The delete alert-provider command removes the given Provider from the cluster.",
+	Long:  withPreviewNote("The delete alert-provider command removes the given Provider from the cluster."),
 	Example: `  # Delete a Provider and the Kubernetes resources created by it
   flux delete alert-provider slack`,
 	ValidArgsFunction: resourceNamesCompletionFunc(notificationv1.GroupVersion.WithKind(notificationv1.ProviderKind)),

--- a/cmd/flux/delete_helmrelease.go
+++ b/cmd/flux/delete_helmrelease.go
@@ -26,7 +26,7 @@ var deleteHelmReleaseCmd = &cobra.Command{
 	Use:     "helmrelease [name]",
 	Aliases: []string{"hr"},
 	Short:   "Delete a HelmRelease resource",
-	Long:    "The delete helmrelease command removes the given HelmRelease from the cluster.",
+	Long:    withPreviewNote("The delete helmrelease command removes the given HelmRelease from the cluster."),
 	Example: `  # Delete a Helm release and the Kubernetes resources created by it
   flux delete hr podinfo`,
 	ValidArgsFunction: resourceNamesCompletionFunc(helmv2.GroupVersion.WithKind(helmv2.HelmReleaseKind)),

--- a/cmd/flux/delete_image.go
+++ b/cmd/flux/delete_image.go
@@ -23,7 +23,7 @@ import (
 var deleteImageCmd = &cobra.Command{
 	Use:   "image",
 	Short: "Delete image automation objects",
-	Long:  "The delete image sub-commands delete image automation objects.",
+	Long:  `The delete image sub-commands delete image automation objects.`,
 }
 
 func init() {

--- a/cmd/flux/delete_image_policy.go
+++ b/cmd/flux/delete_image_policy.go
@@ -25,7 +25,7 @@ import (
 var deleteImagePolicyCmd = &cobra.Command{
 	Use:   "policy [name]",
 	Short: "Delete an ImagePolicy object",
-	Long:  "The delete image policy command deletes the given ImagePolicy from the cluster.",
+	Long:  withPreviewNote(`The delete image policy command deletes the given ImagePolicy from the cluster.`),
 	Example: `  # Delete an image policy
   flux delete image policy alpine3.x`,
 	ValidArgsFunction: resourceNamesCompletionFunc(imagev1.GroupVersion.WithKind(imagev1.ImagePolicyKind)),

--- a/cmd/flux/delete_image_repository.go
+++ b/cmd/flux/delete_image_repository.go
@@ -25,7 +25,7 @@ import (
 var deleteImageRepositoryCmd = &cobra.Command{
 	Use:   "repository [name]",
 	Short: "Delete an ImageRepository object",
-	Long:  "The delete image repository command deletes the given ImageRepository from the cluster.",
+	Long:  withPreviewNote("The delete image repository command deletes the given ImageRepository from the cluster."),
 	Example: `  # Delete an image repository
   flux delete image repository alpine`,
 	ValidArgsFunction: resourceNamesCompletionFunc(imagev1.GroupVersion.WithKind(imagev1.ImageRepositoryKind)),

--- a/cmd/flux/delete_image_update.go
+++ b/cmd/flux/delete_image_update.go
@@ -25,7 +25,7 @@ import (
 var deleteImageUpdateCmd = &cobra.Command{
 	Use:   "update [name]",
 	Short: "Delete an ImageUpdateAutomation object",
-	Long:  "The delete image update command deletes the given ImageUpdateAutomation from the cluster.",
+	Long:  withPreviewNote(`The delete image update command deletes the given ImageUpdateAutomation from the cluster.`),
 	Example: `  # Delete an image update automation
   flux delete image update latest-images`,
 	ValidArgsFunction: resourceNamesCompletionFunc(autov1.GroupVersion.WithKind(autov1.ImageUpdateAutomationKind)),

--- a/cmd/flux/delete_kustomization.go
+++ b/cmd/flux/delete_kustomization.go
@@ -26,7 +26,7 @@ var deleteKsCmd = &cobra.Command{
 	Use:     "kustomization [name]",
 	Aliases: []string{"ks"},
 	Short:   "Delete a Kustomization resource",
-	Long:    "The delete kustomization command deletes the given Kustomization from the cluster.",
+	Long:    `The delete kustomization command deletes the given Kustomization from the cluster.`,
 	Example: `  # Delete a kustomization and the Kubernetes resources created by it when prune is enabled
   flux delete kustomization podinfo`,
 	ValidArgsFunction: resourceNamesCompletionFunc(kustomizev1.GroupVersion.WithKind(kustomizev1.KustomizationKind)),

--- a/cmd/flux/delete_receiver.go
+++ b/cmd/flux/delete_receiver.go
@@ -25,7 +25,7 @@ import (
 var deleteReceiverCmd = &cobra.Command{
 	Use:   "receiver [name]",
 	Short: "Delete a Receiver resource",
-	Long:  "The delete receiver command removes the given Receiver from the cluster.",
+	Long:  `The delete receiver command removes the given Receiver from the cluster.`,
 	Example: `  # Delete an Receiver and the Kubernetes resources created by it
   flux delete receiver main`,
 	ValidArgsFunction: resourceNamesCompletionFunc(notificationv1.GroupVersion.WithKind(notificationv1.ReceiverKind)),

--- a/cmd/flux/delete_source.go
+++ b/cmd/flux/delete_source.go
@@ -23,7 +23,7 @@ import (
 var deleteSourceCmd = &cobra.Command{
 	Use:   "source",
 	Short: "Delete sources",
-	Long:  "The delete source sub-commands delete sources.",
+	Long:  `The delete source sub-commands delete sources.`,
 }
 
 func init() {

--- a/cmd/flux/delete_source_bucket.go
+++ b/cmd/flux/delete_source_bucket.go
@@ -25,7 +25,7 @@ import (
 var deleteSourceBucketCmd = &cobra.Command{
 	Use:   "bucket [name]",
 	Short: "Delete a Bucket source",
-	Long:  "The delete source bucket command deletes the given Bucket from the cluster.",
+	Long:  withPreviewNote("The delete source bucket command deletes the given Bucket from the cluster."),
 	Example: `  # Delete a Bucket source
   flux delete source bucket podinfo`,
 	ValidArgsFunction: resourceNamesCompletionFunc(sourcev1.GroupVersion.WithKind(sourcev1.BucketKind)),

--- a/cmd/flux/delete_source_git.go
+++ b/cmd/flux/delete_source_git.go
@@ -25,7 +25,7 @@ import (
 var deleteSourceGitCmd = &cobra.Command{
 	Use:   "git [name]",
 	Short: "Delete a GitRepository source",
-	Long:  "The delete source git command deletes the given GitRepository from the cluster.",
+	Long:  `The delete source git command deletes the given GitRepository from the cluster.`,
 	Example: `  # Delete a Git repository
   flux delete source git podinfo`,
 	ValidArgsFunction: resourceNamesCompletionFunc(sourcev1.GroupVersion.WithKind(sourcev1.GitRepositoryKind)),

--- a/cmd/flux/delete_source_helm.go
+++ b/cmd/flux/delete_source_helm.go
@@ -25,7 +25,7 @@ import (
 var deleteSourceHelmCmd = &cobra.Command{
 	Use:   "helm [name]",
 	Short: "Delete a HelmRepository source",
-	Long:  "The delete source helm command deletes the given HelmRepository from the cluster.",
+	Long:  withPreviewNote("The delete source helm command deletes the given HelmRepository from the cluster."),
 	Example: `  # Delete a Helm repository
   flux delete source helm podinfo`,
 	ValidArgsFunction: resourceNamesCompletionFunc(sourcev1.GroupVersion.WithKind(sourcev1.HelmRepositoryKind)),

--- a/cmd/flux/delete_source_oci.go
+++ b/cmd/flux/delete_source_oci.go
@@ -25,7 +25,7 @@ import (
 var deleteSourceOCIRepositoryCmd = &cobra.Command{
 	Use:   "oci [name]",
 	Short: "Delete an OCIRepository source",
-	Long:  "The delete source oci command deletes the given OCIRepository from the cluster.",
+	Long:  withPreviewNote("The delete source oci command deletes the given OCIRepository from the cluster."),
 	Example: `  # Delete an OCIRepository 
   flux delete source oci podinfo`,
 	ValidArgsFunction: resourceNamesCompletionFunc(sourcev1.GroupVersion.WithKind(sourcev1.OCIRepositoryKind)),

--- a/cmd/flux/diff.go
+++ b/cmd/flux/diff.go
@@ -23,7 +23,7 @@ import (
 var diffCmd = &cobra.Command{
 	Use:   "diff",
 	Short: "Diff a flux resource",
-	Long:  "The diff command is used to do a server-side dry-run on flux resources, then prints the diff.",
+	Long:  `The diff command is used to do a server-side dry-run on flux resources, then prints the diff.`,
 }
 
 func init() {

--- a/cmd/flux/diff_artifact.go
+++ b/cmd/flux/diff_artifact.go
@@ -30,7 +30,7 @@ import (
 var diffArtifactCmd = &cobra.Command{
 	Use:   "artifact",
 	Short: "Diff Artifact",
-	Long:  `The diff artifact command computes the diff between the remote OCI artifact and a local directory or file`,
+	Long:  withPreviewNote(`The diff artifact command computes the diff between the remote OCI artifact and a local directory or file`),
 	Example: `# Check if local files differ from remote
 flux diff artifact oci://ghcr.io/stefanprodan/manifests:podinfo:6.2.0 --path=./kustomize`,
 	RunE: diffArtifactCmdRun,

--- a/cmd/flux/events.go
+++ b/cmd/flux/events.go
@@ -55,7 +55,7 @@ import (
 var eventsCmd = &cobra.Command{
 	Use:   "events",
 	Short: "Display Kubernetes events for Flux resources",
-	Long:  "The events sub-command shows Kubernetes events from Flux resources",
+	Long:  withPreviewNote("The events sub-command shows Kubernetes events from Flux resources"),
 	Example: ` # Display events for flux resources in default namespace
 	flux events -n default
 	

--- a/cmd/flux/export.go
+++ b/cmd/flux/export.go
@@ -32,7 +32,7 @@ import (
 var exportCmd = &cobra.Command{
 	Use:   "export",
 	Short: "Export resources in YAML format",
-	Long:  "The export sub-commands export resources in YAML format.",
+	Long:  `The export sub-commands export resources in YAML format.`,
 }
 
 type exportFlags struct {

--- a/cmd/flux/export_alert.go
+++ b/cmd/flux/export_alert.go
@@ -26,7 +26,7 @@ import (
 var exportAlertCmd = &cobra.Command{
 	Use:   "alert [name]",
 	Short: "Export Alert resources in YAML format",
-	Long:  "The export alert command exports one or all Alert resources in YAML format.",
+	Long:  withPreviewNote("The export alert command exports one or all Alert resources in YAML format."),
 	Example: `  # Export all Alert resources
   flux export alert --all > alerts.yaml
 

--- a/cmd/flux/export_alertprovider.go
+++ b/cmd/flux/export_alertprovider.go
@@ -26,7 +26,7 @@ import (
 var exportAlertProviderCmd = &cobra.Command{
 	Use:   "alert-provider [name]",
 	Short: "Export Provider resources in YAML format",
-	Long:  "The export alert-provider command exports one or all Provider resources in YAML format.",
+	Long:  withPreviewNote("The export alert-provider command exports one or all Provider resources in YAML format."),
 	Example: `  # Export all Provider resources
   flux export alert-provider --all > alert-providers.yaml
 

--- a/cmd/flux/export_helmrelease.go
+++ b/cmd/flux/export_helmrelease.go
@@ -27,7 +27,7 @@ var exportHelmReleaseCmd = &cobra.Command{
 	Use:     "helmrelease [name]",
 	Aliases: []string{"hr"},
 	Short:   "Export HelmRelease resources in YAML format",
-	Long:    "The export helmrelease command exports one or all HelmRelease resources in YAML format.",
+	Long:    withPreviewNote("The export helmrelease command exports one or all HelmRelease resources in YAML format."),
 	Example: `  # Export all HelmRelease resources
   flux export helmrelease --all > kustomizations.yaml
 

--- a/cmd/flux/export_image.go
+++ b/cmd/flux/export_image.go
@@ -23,7 +23,7 @@ import (
 var exportImageCmd = &cobra.Command{
 	Use:   "image",
 	Short: "Export image automation objects",
-	Long:  "The export image sub-commands export image automation objects in YAML format.",
+	Long:  `The export image sub-commands export image automation objects in YAML format.`,
 }
 
 func init() {

--- a/cmd/flux/export_image_policy.go
+++ b/cmd/flux/export_image_policy.go
@@ -26,7 +26,7 @@ import (
 var exportImagePolicyCmd = &cobra.Command{
 	Use:   "policy [name]",
 	Short: "Export ImagePolicy resources in YAML format",
-	Long:  "The export image policy command exports one or all ImagePolicy resources in YAML format.",
+	Long:  withPreviewNote("The export image policy command exports one or all ImagePolicy resources in YAML format."),
 	Example: `  # Export all ImagePolicy resources
   flux export image policy --all > image-policies.yaml
 

--- a/cmd/flux/export_image_repository.go
+++ b/cmd/flux/export_image_repository.go
@@ -26,7 +26,7 @@ import (
 var exportImageRepositoryCmd = &cobra.Command{
 	Use:   "repository [name]",
 	Short: "Export ImageRepository resources in YAML format",
-	Long:  "The export image repository command exports one or all ImageRepository resources in YAML format.",
+	Long:  withPreviewNote("The export image repository command exports one or all ImageRepository resources in YAML format."),
 	Example: `  # Export all ImageRepository resources
   flux export image repository --all > image-repositories.yaml
 

--- a/cmd/flux/export_image_update.go
+++ b/cmd/flux/export_image_update.go
@@ -26,7 +26,7 @@ import (
 var exportImageUpdateCmd = &cobra.Command{
 	Use:   "update [name]",
 	Short: "Export ImageUpdateAutomation resources in YAML format",
-	Long:  "The export image update command exports one or all ImageUpdateAutomation resources in YAML format.",
+	Long:  withPreviewNote("The export image update command exports one or all ImageUpdateAutomation resources in YAML format."),
 	Example: `  # Export all ImageUpdateAutomation resources
   flux export image update --all > updates.yaml
 

--- a/cmd/flux/export_kustomization.go
+++ b/cmd/flux/export_kustomization.go
@@ -27,7 +27,7 @@ var exportKsCmd = &cobra.Command{
 	Use:     "kustomization [name]",
 	Aliases: []string{"ks"},
 	Short:   "Export Kustomization resources in YAML format",
-	Long:    "The export kustomization command exports one or all Kustomization resources in YAML format.",
+	Long:    `The export kustomization command exports one or all Kustomization resources in YAML format.`,
 	Example: `  # Export all Kustomization resources
   flux export kustomization --all > kustomizations.yaml
 

--- a/cmd/flux/export_receiver.go
+++ b/cmd/flux/export_receiver.go
@@ -26,7 +26,7 @@ import (
 var exportReceiverCmd = &cobra.Command{
 	Use:   "receiver [name]",
 	Short: "Export Receiver resources in YAML format",
-	Long:  "The export receiver command exports one or all Receiver resources in YAML format.",
+	Long:  `The export receiver command exports one or all Receiver resources in YAML format.`,
 	Example: `  # Export all Receiver resources
   flux export receiver --all > receivers.yaml
 

--- a/cmd/flux/export_source.go
+++ b/cmd/flux/export_source.go
@@ -23,7 +23,7 @@ import (
 var exportSourceCmd = &cobra.Command{
 	Use:   "source",
 	Short: "Export sources",
-	Long:  "The export source sub-commands export sources in YAML format.",
+	Long:  `The export source sub-commands export sources in YAML format.`,
 }
 
 var (

--- a/cmd/flux/export_source_bucket.go
+++ b/cmd/flux/export_source_bucket.go
@@ -27,7 +27,7 @@ import (
 var exportSourceBucketCmd = &cobra.Command{
 	Use:   "bucket [name]",
 	Short: "Export Bucket sources in YAML format",
-	Long:  "The export source git command exports one or all Bucket sources in YAML format.",
+	Long:  withPreviewNote("The export source git command exports one or all Bucket sources in YAML format."),
 	Example: `  # Export all Bucket sources
   flux export source bucket --all > sources.yaml
 

--- a/cmd/flux/export_source_git.go
+++ b/cmd/flux/export_source_git.go
@@ -27,7 +27,7 @@ import (
 var exportSourceGitCmd = &cobra.Command{
 	Use:   "git [name]",
 	Short: "Export GitRepository sources in YAML format",
-	Long:  "The export source git command exports one or all GitRepository sources in YAML format.",
+	Long:  `The export source git command exports one or all GitRepository sources in YAML format.`,
 	Example: `  # Export all GitRepository sources
   flux export source git --all > sources.yaml
 

--- a/cmd/flux/export_source_helm.go
+++ b/cmd/flux/export_source_helm.go
@@ -27,7 +27,7 @@ import (
 var exportSourceHelmCmd = &cobra.Command{
 	Use:   "helm [name]",
 	Short: "Export HelmRepository sources in YAML format",
-	Long:  "The export source git command exports one or all HelmRepository sources in YAML format.",
+	Long:  withPreviewNote("The export source git command exports one or all HelmRepository sources in YAML format."),
 	Example: `  # Export all HelmRepository sources
   flux export source helm --all > sources.yaml
 

--- a/cmd/flux/export_source_oci.go
+++ b/cmd/flux/export_source_oci.go
@@ -27,7 +27,7 @@ import (
 var exportSourceOCIRepositoryCmd = &cobra.Command{
 	Use:   "oci [name]",
 	Short: "Export OCIRepository sources in YAML format",
-	Long:  "The export source oci command exports one or all OCIRepository sources in YAML format.",
+	Long:  withPreviewNote("The export source oci command exports one or all OCIRepository sources in YAML format."),
 	Example: `  # Export all OCIRepository sources
   flux export source oci --all > sources.yaml
 

--- a/cmd/flux/get.go
+++ b/cmd/flux/get.go
@@ -59,7 +59,7 @@ func (m typeMap) execute(t string, obj runtime.Object) (summarisable, error) {
 var getCmd = &cobra.Command{
 	Use:   "get",
 	Short: "Get the resources and their status",
-	Long:  "The get sub-commands print the statuses of Flux resources.",
+	Long:  `The get sub-commands print the statuses of Flux resources.`,
 }
 
 type GetFlags struct {

--- a/cmd/flux/get_alert.go
+++ b/cmd/flux/get_alert.go
@@ -31,7 +31,7 @@ var getAlertCmd = &cobra.Command{
 	Use:     "alerts",
 	Aliases: []string{"alert"},
 	Short:   "Get Alert statuses",
-	Long:    "The get alert command prints the statuses of the resources.",
+	Long:    withPreviewNote("The get alert command prints the statuses of the resources."),
 	Example: `  # List all Alerts and their status
   flux get alerts`,
 	ValidArgsFunction: resourceNamesCompletionFunc(notificationv1.GroupVersion.WithKind(notificationv1.AlertKind)),

--- a/cmd/flux/get_alertprovider.go
+++ b/cmd/flux/get_alertprovider.go
@@ -29,7 +29,7 @@ var getAlertProviderCmd = &cobra.Command{
 	Use:     "alert-providers",
 	Aliases: []string{"alert-provider"},
 	Short:   "Get Provider statuses",
-	Long:    "The get alert-provider command prints the statuses of the resources.",
+	Long:    withPreviewNote("The get alert-provider command prints the statuses of the resources."),
 	Example: `  # List all Providers and their status
   flux get alert-providers`,
 	ValidArgsFunction: resourceNamesCompletionFunc(notificationv1.GroupVersion.WithKind(notificationv1.ProviderKind)),

--- a/cmd/flux/get_all.go
+++ b/cmd/flux/get_all.go
@@ -30,7 +30,7 @@ import (
 var getAllCmd = &cobra.Command{
 	Use:   "all",
 	Short: "Get all resources and statuses",
-	Long:  "The get all command print the statuses of all resources.",
+	Long:  withPreviewNote("The get all command print the statuses of all resources."),
 	Example: `  # List all resources in a namespace
   flux get all --namespace=flux-system
 

--- a/cmd/flux/get_helmrelease.go
+++ b/cmd/flux/get_helmrelease.go
@@ -30,7 +30,7 @@ var getHelmReleaseCmd = &cobra.Command{
 	Use:     "helmreleases",
 	Aliases: []string{"hr", "helmrelease"},
 	Short:   "Get HelmRelease statuses",
-	Long:    "The get helmreleases command prints the statuses of the resources.",
+	Long:    withPreviewNote("The get helmreleases command prints the statuses of the resources."),
 	Example: `  # List all Helm releases and their status
   flux get helmreleases`,
 	ValidArgsFunction: resourceNamesCompletionFunc(helmv2.GroupVersion.WithKind(helmv2.HelmReleaseKind)),

--- a/cmd/flux/get_image.go
+++ b/cmd/flux/get_image.go
@@ -24,7 +24,7 @@ var getImageCmd = &cobra.Command{
 	Use:     "images",
 	Aliases: []string{"image"},
 	Short:   "Get image automation object status",
-	Long:    "The get image sub-commands print the status of image automation objects.",
+	Long:    `The get image sub-commands print the status of image automation objects.`,
 }
 
 func init() {

--- a/cmd/flux/get_image_all.go
+++ b/cmd/flux/get_image_all.go
@@ -28,7 +28,7 @@ import (
 var getImageAllCmd = &cobra.Command{
 	Use:   "all",
 	Short: "Get all image statuses",
-	Long:  "The get image sub-commands print the statuses of all image objects.",
+	Long:  withPreviewNote("The get image sub-commands print the statuses of all image objects."),
 	Example: `  # List all image objects in a namespace
   flux get images all --namespace=flux-system
 

--- a/cmd/flux/get_image_policy.go
+++ b/cmd/flux/get_image_policy.go
@@ -28,7 +28,7 @@ import (
 var getImagePolicyCmd = &cobra.Command{
 	Use:   "policy",
 	Short: "Get ImagePolicy status",
-	Long:  "The get image policy command prints the status of ImagePolicy objects.",
+	Long:  withPreviewNote("The get image policy command prints the status of ImagePolicy objects."),
 	Example: `  # List all image policies and their status
   flux get image policy
 

--- a/cmd/flux/get_image_repository.go
+++ b/cmd/flux/get_image_repository.go
@@ -31,7 +31,7 @@ import (
 var getImageRepositoryCmd = &cobra.Command{
 	Use:   "repository",
 	Short: "Get ImageRepository status",
-	Long:  "The get image repository command prints the status of ImageRepository objects.",
+	Long:  withPreviewNote("The get image repository command prints the status of ImageRepository objects."),
 	Example: `  # List all image repositories and their status
   flux get image repository
 

--- a/cmd/flux/get_image_update.go
+++ b/cmd/flux/get_image_update.go
@@ -31,7 +31,7 @@ import (
 var getImageUpdateCmd = &cobra.Command{
 	Use:   "update",
 	Short: "Get ImageUpdateAutomation status",
-	Long:  "The get image update command prints the status of ImageUpdateAutomation objects.",
+	Long:  withPreviewNote("The get image update command prints the status of ImageUpdateAutomation objects."),
 	Example: `  # List all image update automation object and their status
   flux get image update
 

--- a/cmd/flux/get_kustomization.go
+++ b/cmd/flux/get_kustomization.go
@@ -33,7 +33,7 @@ var getKsCmd = &cobra.Command{
 	Use:     "kustomizations",
 	Aliases: []string{"ks", "kustomization"},
 	Short:   "Get Kustomization statuses",
-	Long:    "The get kustomizations command prints the statuses of the resources.",
+	Long:    `The get kustomizations command prints the statuses of the resources.`,
 	Example: `  # List all kustomizations and their status
   flux get kustomizations`,
 	ValidArgsFunction: resourceNamesCompletionFunc(kustomizev1.GroupVersion.WithKind(kustomizev1.KustomizationKind)),

--- a/cmd/flux/get_receiver.go
+++ b/cmd/flux/get_receiver.go
@@ -31,7 +31,7 @@ var getReceiverCmd = &cobra.Command{
 	Use:     "receivers",
 	Aliases: []string{"receiver"},
 	Short:   "Get Receiver statuses",
-	Long:    "The get receiver command prints the statuses of the resources.",
+	Long:    `The get receiver command prints the statuses of the resources.`,
 	Example: `  # List all Receiver and their status
   flux get receivers`,
 	ValidArgsFunction: resourceNamesCompletionFunc(notificationv1.GroupVersion.WithKind(notificationv1.ReceiverKind)),

--- a/cmd/flux/get_source.go
+++ b/cmd/flux/get_source.go
@@ -24,7 +24,7 @@ var getSourceCmd = &cobra.Command{
 	Use:     "sources",
 	Aliases: []string{"source"},
 	Short:   "Get source statuses",
-	Long:    "The get source sub-commands print the statuses of the sources.",
+	Long:    `The get source sub-commands print the statuses of the sources.`,
 }
 
 func init() {

--- a/cmd/flux/get_source_all.go
+++ b/cmd/flux/get_source_all.go
@@ -28,7 +28,7 @@ import (
 var getSourceAllCmd = &cobra.Command{
 	Use:   "all",
 	Short: "Get all source statuses",
-	Long:  "The get sources all command print the statuses of all sources.",
+	Long:  withPreviewNote("The get sources all command print the statuses of all sources."),
 	Example: `  # List all sources in a namespace
   flux get sources all --namespace=flux-system
 

--- a/cmd/flux/get_source_bucket.go
+++ b/cmd/flux/get_source_bucket.go
@@ -32,7 +32,7 @@ import (
 var getSourceBucketCmd = &cobra.Command{
 	Use:   "bucket",
 	Short: "Get Bucket source statuses",
-	Long:  "The get sources bucket command prints the status of the Bucket sources.",
+	Long:  withPreviewNote("The get sources bucket command prints the status of the Bucket sources."),
 	Example: `  # List all Buckets and their status
   flux get sources bucket
 

--- a/cmd/flux/get_source_chart.go
+++ b/cmd/flux/get_source_chart.go
@@ -32,7 +32,7 @@ import (
 var getSourceHelmChartCmd = &cobra.Command{
 	Use:   "chart",
 	Short: "Get HelmChart statuses",
-	Long:  "The get sources chart command prints the status of the HelmCharts.",
+	Long:  withPreviewNote("The get sources chart command prints the status of the HelmCharts."),
 	Example: `  # List all Helm charts and their status
   flux get sources chart
 

--- a/cmd/flux/get_source_git.go
+++ b/cmd/flux/get_source_git.go
@@ -32,7 +32,7 @@ import (
 var getSourceGitCmd = &cobra.Command{
 	Use:   "git",
 	Short: "Get GitRepository source statuses",
-	Long:  "The get sources git command prints the status of the GitRepository sources.",
+	Long:  `The get sources git command prints the status of the GitRepository sources.`,
 	Example: `  # List all Git repositories and their status
   flux get sources git
 

--- a/cmd/flux/get_source_helm.go
+++ b/cmd/flux/get_source_helm.go
@@ -32,7 +32,7 @@ import (
 var getSourceHelmCmd = &cobra.Command{
 	Use:   "helm",
 	Short: "Get HelmRepository source statuses",
-	Long:  "The get sources helm command prints the status of the HelmRepository sources.",
+	Long:  withPreviewNote("The get sources helm command prints the status of the HelmRepository sources."),
 	Example: `  # List all Helm repositories and their status
   flux get sources helm
 

--- a/cmd/flux/get_source_oci.go
+++ b/cmd/flux/get_source_oci.go
@@ -32,7 +32,7 @@ import (
 var getSourceOCIRepositoryCmd = &cobra.Command{
 	Use:   "oci",
 	Short: "Get OCIRepository status",
-	Long:  "The get sources oci command prints the status of the OCIRepository sources.",
+	Long:  withPreviewNote("The get sources oci command prints the status of the OCIRepository sources."),
 	Example: `  # List all OCIRepositories and their status
   flux get sources oci
 

--- a/cmd/flux/list.go
+++ b/cmd/flux/list.go
@@ -23,7 +23,7 @@ import (
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List artifacts",
-	Long:  "The list command is used for printing the OCI artifacts metadata.",
+	Long:  `The list command is used for printing the OCI artifacts metadata.`,
 }
 
 func init() {

--- a/cmd/flux/list_artifact.go
+++ b/cmd/flux/list_artifact.go
@@ -47,8 +47,8 @@ func newListArtifactFlags() listArtifactFlags {
 var listArtifactsCmd = &cobra.Command{
 	Use:   "artifacts",
 	Short: "list artifacts",
-	Long: `The list command fetches the tags and their metadata from a remote OCI repository.
-The command can read the credentials from '~/.docker/config.json' but they can also be passed with --creds. It can also login to a supported provider with the --provider flag.`,
+	Long: withPreviewNote(`The list command fetches the tags and their metadata from a remote OCI repository.
+The command can read the credentials from '~/.docker/config.json' but they can also be passed with --creds. It can also login to a supported provider with the --provider flag.`),
 	Example: `  # List the artifacts stored in an OCI repository
   flux list artifact oci://ghcr.io/org/config/app
 `,

--- a/cmd/flux/logs.go
+++ b/cmd/flux/logs.go
@@ -45,7 +45,7 @@ import (
 var logsCmd = &cobra.Command{
 	Use:   "logs",
 	Short: "Display formatted logs for Flux components",
-	Long:  "The logs command displays formatted logs from various Flux components.",
+	Long:  withPreviewNote("The logs command displays formatted logs from various Flux components."),
 	Example: `  # Print the reconciliation logs of all Flux custom resources in your cluster
   flux logs --all-namespaces
   

--- a/cmd/flux/main.go
+++ b/cmd/flux/main.go
@@ -224,3 +224,10 @@ func readPasswordFromStdin(prompt string) (string, error) {
 	fmt.Println()
 	return strings.TrimRight(out, "\r\n"), nil
 }
+
+func withPreviewNote(desc string) string {
+	previewNote := `⚠️  Please note that this command is in preview and under development.
+While we try our best to not introduce breaking changes, they may occur when
+we adapt to new features and/or find better ways to facilitate what it does.`
+	return fmt.Sprintf("%s\n\n%s", strings.TrimSpace(desc), previewNote)
+}

--- a/cmd/flux/pull.go
+++ b/cmd/flux/pull.go
@@ -23,7 +23,7 @@ import (
 var pullCmd = &cobra.Command{
 	Use:   "pull",
 	Short: "Pull artifacts",
-	Long:  "The pull command is used to download OCI artifacts.",
+	Long:  `The pull command is used to download OCI artifacts.`,
 }
 
 func init() {

--- a/cmd/flux/pull_artifact.go
+++ b/cmd/flux/pull_artifact.go
@@ -31,8 +31,8 @@ import (
 var pullArtifactCmd = &cobra.Command{
 	Use:   "artifact",
 	Short: "Pull artifact",
-	Long: `The pull artifact command downloads and extracts the OCI artifact content to the given path.
-The command can read the credentials from '~/.docker/config.json' but they can also be passed with --creds. It can also login to a supported provider with the --provider flag.`,
+	Long: withPreviewNote(`The pull artifact command downloads and extracts the OCI artifact content to the given path.
+The command can read the credentials from '~/.docker/config.json' but they can also be passed with --creds. It can also login to a supported provider with the --provider flag.`),
 	Example: `  # Pull an OCI artifact created by flux from GHCR
   flux pull artifact oci://ghcr.io/org/manifests/app:v0.0.1 --output ./path/to/local/manifests
 `,

--- a/cmd/flux/push.go
+++ b/cmd/flux/push.go
@@ -23,7 +23,7 @@ import (
 var pushCmd = &cobra.Command{
 	Use:   "push",
 	Short: "Push artifacts",
-	Long:  "The push command is used to publish OCI artifacts.",
+	Long:  `The push command is used to publish OCI artifacts.`,
 }
 
 func init() {

--- a/cmd/flux/push_artifact.go
+++ b/cmd/flux/push_artifact.go
@@ -35,8 +35,8 @@ import (
 var pushArtifactCmd = &cobra.Command{
 	Use:   "artifact",
 	Short: "Push artifact",
-	Long: `The push artifact command creates a tarball from the given directory or the single file and uploads the artifact to an OCI repository.
-The command can read the credentials from '~/.docker/config.json' but they can also be passed with --creds. It can also login to a supported provider with the --provider flag.`,
+	Long: withPreviewNote(`The push artifact command creates a tarball from the given directory or the single file and uploads the artifact to an OCI repository.
+The command can read the credentials from '~/.docker/config.json' but they can also be passed with --creds. It can also login to a supported provider with the --provider flag.`),
 	Example: `  # Push manifests to GHCR using the short Git SHA as the OCI artifact tag
   echo $GITHUB_PAT | docker login ghcr.io --username flux --password-stdin
   flux push artifact oci://ghcr.io/org/config/app:$(git rev-parse --short HEAD) \

--- a/cmd/flux/reconcile.go
+++ b/cmd/flux/reconcile.go
@@ -40,7 +40,7 @@ import (
 var reconcileCmd = &cobra.Command{
 	Use:   "reconcile",
 	Short: "Reconcile sources and resources",
-	Long:  "The reconcile sub-commands trigger a reconciliation of sources and resources.",
+	Long:  `The reconcile sub-commands trigger a reconciliation of sources and resources.`,
 }
 
 func init() {

--- a/cmd/flux/reconcile_image.go
+++ b/cmd/flux/reconcile_image.go
@@ -23,7 +23,7 @@ import (
 var reconcileImageCmd = &cobra.Command{
 	Use:   "image",
 	Short: "Reconcile image automation objects",
-	Long:  "The reconcile sub-commands trigger a reconciliation of image automation objects.",
+	Long:  `The reconcile sub-commands trigger a reconciliation of image automation objects.`,
 }
 
 func init() {

--- a/cmd/flux/reconcile_source.go
+++ b/cmd/flux/reconcile_source.go
@@ -23,7 +23,7 @@ import (
 var reconcileSourceCmd = &cobra.Command{
 	Use:   "source",
 	Short: "Reconcile sources",
-	Long:  "The reconcile source sub-commands trigger a reconciliation of sources.",
+	Long:  `The reconcile source sub-commands trigger a reconciliation of sources.`,
 }
 
 func init() {

--- a/cmd/flux/resume.go
+++ b/cmd/flux/resume.go
@@ -31,7 +31,7 @@ import (
 var resumeCmd = &cobra.Command{
 	Use:   "resume",
 	Short: "Resume suspended resources",
-	Long:  "The resume sub-commands resume a suspended resource.",
+	Long:  `The resume sub-commands resume a suspended resource.`,
 }
 
 type ResumeFlags struct {

--- a/cmd/flux/resume_image.go
+++ b/cmd/flux/resume_image.go
@@ -23,7 +23,7 @@ import (
 var resumeImageCmd = &cobra.Command{
 	Use:   "image",
 	Short: "Resume image automation objects",
-	Long:  "The resume image sub-commands resume suspended image automation objects.",
+	Long:  `The resume image sub-commands resume suspended image automation objects.`,
 }
 
 func init() {

--- a/cmd/flux/resume_source.go
+++ b/cmd/flux/resume_source.go
@@ -23,7 +23,7 @@ import (
 var resumeSourceCmd = &cobra.Command{
 	Use:   "source",
 	Short: "Resume sources",
-	Long:  "The resume sub-commands resume a suspended source.",
+	Long:  `The resume sub-commands resume a suspended source.`,
 }
 
 func init() {

--- a/cmd/flux/stats.go
+++ b/cmd/flux/stats.go
@@ -42,8 +42,8 @@ import (
 var statsCmd = &cobra.Command{
 	Use:   "stats",
 	Short: "Stats of Flux reconciles",
-	Long: `The stats command prints a report of Flux custom resources present on a cluster,
-including their reconcile status and the amount of cumulative storage used for each source type`,
+	Long: withPreviewNote(`The stats command prints a report of Flux custom resources present on a cluster,
+including their reconcile status and the amount of cumulative storage used for each source type`),
 	Example: `  # Print the stats report for a namespace
   flux stats --namespace default
 

--- a/cmd/flux/suspend.go
+++ b/cmd/flux/suspend.go
@@ -29,7 +29,7 @@ import (
 var suspendCmd = &cobra.Command{
 	Use:   "suspend",
 	Short: "Suspend resources",
-	Long:  "The suspend sub-commands suspend the reconciliation of a resource.",
+	Long:  `The suspend sub-commands suspend the reconciliation of a resource.`,
 }
 
 type SuspendFlags struct {

--- a/cmd/flux/suspend_alert.go
+++ b/cmd/flux/suspend_alert.go
@@ -25,7 +25,7 @@ import (
 var suspendAlertCmd = &cobra.Command{
 	Use:   "alert [name]",
 	Short: "Suspend reconciliation of Alert",
-	Long:  "The suspend command disables the reconciliation of a Alert resource.",
+	Long:  `The suspend command disables the reconciliation of a Alert resource.`,
 	Example: `  # Suspend reconciliation for an existing Alert
   flux suspend alert main`,
 	ValidArgsFunction: resourceNamesCompletionFunc(notificationv1.GroupVersion.WithKind(notificationv1.AlertKind)),

--- a/cmd/flux/suspend_helmrelease.go
+++ b/cmd/flux/suspend_helmrelease.go
@@ -26,7 +26,7 @@ var suspendHrCmd = &cobra.Command{
 	Use:     "helmrelease [name]",
 	Aliases: []string{"hr"},
 	Short:   "Suspend reconciliation of HelmRelease",
-	Long:    "The suspend command disables the reconciliation of a HelmRelease resource.",
+	Long:    `The suspend command disables the reconciliation of a HelmRelease resource.`,
 	Example: `  # Suspend reconciliation for an existing Helm release
   flux suspend hr podinfo`,
 	ValidArgsFunction: resourceNamesCompletionFunc(helmv2.GroupVersion.WithKind(helmv2.HelmReleaseKind)),

--- a/cmd/flux/suspend_image.go
+++ b/cmd/flux/suspend_image.go
@@ -23,7 +23,7 @@ import (
 var suspendImageCmd = &cobra.Command{
 	Use:   "image",
 	Short: "Suspend image automation objects",
-	Long:  "The suspend image sub-commands suspend the reconciliation of an image automation object.",
+	Long:  `The suspend image sub-commands suspend the reconciliation of an image automation object.`,
 }
 
 func init() {

--- a/cmd/flux/suspend_image_repository.go
+++ b/cmd/flux/suspend_image_repository.go
@@ -25,7 +25,7 @@ import (
 var suspendImageRepositoryCmd = &cobra.Command{
 	Use:   "repository [name]",
 	Short: "Suspend reconciliation of an ImageRepository",
-	Long:  "The suspend image repository command disables the reconciliation of a ImageRepository resource.",
+	Long:  `The suspend image repository command disables the reconciliation of a ImageRepository resource.`,
 	Example: `  # Suspend reconciliation for an existing ImageRepository
   flux suspend image repository alpine`,
 	ValidArgsFunction: resourceNamesCompletionFunc(imagev1.GroupVersion.WithKind(imagev1.ImageRepositoryKind)),

--- a/cmd/flux/suspend_image_updateauto.go
+++ b/cmd/flux/suspend_image_updateauto.go
@@ -25,7 +25,7 @@ import (
 var suspendImageUpdateCmd = &cobra.Command{
 	Use:   "update [name]",
 	Short: "Suspend reconciliation of an ImageUpdateAutomation",
-	Long:  "The suspend image update command disables the reconciliation of a ImageUpdateAutomation resource.",
+	Long:  `The suspend image update command disables the reconciliation of a ImageUpdateAutomation resource.`,
 	Example: `  # Suspend reconciliation for an existing ImageUpdateAutomation
   flux suspend image update latest-images`,
 	ValidArgsFunction: resourceNamesCompletionFunc(autov1.GroupVersion.WithKind(autov1.ImageUpdateAutomationKind)),

--- a/cmd/flux/suspend_kustomization.go
+++ b/cmd/flux/suspend_kustomization.go
@@ -26,7 +26,7 @@ var suspendKsCmd = &cobra.Command{
 	Use:     "kustomization [name]",
 	Aliases: []string{"ks"},
 	Short:   "Suspend reconciliation of Kustomization",
-	Long:    "The suspend command disables the reconciliation of a Kustomization resource.",
+	Long:    `The suspend command disables the reconciliation of a Kustomization resource.`,
 	Example: `  # Suspend reconciliation for an existing Kustomization
   flux suspend ks podinfo`,
 	ValidArgsFunction: resourceNamesCompletionFunc(kustomizev1.GroupVersion.WithKind(kustomizev1.KustomizationKind)),

--- a/cmd/flux/suspend_receiver.go
+++ b/cmd/flux/suspend_receiver.go
@@ -25,7 +25,7 @@ import (
 var suspendReceiverCmd = &cobra.Command{
 	Use:   "receiver [name]",
 	Short: "Suspend reconciliation of Receiver",
-	Long:  "The suspend command disables the reconciliation of a Receiver resource.",
+	Long:  `The suspend command disables the reconciliation of a Receiver resource.`,
 	Example: `  # Suspend reconciliation for an existing Receiver
   flux suspend receiver main`,
 	ValidArgsFunction: resourceNamesCompletionFunc(notificationv1.GroupVersion.WithKind(notificationv1.ReceiverKind)),

--- a/cmd/flux/suspend_source.go
+++ b/cmd/flux/suspend_source.go
@@ -23,7 +23,7 @@ import (
 var suspendSourceCmd = &cobra.Command{
 	Use:   "source",
 	Short: "Suspend sources",
-	Long:  "The suspend sub-commands suspend the reconciliation of a source.",
+	Long:  `The suspend sub-commands suspend the reconciliation of a source.`,
 }
 
 func init() {

--- a/cmd/flux/suspend_source_bucket.go
+++ b/cmd/flux/suspend_source_bucket.go
@@ -25,7 +25,7 @@ import (
 var suspendSourceBucketCmd = &cobra.Command{
 	Use:   "bucket [name]",
 	Short: "Suspend reconciliation of a Bucket",
-	Long:  "The suspend command disables the reconciliation of a Bucket resource.",
+	Long:  `The suspend command disables the reconciliation of a Bucket resource.`,
 	Example: `  # Suspend reconciliation for an existing Bucket
   flux suspend source bucket podinfo`,
 	ValidArgsFunction: resourceNamesCompletionFunc(sourcev1.GroupVersion.WithKind(sourcev1.BucketKind)),

--- a/cmd/flux/suspend_source_chart.go
+++ b/cmd/flux/suspend_source_chart.go
@@ -25,7 +25,7 @@ import (
 var suspendSourceHelmChartCmd = &cobra.Command{
 	Use:   "chart [name]",
 	Short: "Suspend reconciliation of a HelmChart",
-	Long:  "The suspend command disables the reconciliation of a HelmChart resource.",
+	Long:  `The suspend command disables the reconciliation of a HelmChart resource.`,
 	Example: `  # Suspend reconciliation for an existing HelmChart
   flux suspend source chart podinfo`,
 	ValidArgsFunction: resourceNamesCompletionFunc(sourcev1.GroupVersion.WithKind(sourcev1.HelmChartKind)),

--- a/cmd/flux/suspend_source_git.go
+++ b/cmd/flux/suspend_source_git.go
@@ -25,7 +25,7 @@ import (
 var suspendSourceGitCmd = &cobra.Command{
 	Use:   "git [name]",
 	Short: "Suspend reconciliation of a GitRepository",
-	Long:  "The suspend command disables the reconciliation of a GitRepository resource.",
+	Long:  `The suspend command disables the reconciliation of a GitRepository resource.`,
 	Example: `  # Suspend reconciliation for an existing GitRepository
   flux suspend source git podinfo`,
 	ValidArgsFunction: resourceNamesCompletionFunc(sourcev1.GroupVersion.WithKind(sourcev1.GitRepositoryKind)),

--- a/cmd/flux/suspend_source_helm.go
+++ b/cmd/flux/suspend_source_helm.go
@@ -25,7 +25,7 @@ import (
 var suspendSourceHelmCmd = &cobra.Command{
 	Use:   "helm [name]",
 	Short: "Suspend reconciliation of a HelmRepository",
-	Long:  "The suspend command disables the reconciliation of a HelmRepository resource.",
+	Long:  `The suspend command disables the reconciliation of a HelmRepository resource.`,
 	Example: `  # Suspend reconciliation for an existing HelmRepository
   flux suspend source helm bitnami`,
 	ValidArgsFunction: resourceNamesCompletionFunc(sourcev1.GroupVersion.WithKind(sourcev1.HelmRepositoryKind)),

--- a/cmd/flux/suspend_source_oci.go
+++ b/cmd/flux/suspend_source_oci.go
@@ -25,7 +25,7 @@ import (
 var suspendSourceOCIRepositoryCmd = &cobra.Command{
 	Use:   "oci [name]",
 	Short: "Suspend reconciliation of an OCIRepository",
-	Long:  "The suspend command disables the reconciliation of an OCIRepository resource.",
+	Long:  `The suspend command disables the reconciliation of an OCIRepository resource.`,
 	Example: `  # Suspend reconciliation for an existing OCIRepository
   flux suspend source oci podinfo`,
 	ValidArgsFunction: resourceNamesCompletionFunc(sourcev1.GroupVersion.WithKind(sourcev1.OCIRepositoryKind)),

--- a/cmd/flux/tag.go
+++ b/cmd/flux/tag.go
@@ -23,7 +23,7 @@ import (
 var tagCmd = &cobra.Command{
 	Use:   "tag",
 	Short: "Tag artifacts",
-	Long:  "The tag command is used to tag OCI artifacts.",
+	Long:  `The tag command is used to tag OCI artifacts.`,
 }
 
 func init() {

--- a/cmd/flux/tag_artifact.go
+++ b/cmd/flux/tag_artifact.go
@@ -31,8 +31,8 @@ import (
 var tagArtifactCmd = &cobra.Command{
 	Use:   "artifact",
 	Short: "Tag artifact",
-	Long: `The tag artifact command creates tags for the given OCI artifact.
-The command can read the credentials from '~/.docker/config.json' but they can also be passed with --creds. It can also login to a supported provider with the --provider flag.`,
+	Long: withPreviewNote(`The tag artifact command creates tags for the given OCI artifact.
+The command can read the credentials from '~/.docker/config.json' but they can also be passed with --creds. It can also login to a supported provider with the --provider flag.`),
 	Example: `  # Tag an artifact version as latest
   flux tag artifact oci://ghcr.io/org/manifests/app:v0.0.1 --tag latest
 `,

--- a/cmd/flux/trace.go
+++ b/cmd/flux/trace.go
@@ -45,10 +45,10 @@ import (
 var traceCmd = &cobra.Command{
 	Use:   "trace <resource> <name> [<name> ...]",
 	Short: "Trace in-cluster objects throughout the GitOps delivery pipeline",
-	Long: `The trace command shows how one or more objects are managed by Flux,
+	Long: withPreviewNote(`The trace command shows how one or more objects are managed by Flux,
 from which source and revision they come, and what the latest reconciliation status is.
 
-You can also trace multiple objects with different resource kinds using <resource>/<name> multiple times.`,
+You can also trace multiple objects with different resource kinds using <resource>/<name> multiple times.`),
 	Example: `  # Trace a Kubernetes Deployment
   flux trace -n apps deployment my-app
 

--- a/cmd/flux/tree.go
+++ b/cmd/flux/tree.go
@@ -23,7 +23,7 @@ import (
 var treeCmd = &cobra.Command{
 	Use:   "tree",
 	Short: "Print the resources reconciled by Flux",
-	Long:  `The tree command shows the list of resources reconciled by a Flux object.'`,
+	Long:  withPreviewNote(`The tree command shows the list of resources reconciled by a Flux object.`),
 }
 
 func init() {

--- a/cmd/flux/tree_kustomization.go
+++ b/cmd/flux/tree_kustomization.go
@@ -47,7 +47,7 @@ var treeKsCmd = &cobra.Command{
 	Use:     "kustomization [name]",
 	Aliases: []string{"ks", "kustomization"},
 	Short:   "Print the resource inventory of a Kustomization",
-	Long:    `The tree command prints the resource list reconciled by a Kustomization.'`,
+	Long:    withPreviewNote(`The tree command prints the resource list reconciled by a Kustomization.'`),
 	Example: `  # Print the resources managed by the root Kustomization
   flux tree kustomization flux-system
 

--- a/cmd/flux/uninstall.go
+++ b/cmd/flux/uninstall.go
@@ -30,7 +30,7 @@ import (
 var uninstallCmd = &cobra.Command{
 	Use:   "uninstall",
 	Short: "Uninstall Flux and its custom resource definitions",
-	Long:  "The uninstall command removes the Flux components and the toolkit.fluxcd.io resources from the cluster.",
+	Long:  `The uninstall command removes the Flux components and the toolkit.fluxcd.io resources from the cluster.`,
 	Example: `  # Uninstall Flux components, its custom resources and namespace
   flux uninstall --namespace=flux-system
 

--- a/cmd/flux/version.go
+++ b/cmd/flux/version.go
@@ -34,7 +34,7 @@ import (
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the client and server-side components version information.",
-	Long:  "Print the client and server-side components version information for the current context.",
+	Long:  `Print the client and server-side components version information for the current context.`,
 	Example: `# Print client and server-side version 
 	flux version
 


### PR DESCRIPTION
add the following note to all non-GA commands as described in #3274:

>⚠️  Please note that this command (group) is in preview and under development.
While we try our best to not introduce breaking changes, they may occur when
we adapt to new features and/or find better ways to facilitate what it does.

fixes #3739 