### PR TITLE
Set minimum supported version to Kubernetes 1.24.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,8 +68,8 @@ for source changes.
 Prerequisites:
 
 * go >= 1.20
-* kubectl >= 1.20
-* kustomize >= 4.4
+* kubectl >= 1.24
+* kustomize >= 5.0
 * coreutils (on Mac OS)
 
 Install the [controller-runtime/envtest](https://github.com/kubernetes-sigs/controller-runtime/tree/master/tools/setup-envtest) binaries with:

--- a/cmd/flux/check.go
+++ b/cmd/flux/check.go
@@ -57,7 +57,7 @@ type checkFlags struct {
 }
 
 var kubernetesConstraints = []string{
-	">=1.20.6-0",
+	">=1.24.0-0",
 }
 
 var checkArgs checkFlags

--- a/cmd/flux/testdata/check/check_pre.golden
+++ b/cmd/flux/testdata/check/check_pre.golden
@@ -1,3 +1,3 @@
 ► checking prerequisites
-✔ Kubernetes {{ .serverVersion }} >=1.20.6-0
+✔ Kubernetes {{ .serverVersion }} >=1.24.0-0
 ✔ prerequisites checks passed


### PR DESCRIPTION
Bump the minimum supported version to Kubernetes 1.24.0 as 1.23/22 are now EOL https://endoflife.date/kubernetes