### PR TITLE
Run e2e tests on release branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,13 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     labels: ["area/ci", "dependencies"]
+    groups:
+      # Group all updates together, so that they are all applied in a single PR.
+      # Grouped updates are currently in beta and is subject to change.
+      # xref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
+      ci:
+        patterns:
+          - "*"
     schedule:
       # By default, this will be on a monday.
       interval: "weekly"

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -23,6 +23,8 @@ jobs:
         uses: korthout/backport-action@bf5fdd624b35f95d5b85991a728bd5744e8c6cf2 # v1.3.1
         # xref: https://github.com/korthout/backport-action#inputs
         with:
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
+          github_workspace: ${{ github.workspace }}
           # Match labels with a pattern `backport:<target-branch>`
           label_pattern: '^backport:([^ ]+)$'
           # A bit shorter pull-request title than the default

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -4,15 +4,11 @@ on:
   pull_request_target:
     types: [closed, labeled]
 
-permissions:
-  contents: read
-
 jobs:
   pull-request:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     if: github.event.pull_request.state == 'closed' && github.event.pull_request.merged && (github.event_name != 'labeled' || startsWith('backport:', github.event.label.name))
     steps:
       - name: Checkout
@@ -23,8 +19,8 @@ jobs:
         uses: korthout/backport-action@bf5fdd624b35f95d5b85991a728bd5744e8c6cf2 # v1.3.1
         # xref: https://github.com/korthout/backport-action#inputs
         with:
-          token: ${{ secrets.BOT_GITHUB_TOKEN }}
-          github_workspace: ${{ github.workspace }}
+          # Use token to allow workflows to be triggered for the created PR
+          github_token: ${{ secrets.BOT_GITHUB_TOKEN }}
           # Match labels with a pattern `backport:<target-branch>`
           label_pattern: '^backport:([^ ]+)$'
           # A bit shorter pull-request title than the default

--- a/.github/workflows/e2e-arm64.yaml
+++ b/.github/workflows/e2e-arm64.yaml
@@ -3,7 +3,7 @@ name: e2e-arm64
 on:
   workflow_dispatch:
   push:
-    branches: [ main, update-components, e2e-*, release-* ]
+    branches: [ 'main', 'update-components', 'e2e-*', 'release/**' ]
 
 permissions:
   contents: read

--- a/.github/workflows/e2e-bootstrap.yaml
+++ b/.github/workflows/e2e-bootstrap.yaml
@@ -3,9 +3,9 @@ name: e2e-bootstrap
 on:
   workflow_dispatch:
   push:
-    branches: [ main, release-* ]
+    branches: [ 'main', 'release/**' ]
   pull_request:
-    branches: [ main, release-* ]
+    branches: [ 'main', 'release/**' ]
 
 permissions:
   contents: read

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -3,9 +3,9 @@ name: e2e
 on:
   workflow_dispatch:
   push:
-    branches: [ main, release-* ]
+    branches: [ 'main', 'release/**' ]
   pull_request:
-    branches: [ main, release-* ]
+    branches: [ 'main', 'release/**' ]
 
 permissions:
   contents: read

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -3,9 +3,9 @@ name: scan
 on:
   workflow_dispatch:
   push:
-    branches: [ main ]
+    branches: [ 'main', 'release/**' ]
   pull_request:
-    branches: [ main ]
+    branches: [ 'main', 'release/**' ]
   schedule:
     - cron: '18 10 * * 3'
 

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -99,7 +99,7 @@ jobs:
           body: |
             ${{ steps.update.outputs.pr_body }}
           labels: |
-            area/build
+            dependencies
           reviewers: ${{ secrets.ASSIGNEES }}
 
       - name: Check output


### PR DESCRIPTION
Changes:
- run backport under fluxcdbot account
- enable workflows for `release/**` branches
- group all GH action updates under the same PR