### PR TITLE
Set Kubernetes min version to 1.25

### DIFF
--- a/cmd/flux/check.go
+++ b/cmd/flux/check.go
@@ -57,7 +57,7 @@ type checkFlags struct {
 }
 
 var kubernetesConstraints = []string{
-	">=1.24.0-0",
+	">=1.25.0-0",
 }
 
 var checkArgs checkFlags

--- a/cmd/flux/testdata/check/check_pre.golden
+++ b/cmd/flux/testdata/check/check_pre.golden
@@ -1,3 +1,3 @@
 ► checking prerequisites
-✔ Kubernetes {{ .serverVersion }} >=1.24.0-0
+✔ Kubernetes {{ .serverVersion }} >=1.25.0-0
 ✔ prerequisites checks passed


### PR DESCRIPTION
Drop support for Kubernetes 1.24 (EOL 28 Jul 2023)

Part of: #4125 