### PR TITLE
better messaging for `pull artifact` command

### DIFF
--- a/cmd/flux/pull_artifact.go
+++ b/cmd/flux/pull_artifact.go
@@ -67,11 +67,11 @@ func pullArtifactCmdRun(cmd *cobra.Command, args []string) error {
 	ociURL := args[0]
 
 	if pullArtifactArgs.output == "" {
-		return fmt.Errorf("invalid output path %s", pullArtifactArgs.output)
+		return fmt.Errorf("output path cannot be empty")
 	}
 
 	if fs, err := os.Stat(pullArtifactArgs.output); err != nil || !fs.IsDir() {
-		return fmt.Errorf("invalid output path %s", pullArtifactArgs.output)
+		return fmt.Errorf("invalid output path %q: %w", pullArtifactArgs.output, err)
 	}
 
 	url, err := oci.ParseArtifactURL(ociURL)


### PR DESCRIPTION
- When there's an error stat'ing the output directory flux now prints
  the error:

  Before:
  ```
  ✗ invalid output path ./ro-dir/foo
  ```

  After:
  ```
  ✗ invalid output path "./ro-dir/foo": stat ./ro-dir/foo: permission denied
  ```
- When no output directory is provided flux now explicitly says so in
  the error:

  Before:
  ```
  ✗ invalid output path
  ```

  After:
  ```
  ✗ output path cannot be empty
  ```
