### PR TITLE
diff: Take into account the server-side inventory for local Flux Kustomizations

### DIFF
--- a/cmd/flux/build_kustomization_test.go
+++ b/cmd/flux/build_kustomization_test.go
@@ -159,6 +159,7 @@ spec:
 	tmpl := map[string]string{
 		"fluxns": allocateNamespace("flux-system"),
 	}
+	setup(t, tmpl)
 
 	testEnv.CreateObjectFile("./testdata/build-kustomization/podinfo-source.yaml", tmpl, t)
 

--- a/internal/build/diff.go
+++ b/internal/build/diff.go
@@ -136,11 +136,14 @@ func (b *Builder) Diff() (string, bool, error) {
 	if b.kustomization.Spec.Prune && len(diffErrs) == 0 {
 		oldStatus := b.kustomization.Status.DeepCopy()
 		if oldStatus.Inventory != nil {
-			diffObjects, err := diffInventory(oldStatus.Inventory, newInventory)
+			staleObjects, err := diffInventory(oldStatus.Inventory, newInventory)
 			if err != nil {
 				return "", createdOrDrifted, err
 			}
-			for _, object := range diffObjects {
+			if len(staleObjects) > 0 {
+				createdOrDrifted = true
+			}
+			for _, object := range staleObjects {
 				output.WriteString(writeString(fmt.Sprintf("► %s deleted\n", ssa.FmtUnstructured(object)), bunt.OrangeRed))
 			}
 		}


### PR DESCRIPTION
fix #3733

If implemented users will be able to use `flux diff ks --kustomization-file` while retrieving the inventory from the cluster to report stale objects. This implies that a local Flux Kustomization file takes precedence over it's live counterpart.

For `flux build ks --kustomization-file`, the cluster will be not queried when using `--dry-run`.