### PR TITLE
Add the possibility to ignore files with build and diff Kustomization

### DIFF
--- a/cmd/flux/build_kustomization_test.go
+++ b/cmd/flux/build_kustomization_test.go
@@ -63,6 +63,12 @@ func TestBuildKustomization(t *testing.T) {
 			resultFile: "./testdata/build-kustomization/podinfo-with-var-substitution-result.yaml",
 			assertFunc: "assertGoldenTemplateFile",
 		},
+		{
+			name:       "build ignore",
+			args:       "build kustomization podinfo --path ./testdata/build-kustomization/ignore --ignore-paths \"!configmap.yaml,!secret.yaml\"",
+			resultFile: "./testdata/build-kustomization/podinfo-with-ignore-result.yaml",
+			assertFunc: "assertGoldenTemplateFile",
+		},
 	}
 
 	tmpl := map[string]string{

--- a/cmd/flux/testdata/build-kustomization/ignore/.sourceignore
+++ b/cmd/flux/testdata/build-kustomization/ignore/.sourceignore
@@ -1,0 +1,2 @@
+# exclude all
+/*

--- a/cmd/flux/testdata/build-kustomization/ignore/configmap.yaml
+++ b/cmd/flux/testdata/build-kustomization/ignore/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+data:
+  var: test
+kind: ConfigMap
+metadata:
+  name: configmap_ignore

--- a/cmd/flux/testdata/build-kustomization/ignore/not_deployable/ignore_svc.yaml
+++ b/cmd/flux/testdata/build-kustomization/ignore/not_deployable/ignore_svc.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: do_not_deploy
+spec:
+  type: ClusterIP
+  selector:
+    app: podinfo
+  ports:
+    - name: http
+      port: 9898
+      protocol: TCP
+      targetPort: http
+    - port: 9999
+      targetPort: grpc
+      protocol: TCP
+      name: grpc

--- a/cmd/flux/testdata/build-kustomization/ignore/secret.yaml
+++ b/cmd/flux/testdata/build-kustomization/ignore/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+  token: KipTT1BTKio=
+kind: Secret
+metadata:
+  name: secret_ignore
+type: Opaque

--- a/cmd/flux/testdata/build-kustomization/podinfo-with-ignore-result.yaml
+++ b/cmd/flux/testdata/build-kustomization/podinfo-with-ignore-result.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+data:
+  var: test
+kind: ConfigMap
+metadata:
+  labels:
+    kustomize.toolkit.fluxcd.io/name: podinfo
+    kustomize.toolkit.fluxcd.io/namespace: {{ .fluxns }}
+  name: configmap_ignore
+  namespace: default
+---
+apiVersion: v1
+data:
+  token: KipTT1BTKio=
+kind: Secret
+metadata:
+  labels:
+    kustomize.toolkit.fluxcd.io/name: podinfo
+    kustomize.toolkit.fluxcd.io/namespace: {{ .fluxns }}
+  name: secret_ignore
+  namespace: default
+type: Opaque
+---

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/fluxcd/pkg/apis/meta v1.0.0
 	github.com/fluxcd/pkg/git v0.11.0
 	github.com/fluxcd/pkg/git/gogit v0.8.1
-	github.com/fluxcd/pkg/kustomize v1.1.0
+	github.com/fluxcd/pkg/kustomize v1.1.1
 	github.com/fluxcd/pkg/oci v0.22.0
 	github.com/fluxcd/pkg/runtime v0.35.0
 	github.com/fluxcd/pkg/sourceignore v0.3.3

--- a/go.sum
+++ b/go.sum
@@ -222,8 +222,8 @@ github.com/fluxcd/pkg/git v0.11.0/go.mod h1:VHRVlrZMHNoWBlaSAWxlGH6Vwlb9VRazUhPU
 github.com/fluxcd/pkg/git/gogit v0.8.1 h1:Q3EV2WBX6HiXSmsHyrwFzwl82gO4ZtFwb675iQPWwVc=
 github.com/fluxcd/pkg/git/gogit v0.8.1/go.mod h1:5M27gCl0gyo6l+ht9HwZSzimPY3LahKVIJ7/1vCCctg=
 github.com/fluxcd/pkg/gittestserver v0.8.1 h1:FMqnZBuS/11+9NhtLv9UAg+wm/v0Nf+hHeUOi2wJR3Q=
-github.com/fluxcd/pkg/kustomize v1.1.0 h1:4qoTJBCtlg9RbO6YUwTNV3SttvXRIZxkjRRJE+jbsKk=
-github.com/fluxcd/pkg/kustomize v1.1.0/go.mod h1:i+Z9iPAoSz28oH0FmDI73iqZ3oXZxQR2O3HfhdsWhfo=
+github.com/fluxcd/pkg/kustomize v1.1.1 h1:hYFJGi+fiaecY4gXvx52fumlvDEq/1RdFbaev67oBhE=
+github.com/fluxcd/pkg/kustomize v1.1.1/go.mod h1:i+Z9iPAoSz28oH0FmDI73iqZ3oXZxQR2O3HfhdsWhfo=
 github.com/fluxcd/pkg/oci v0.22.0 h1:6QRvCj1YXGEGXHyVkmKiBvYxsE0sEjUrpFknM513MbQ=
 github.com/fluxcd/pkg/oci v0.22.0/go.mod h1:y0jUgMqb6ionfX+8AjhnoG8D6hSSx4elhtrQ7Uo0WzI=
 github.com/fluxcd/pkg/runtime v0.35.0 h1:9PYLcul8qdfLYQArcYpHe/QuMqyhAGGFN9F7uY/QVX4=


### PR DESCRIPTION
If implemented, users will be able to ignore files when using `build kustomization` and `diff kustomization` using `.sourceignore` and `ignore-paths` flag.

`ignore-paths` accepts a comma separated list of entries that follow the .gitignore pattern format.

Fix: #3760