### PR TITLE
[release/v2.0.x] ci: release: disable interpretation backslash esc

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -94,7 +94,7 @@ jobs:
         run: |
           set -euo pipefail
           
-          hashes=$(echo $ARTIFACTS | jq --raw-output '.[] | {name, "digest": (.extra.Digest // .extra.Checksum)} | select(.digest) | {digest} + {name} | join("  ") | sub("^sha256:";"")' | base64 -w0)
+          hashes=$(echo -E $ARTIFACTS | jq --raw-output '.[] | {name, "digest": (.extra.Digest // .extra.Checksum)} | select(.digest) | {digest} + {name} | join("  ") | sub("^sha256:";"")' | base64 -w0)
           echo "hashes=$hashes" >> $GITHUB_OUTPUT
           
           image_url=fluxcd/flux-cli:${{ steps.prep.outputs.version }}


### PR DESCRIPTION
Backport of #4041 to `release/v2.0.x`.