### PR TITLE
Fix break lines in create helmrelease and source

### DIFF
--- a/cmd/flux/create_helmrelease.go
+++ b/cmd/flux/create_helmrelease.go
@@ -83,9 +83,9 @@ var createHelmReleaseCmd = &cobra.Command{
 
   # Create a HelmRelease with a custom release name
   flux create hr podinfo \
-    --release-name=podinfo-dev
+    --release-name=podinfo-dev \
     --source=HelmRepository/podinfo \
-    --chart=podinfo \
+    --chart=podinfo
 
   # Create a HelmRelease targeting another namespace than the resource
   flux create hr podinfo \

--- a/cmd/flux/create_source_helm.go
+++ b/cmd/flux/create_source_helm.go
@@ -64,13 +64,13 @@ For private Helm repositories, the basic authentication credentials are stored i
 
   # Create a source for an OCI Helm repository
   flux create source helm podinfo \
-    --url=oci://ghcr.io/stefanprodan/charts/podinfo
+    --url=oci://ghcr.io/stefanprodan/charts/podinfo \
     --username=username \
     --password=password
 
   # Create a source for an OCI Helm repository using an existing secret with basic auth or dockerconfig credentials
   flux create source helm podinfo \
-    --url=oci://ghcr.io/stefanprodan/charts/podinfo
+    --url=oci://ghcr.io/stefanprodan/charts/podinfo \
     --secret-ref=docker-config`,
 	RunE: createSourceHelmCmdRun,
 }


### PR DESCRIPTION
Hello flux maintainers!

This PR fixes a few missing break lines in the create helmrelease and create source help documentation that could lead to some unintended executions if blindly copy-pasted 

For example, I've added `--export` to the `create source helm` OCI example included in the `flux create source helm --help` command:

Discovered this while I was pasting examples in my terminal with the `--export` flag to check if I was using the newest API versions for my flux objects

```
❯   flux create source helm podinfo \
    --url=oci://ghcr.io/stefanprodan/charts/podinfo
    --username=username \
    --password=password --export
✚ generating HelmRepository source
► applying HelmRepository source
✔ source updated
◎ waiting for HelmRepository source reconciliation
^C
```
