### PR TITLE
action: use `$RUNNER_TOOL_CACHE`, support MacOS and Windows, validate checksum

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -1,0 +1,29 @@
+name: test-gh-action
+
+on:
+  pull_request:
+    paths:
+      - 'action/**'
+  push:
+    paths:
+      - 'action/**'
+    branches:
+      - 'main'
+      - 'release/**'
+
+permissions: read-all
+
+jobs:
+  actions:
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [ubuntu-latest, macos-latest, windows-latest]
+
+    runs-on: ${{ matrix.version }}
+    name: action on ${{ matrix.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - name: Setup flux
+        uses: ./action

--- a/action/action.yml
+++ b/action/action.yml
@@ -1,64 +1,104 @@
 name: Setup Flux CLI
-description: A GitHub Action for running Flux commands
-author: Stefan Prodan
+description: A GitHub Action for installing the Flux CLI
+author: Flux project
 branding:
   color: blue
   icon: command
 inputs:
   version:
-    description: "Flux version e.g. 0.8.0 (defaults to latest stable release)"
+    description: "Flux version e.g. 2.0.0 (defaults to latest stable release)"
     required: false
   arch:
     description: "arch can be amd64, arm64 or arm"
-    required: true
-    default: "amd64"
+    required: false
+    deprecationMessage: "No longer required, action will now detect runner arch."
   bindir:
-    description: "Optional location of the Flux binary. Will not use sudo if set. Updates System Path."
+    description: "Alternative location for the Flux binary, defaults to path relative to $RUNNER_TOOL_CACHE."
     required: false
   token:
     description: "GitHub Token used to authentication against the API (generally only needed to prevent quota limit errors)"
     required: false
+    deprecationMessage: "No longer required, action will now use GitHub token from runner."
 runs:
   using: composite
   steps:
-    - name: "Download flux binary to tmp"
+    - name: "Download the binary to the runner's cache dir"
       shell: bash
       run: |
-        ARCH=${{ inputs.arch }}
         VERSION=${{ inputs.version }}
-        TOKEN=${{ inputs.token }}
+        if [[ -z "$VERSION" ]] || [[ "$VERSION" = "latest" ]]; then
+          VERSION=$(curl -fsSL -H "Authorization: token ${{ github.token }}" https://api.github.com/repos/fluxcd/flux2/releases/latest | grep tag_name | cut -d '"' -f 4)
+        fi
+        if [[ -z "$VERSION" ]]; then
+          echo "Unable to determine Flux CLI version"
+          exit 1
+        fi
+        if [[ $VERSION = v* ]]; then
+          VERSION="${VERSION:1}"
+        fi
 
-        if [ -z "${VERSION}" ]; then
-          if [ -n "${TOKEN}" ]; then
-            VERSION_SLUG=$(curl https://api.github.com/repos/fluxcd/flux2/releases/latest --silent --location --header "Authorization: token ${TOKEN}" | grep tag_name)
-          else
-            # With no GITHUB_TOKEN you will experience occasional failures due to rate limiting
-            # Ref: https://github.com/fluxcd/flux2/issues/3509#issuecomment-1400820992
-            VERSION_SLUG=$(curl https://api.github.com/repos/fluxcd/flux2/releases/latest --silent --location | grep tag_name)
+        OS=$(echo "${RUNNER_OS}" | tr '[:upper:]' '[:lower:]')
+        if [[ "$OS" == "macos" ]]; then
+          OS="darwin"
+        fi
+
+        ARCH=$(echo "${RUNNER_ARCH}" | tr '[:upper:]' '[:lower:]')
+        if [[ "$ARCH" == "x64" ]]; then
+          ARCH="amd64"
+        elif [[ "$ARCH" == "x86" ]]; then
+          ARCH="386"
+        fi
+
+        FLUX_EXEC_FILE="flux"
+        if [[ "$OS" == "windows" ]]; then
+            FLUX_EXEC_FILE="${FLUX_EXEC_FILE}.exe"
+        fi
+
+        FLUX_TOOL_DIR=${{ inputs.bindir }}
+        if [[ -z "$FLUX_TOOL_DIR" ]]; then
+          FLUX_TOOL_DIR="${RUNNER_TOOL_CACHE}/flux2/${VERSION}/${OS}/${ARCH}"
+        fi
+        if [[ ! -x "$FLUX_TOOL_DIR/FLUX_EXEC_FILE" ]]; then
+          DL_DIR="$(mktemp -dt flux2-XXXXXX)"
+          trap 'rm -rf $DL_DIR' EXIT
+
+          echo "Downloading flux ${VERSION} for ${OS}/${ARCH}"
+          FLUX_TARGET_FILE="flux_${VERSION}_${OS}_${ARCH}.tar.gz"
+          if [[ "$OS" == "windows" ]]; then
+            FLUX_TARGET_FILE="flux_${VERSION}_${OS}_${ARCH}.zip"
           fi
 
-          VERSION=$(echo "${VERSION_SLUG}" | sed -E 's/.*"([^"]+)".*/\1/' | cut -c 2-)
+          FLUX_CHECKSUMS_FILE="flux_${VERSION}_checksums.txt"
+
+          FLUX_DOWNLOAD_URL="https://github.com/fluxcd/flux2/releases/download/v${VERSION}/"
+
+          curl -fsSL -o "$DL_DIR/$FLUX_TARGET_FILE" "$FLUX_DOWNLOAD_URL/$FLUX_TARGET_FILE"
+          curl -fsSL -o "$DL_DIR/$FLUX_CHECKSUMS_FILE" "$FLUX_DOWNLOAD_URL/$FLUX_CHECKSUMS_FILE"
+
+          echo "Verifying checksum"
+          sum=$(openssl sha1 -sha256 "$DL_DIR/$FLUX_TARGET_FILE" | awk '{print $2}')
+          expected_sum=$(grep " $FLUX_TARGET_FILE\$" "$DL_DIR/$FLUX_CHECKSUMS_FILE" | awk '{print $1}')
+          if [ "$sum" != "$expected_sum" ]; then
+            echo "SHA sum of ${FLUX_TARGET_FILE} does not match. Aborting."
+            exit 1
+          fi
+
+          echo "Installing flux to ${FLUX_TOOL_DIR}"
+          mkdir -p "$FLUX_TOOL_DIR"
+        
+          if [[ "$OS" == "windows" ]]; then
+            unzip "$DL_DIR/$FLUX_TARGET_FILE" "$FLUX_EXEC_FILE" -d "$FLUX_TOOL_DIR"
+          else
+            tar xzf "$DL_DIR/$FLUX_TARGET_FILE" -C "$FLUX_TOOL_DIR" $FLUX_EXEC_FILE
+          fi
+
+          chmod +x "$FLUX_TOOL_DIR/$FLUX_EXEC_FILE"
         fi
 
-        BIN_URL="https://github.com/fluxcd/flux2/releases/download/v${VERSION}/flux_${VERSION}_linux_${ARCH}.tar.gz"
-        curl --silent --fail --location "${BIN_URL}" --output /tmp/flux.tar.gz
-        mkdir -p /tmp/flux
-        tar -C /tmp/flux/ -zxvf /tmp/flux.tar.gz
-    - name: "Copy Flux binary to execute location"
-      shell: bash
-      run: |
-        BINDIR=${{ inputs.bindir }}
-        if [ -z "${BINDIR}" ]; then
-          sudo cp /tmp/flux/flux /usr/local/bin
-        else
-          cp /tmp/flux/flux "${BINDIR}"
-          echo "${BINDIR}" >> $GITHUB_PATH
-        fi
-    - name: "Cleanup tmp"
-      shell: bash
-      run: |
-        rm -rf /tmp/flux/ /tmp/flux.tar.gz
-    - name: "Verify correct installation of binary"
+        echo "Adding flux to path"
+        echo "$FLUX_TOOL_DIR" >> "$GITHUB_PATH"
+
+    - name: "Print installed flux version"
       shell: bash
       run: |
         flux -v


### PR DESCRIPTION
Plus the verification of the SHA256 of the archive, as advertised in the checksum file published together with the release.