### PR TITLE
ci: backport: set write permissions

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -8,7 +8,8 @@ jobs:
   pull-request:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
+      pull-requests: write
     if: github.event.pull_request.state == 'closed' && github.event.pull_request.merged && (github.event_name != 'labeled' || startsWith('backport:', github.event.label.name))
     steps:
       - name: Checkout


### PR DESCRIPTION
The backport workflow uses the default token to push the cherrypick branch so we need to give it write perms.