### PR TITLE
Return clone error in Azure e2e tests

### DIFF
--- a/tests/azure/util_test.go
+++ b/tests/azure/util_test.go
@@ -318,6 +318,9 @@ func getRepository(repoURL, branchName string, overrideBranch bool, password str
 			Branch: checkoutBranch,
 		},
 	})
+	if err != nil {
+		return nil, "", err
+	}
 
 	err = c.SwitchBranch(context.Background(), branchName)
 	if err != nil {


### PR DESCRIPTION
Checks and returns error if cloning Azure DevOps repository fails