### PR TITLE
Outdated Loki Helm values URL

### DIFF
--- a/manifests/monitoring/loki-stack/release.yaml
+++ b/manifests/monitoring/loki-stack/release.yaml
@@ -15,7 +15,7 @@ spec:
         name: grafana-charts
       interval: 60m
   # https://github.com/grafana/helm-charts/blob/main/charts/loki-stack/values.yaml
-  # https://github.com/grafana/helm-charts/blob/main/charts/loki/values.yaml
+  # https://github.com/grafana/loki/blob/main/production/helm/loki/values.yaml
   values:
     grafana:
       enabled: false


### PR DESCRIPTION
The location of this URL was moved: https://github.com/grafana/helm-charts/blob/main/charts/loki/README.md