### PR TITLE
Use equivalent and shorter way to generate shell completions

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -83,14 +83,7 @@ brews:
     install: |
       bin.install "flux"
 
-      bash_output = Utils.safe_popen_read(bin/"flux", "completion", "bash")
-      (bash_completion/"flux").write bash_output
-
-      zsh_output = Utils.safe_popen_read(bin/"flux", "completion", "zsh")
-      (zsh_completion/"_flux").write zsh_output
-
-      fish_output = Utils.safe_popen_read(bin/"flux", "completion", "fish")
-      (fish_completion/"flux.fish").write fish_output
+      generate_completions_from_executable(bin/"flux", "completion")
     test: |
       system "#{bin}/flux --version"
 publishers:


### PR DESCRIPTION
Replace homebrew script with equivalent and [more shorter method](https://rubydoc.brew.sh/Formula#generate_completions_from_executable-instance_method) to install shell completion script.
