### PR TITLE
Don't log errors with missing CRDs for "get * all" commands

### DIFF
--- a/cmd/flux/get.go
+++ b/cmd/flux/get.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -27,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/discovery"
 	watchtools "k8s.io/client-go/tools/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -176,6 +178,10 @@ func (get getCommand) run(cmd *cobra.Command, args []string) error {
 
 	err = kubeClient.List(ctx, get.list.asClientList(), listOpts...)
 	if err != nil {
+		var discErr *discovery.ErrGroupDiscoveryFailed
+		if getAll && (strings.Contains(err.Error(), "no matches for kind") || errors.As(err, &discErr)) {
+			return nil
+		}
 		return err
 	}
 

--- a/cmd/flux/get_image_all.go
+++ b/cmd/flux/get_image_all.go
@@ -17,8 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"strings"
-
 	"github.com/spf13/cobra"
 
 	autov1 "github.com/fluxcd/image-automation-controller/api/v1beta1"
@@ -57,9 +55,7 @@ var getImageAllCmd = &cobra.Command{
 
 		for _, c := range allImageCmd {
 			if err := c.run(cmd, args); err != nil {
-				if !strings.Contains(err.Error(), "no matches for kind") {
-					logger.Failuref(err.Error())
-				}
+				logger.Failuref(err.Error())
 			}
 		}
 


### PR DESCRIPTION
Whenever an API type is not available then both, `flux get all` and `flux get image all` will just skip over that type instead of logging an error message.

Before:

```
$ flux get all
✗ failed to get API group resources: unable to retrieve the complete list of server APIs: source.toolkit.fluxcd.io/v1beta2: the server could not find the requested resource
[...]
✗ failed to get API group resources: unable to retrieve the complete list of server APIs: image.toolkit.fluxcd.io/v1beta2: the server could not find the requested resource
✗ failed to get API group resources: unable to retrieve the complete list of server APIs: image.toolkit.fluxcd.io/v1beta2: the server could not find the requested resource
[...]
$ echo $?
0
```

After:

```
$ flux get all
$ echo $?
0
```

closes #3973
