### PR TITLE
Set controller runtime logger in Azure e2e tests

### DIFF
--- a/tests/azure/azure_test.go
+++ b/tests/azure/azure_test.go
@@ -44,8 +44,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2/klogr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	runtimeLog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	automationv1beta1 "github.com/fluxcd/image-automation-controller/api/v1beta1"
 	reflectorv1beta2 "github.com/fluxcd/image-reflector-controller/api/v1beta2"
@@ -111,7 +113,7 @@ func TestMain(m *testing.M) {
 
 func setup(m *testing.M) (exitVal int, err error) {
 	ctx := context.TODO()
-
+	runtimeLog.SetLogger(klogr.New())
 	// Setup Terraform binary and init state
 	log.Println("Setting up Azure test infrastructure")
 	i := install.NewInstaller()

--- a/tests/azure/go.mod
+++ b/tests/azure/go.mod
@@ -24,6 +24,7 @@ require (
 	k8s.io/api v0.27.2
 	k8s.io/apimachinery v0.27.2
 	k8s.io/client-go v0.27.2
+	k8s.io/klog/v2 v2.100.1
 	sigs.k8s.io/controller-runtime v0.15.0
 )
 
@@ -111,7 +112,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.27.2 // indirect
-	k8s.io/klog/v2 v2.100.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f // indirect
 	k8s.io/utils v0.0.0-20230505201702-9f6742963106 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/tests/azure/util_test.go
+++ b/tests/azure/util_test.go
@@ -318,6 +318,9 @@ func getRepository(repoURL, branchName string, overrideBranch bool, password str
 			Branch: checkoutBranch,
 		},
 	})
+	if err != nil {
+		return nil, "", err
+	}
 
 	err = c.SwitchBranch(context.Background(), branchName)
 	if err != nil {


### PR DESCRIPTION
This pull request sets the controller-runtime logger and checks for clone errors.