### PR TITLE
Run conformance tests for Kubernetes v1.27.3

### DIFF
--- a/.github/workflows/e2e-arm64.yaml
+++ b/.github/workflows/e2e-arm64.yaml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         # Keep this list up-to-date with https://endoflife.date/kubernetes
         # Check which versions are available on DockerHub with 'crane ls kindest/node'
-        KUBERNETES_VERSION: [ 1.25.8, 1.26.3, 1.27.1 ]
+        KUBERNETES_VERSION: [ 1.25.8, 1.26.3, 1.27.3 ]
     steps:
       - name: Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/.github/workflows/e2e-bootstrap.yaml
+++ b/.github/workflows/e2e-bootstrap.yaml
@@ -6,6 +6,7 @@ on:
     branches: [ 'main', 'release/**' ]
   pull_request:
     branches: [ 'main', 'release/**' ]
+    paths-ignore: [ 'docs/**', 'rfcs/**' ]
 
 permissions:
   contents: read
@@ -27,12 +28,12 @@ jobs:
       - name: Setup Kubernetes
         uses: helm/kind-action@fa81e57adff234b2908110485695db0f181f3c67 # v1.7.0
         with:
-          version: v0.17.0
+          version: v0.20.0
           cluster_name: kind
           # The versions below should target the newest Kubernetes version
           # Keep this up-to-date with https://endoflife.date/kubernetes
-          node_image: kindest/node:v1.26.0
-          kubectl_version: v1.26.2
+          node_image: kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
+          kubectl_version: v1.27.3
       - name: Setup Kustomize
         uses: fluxcd/pkg/actions/kustomize@main
       - name: Build

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -6,6 +6,7 @@ on:
     branches: [ 'main', 'release/**' ]
   pull_request:
     branches: [ 'main', 'release/**' ]
+    paths-ignore: [ 'docs/**', 'rfcs/**' ]
 
 permissions:
   contents: read
@@ -31,13 +32,13 @@ jobs:
       - name: Setup Kubernetes
         uses: helm/kind-action@fa81e57adff234b2908110485695db0f181f3c67 # v1.7.0
         with:
-          version: v0.17.0
+          version: v0.20.0
           cluster_name: kind
           config: .github/kind/config.yaml # disable KIND-net
           # The versions below should target the newest Kubernetes version
           # Keep this up-to-date with https://endoflife.date/kubernetes
-          node_image: kindest/node:v1.26.0
-          kubectl_version: v1.26.2
+          node_image: kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
+          kubectl_version: v1.27.3
       - name: Setup Calico for network policy
         run: |
           kubectl apply -f https://docs.projectcalico.org/v3.25/manifests/calico.yaml


### PR DESCRIPTION
CI changes:
- bump kind to v0.20.0
- bump Kubernetes to v1.27.3
- don't run e2e tests for docs changes 