### PR TITLE
e2e: Add summary to Azure Alert

### DIFF
--- a/tests/azure/azure_test.go
+++ b/tests/azure/azure_test.go
@@ -842,6 +842,7 @@ func TestEventHubNotification(t *testing.T) {
 					Namespace: name,
 				},
 			},
+			Summary: "cluster: test-1",
 		}
 		return nil
 	})


### PR DESCRIPTION
This updates the Azure alert testing to add a summary which should be sent to Azure as a commit-status genre.