### PR TITLE
Add ResourceQuota for critical pods

### DIFF
--- a/manifests/rbac/kustomization.yaml
+++ b/manifests/rbac/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - reconciler.yaml
   - edit.yaml
   - view.yaml
+  - resourcequota.yaml

--- a/manifests/rbac/resourcequota.yaml
+++ b/manifests/rbac/resourcequota.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: critical-pods
+spec:
+  hard:
+    pods: "1000"
+  scopeSelector:
+    matchExpressions:
+      - operator: In
+        scopeName: PriorityClass
+        values:
+          - system-node-critical
+          - system-cluster-critical


### PR DESCRIPTION
Added `ResourceQuota` for critical pods set to max 1K pods to allow horizontal scaling and sharding. 

Fixes insufficient quota error on GKE, reported [here](https://github.com/fluxcd/flux2/issues/3800#issuecomment-1544270865).

Tested on GKE 1.26

```console
$ flux check
► checking prerequisites
✔ Kubernetes 1.26.2-gke.1000 >=1.20.6-0
► checking controllers
✔ helm-controller: deployment ready
► ghcr.io/fluxcd/helm-controller:v0.32.2
✔ kustomize-controller: deployment ready
► ghcr.io/fluxcd/kustomize-controller:v1.0.0-rc.2
✔ notification-controller: deployment ready
► ghcr.io/fluxcd/notification-controller:v1.0.0-rc.2
✔ source-controller: deployment ready
► ghcr.io/fluxcd/source-controller:v1.0.0-rc.2
► checking crds
✔ alerts.notification.toolkit.fluxcd.io/v1beta2
✔ buckets.source.toolkit.fluxcd.io/v1beta2
✔ gitrepositories.source.toolkit.fluxcd.io/v1
✔ helmcharts.source.toolkit.fluxcd.io/v1beta2
✔ helmreleases.helm.toolkit.fluxcd.io/v2beta1
✔ helmrepositories.source.toolkit.fluxcd.io/v1beta2
✔ kustomizations.kustomize.toolkit.fluxcd.io/v1
✔ ocirepositories.source.toolkit.fluxcd.io/v1beta2
✔ providers.notification.toolkit.fluxcd.io/v1beta2
✔ receivers.notification.toolkit.fluxcd.io/v1
✔ all checks passed
```

PS. We need to find a better place for the manifest location, but since this requires changes to the manifest generation logic and packaging, I'll leave it for another time.