### PR TITLE
Make `flux logs` more lenient

### DIFF
--- a/cmd/flux/logs_e2e_test.go
+++ b/cmd/flux/logs_e2e_test.go
@@ -1,0 +1,88 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2021 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+)
+
+func TestLogsNoArgs(t *testing.T) {
+	cmd := cmdTestCase{
+		args:   "logs",
+		assert: assertSuccess(),
+	}
+	cmd.runTestCmd(t)
+}
+
+func TestLogsWrongNamespace(t *testing.T) {
+	cmd := cmdTestCase{
+		args:   "logs --flux-namespace=default",
+		assert: assertError(`no Flux pods found in namespace "default"`),
+	}
+	cmd.runTestCmd(t)
+}
+
+func TestLogsAllNamespaces(t *testing.T) {
+	cmd := cmdTestCase{
+		args:   "logs --all-namespaces",
+		assert: assertSuccess(),
+	}
+	cmd.runTestCmd(t)
+}
+
+func TestLogsSince(t *testing.T) {
+	cmd := cmdTestCase{
+		args:   "logs --since=2m",
+		assert: assertSuccess(),
+	}
+	cmd.runTestCmd(t)
+}
+
+func TestLogsSinceInvalid(t *testing.T) {
+	cmd := cmdTestCase{
+		args:   "logs --since=XXX",
+		assert: assertError(`invalid argument "XXX" for "--since" flag: time: invalid duration "XXX"`),
+	}
+	cmd.runTestCmd(t)
+}
+
+func TestLogsSinceTime(t *testing.T) {
+	cmd := cmdTestCase{
+		args:   "logs --since-time=2021-08-06T14:26:25.546Z",
+		assert: assertSuccess(),
+	}
+	cmd.runTestCmd(t)
+}
+
+func TestLogsSinceTimeInvalid(t *testing.T) {
+	cmd := cmdTestCase{
+		args:   "logs --since-time=XXX",
+		assert: assertError("XXX is not a valid (RFC3339) time"),
+	}
+	cmd.runTestCmd(t)
+}
+
+func TestLogsSinceOnlyOneAllowed(t *testing.T) {
+	cmd := cmdTestCase{
+		args:   "logs --since=2m --since-time=2021-08-06T14:26:25.546Z",
+		assert: assertError("at most one of `sinceTime` or `sinceSeconds` may be specified"),
+	}
+	cmd.runTestCmd(t)
+}

--- a/cmd/flux/logs_unit_test.go
+++ b/cmd/flux/logs_unit_test.go
@@ -30,73 +30,17 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestLogsNoArgs(t *testing.T) {
-	cmd := cmdTestCase{
-		args:   "logs",
-		assert: assertSuccess(),
-	}
-	cmd.runTestCmd(t)
-}
-
-func TestLogsAllNamespaces(t *testing.T) {
-	cmd := cmdTestCase{
-		args:   "logs --all-namespaces",
-		assert: assertSuccess(),
-	}
-	cmd.runTestCmd(t)
-}
-
-func TestLogsSince(t *testing.T) {
-	cmd := cmdTestCase{
-		args:   "logs --since=2m",
-		assert: assertSuccess(),
-	}
-	cmd.runTestCmd(t)
-}
-
-func TestLogsSinceInvalid(t *testing.T) {
-	cmd := cmdTestCase{
-		args:   "logs --since=XXX",
-		assert: assertError(`invalid argument "XXX" for "--since" flag: time: invalid duration "XXX"`),
-	}
-	cmd.runTestCmd(t)
-}
-
-func TestLogsSinceTime(t *testing.T) {
-	cmd := cmdTestCase{
-		args:   "logs --since-time=2021-08-06T14:26:25.546Z",
-		assert: assertSuccess(),
-	}
-	cmd.runTestCmd(t)
-}
-
-func TestLogsSinceTimeInvalid(t *testing.T) {
-	cmd := cmdTestCase{
-		args:   "logs --since-time=XXX",
-		assert: assertError("XXX is not a valid (RFC3339) time"),
-	}
-	cmd.runTestCmd(t)
-}
-
-func TestLogsSinceOnlyOneAllowed(t *testing.T) {
-	cmd := cmdTestCase{
-		args:   "logs --since=2m --since-time=2021-08-06T14:26:25.546Z",
-		assert: assertError("at most one of `sinceTime` or `sinceSeconds` may be specified"),
-	}
-	cmd.runTestCmd(t)
-}
-
 func TestLogRequest(t *testing.T) {
 	mapper := &testResponseMapper{}
 	tests := []struct {
 		name       string
 		namespace  string
-		flags      *logsFlags
+		flags      logsFlags
 		assertFile string
 	}{
 		{
 			name: "all logs",
-			flags: &logsFlags{
+			flags: logsFlags{
 				tail:          -1,
 				allNamespaces: true,
 			},
@@ -105,14 +49,14 @@ func TestLogRequest(t *testing.T) {
 		{
 			name:      "filter by namespace",
 			namespace: "default",
-			flags: &logsFlags{
+			flags: logsFlags{
 				tail: -1,
 			},
 			assertFile: "testdata/logs/namespace.txt",
 		},
 		{
 			name: "filter by kind and namespace",
-			flags: &logsFlags{
+			flags: logsFlags{
 				tail: -1,
 				kind: "Kustomization",
 			},
@@ -120,7 +64,7 @@ func TestLogRequest(t *testing.T) {
 		},
 		{
 			name: "filter by loglevel",
-			flags: &logsFlags{
+			flags: logsFlags{
 				tail:          -1,
 				logLevel:      "error",
 				allNamespaces: true,
@@ -130,7 +74,7 @@ func TestLogRequest(t *testing.T) {
 		{
 			name:      "filter by namespace, name, loglevel and kind",
 			namespace: "flux-system",
-			flags: &logsFlags{
+			flags: logsFlags{
 				tail:     -1,
 				logLevel: "error",
 				kind:     "Kustomization",
@@ -163,7 +107,7 @@ func TestLogRequest(t *testing.T) {
 
 			// reset flags to default
 			*kubeconfigArgs.Namespace = rootArgs.defaults.Namespace
-			logsArgs = &logsFlags{
+			logsArgs = logsFlags{
 				tail: -1,
 			}
 		})

--- a/cmd/flux/main_test.go
+++ b/cmd/flux/main_test.go
@@ -392,6 +392,10 @@ func resetCmdArgs() {
 	alertProviderArgs = alertProviderFlags{}
 	bootstrapArgs = NewBootstrapFlags()
 	bServerArgs = bServerFlags{}
+	logsArgs = logsFlags{
+		tail:          -1,
+		fluxNamespace: rootArgs.defaults.Namespace,
+	}
 	buildKsArgs = buildKsFlags{}
 	checkArgs = checkFlags{}
 	createArgs = createFlags{}


### PR DESCRIPTION
**UX changes:**

- Only print an error when a pod doesn't have a matching container
  instead of exiting early.
- Return a non-zero status code when no pod is found at all.

**Details:**

In certain situations there might be 3rd-party pods running in the
Flux namespace that cause the command to fail streaming logs, e.g.
when they have multiple containers but none of them is called
`manager` (which all Flux-maintained pods do). An example of such a
situation is when Flux is installed with the 3rd-party Flux extension
on AKS.

The `logs` command is now more forgiving and merely logs an error in
these situations instead of completely bailing out. It still returns a
non-zero exit code.

For the parallel log streaming with `-f` the code is now a little more
complex so that errors are now written to stderr in parallel with all
other logs written to stdout. That's what `asyncCopy` is for.

**Before:**

```
$ flux logs
✗ container manager is not valid for pod nginx-797bf9d444-vrhdr
$ echo $?
1
```

**After:**

```
$ flux logs
[...]
2023-06-01T08:05:07.860Z info Kustomization/flux-system.flux-system - Discarding event, no alerts found for the involved object 
2023-06-01T08:15:08.581Z info Kustomization/flux-system.flux-system - Discarding event, no alerts found for the involved object
container manager is not valid for pod nginx-797bf9d444-tbc8m
container manager is not valid for pod nginx2-7b4b6d8d54-stdrk
2023-06-02T12:11:17.309Z info GitRepository/flux-system.flux-system - Discarding event, no alerts found for the involved object 
2023-06-02T12:11:18.811Z info Kustomization/flux-system.flux-system - Discarding event, no alerts found for the involved object
[...]
✗ failed to collect logs from all Flux pods
$ echo $?
1
```

## Tests

I changed the testing of the `logs` command and split the tests into unit and e2e tests so that the tests running the actual command are now run as part of the e2e suite so that they run against an actual cluster and we can test more complex scenarios and also because the command now fails if no pod can be found to print logs from.

refs #3944
