### PR TITLE
Add Reason to Suspend

### DIFF
--- a/cmd/flux/resume_alert.go
+++ b/cmd/flux/resume_alert.go
@@ -49,6 +49,9 @@ func (obj alertAdapter) getObservedGeneration() int64 {
 
 func (obj alertAdapter) setUnsuspended() {
 	obj.Alert.Spec.Suspend = false
+	if _, ok := obj.Alert.Annotations[SuspendReasonAnnotation]; ok {
+		delete(obj.Alert.Annotations, SuspendReasonAnnotation)
+	}
 }
 
 func (obj alertAdapter) successMessage() string {

--- a/cmd/flux/resume_helmrelease.go
+++ b/cmd/flux/resume_helmrelease.go
@@ -52,6 +52,9 @@ func (obj helmReleaseAdapter) getObservedGeneration() int64 {
 
 func (obj helmReleaseAdapter) setUnsuspended() {
 	obj.HelmRelease.Spec.Suspend = false
+	if _, ok := obj.HelmRelease.Annotations[SuspendReasonAnnotation]; ok {
+		delete(obj.HelmRelease.Annotations, SuspendReasonAnnotation)
+	}
 }
 
 func (obj helmReleaseAdapter) successMessage() string {

--- a/cmd/flux/resume_image_repository.go
+++ b/cmd/flux/resume_image_repository.go
@@ -48,6 +48,9 @@ func (obj imageRepositoryAdapter) getObservedGeneration() int64 {
 
 func (obj imageRepositoryAdapter) setUnsuspended() {
 	obj.ImageRepository.Spec.Suspend = false
+	if _, ok := obj.ImageRepository.Annotations[SuspendReasonAnnotation]; ok {
+		delete(obj.ImageRepository.Annotations, SuspendReasonAnnotation)
+	}
 }
 
 func (a imageRepositoryListAdapter) resumeItem(i int) resumable {

--- a/cmd/flux/resume_image_updateauto.go
+++ b/cmd/flux/resume_image_updateauto.go
@@ -44,6 +44,9 @@ func init() {
 
 func (obj imageUpdateAutomationAdapter) setUnsuspended() {
 	obj.ImageUpdateAutomation.Spec.Suspend = false
+	if _, ok := obj.ImageUpdateAutomation.Annotations[SuspendReasonAnnotation]; ok {
+		delete(obj.ImageUpdateAutomation.Annotations, SuspendReasonAnnotation)
+	}
 }
 
 func (obj imageUpdateAutomationAdapter) getObservedGeneration() int64 {

--- a/cmd/flux/resume_kustomization.go
+++ b/cmd/flux/resume_kustomization.go
@@ -52,6 +52,9 @@ func (obj kustomizationAdapter) getObservedGeneration() int64 {
 
 func (obj kustomizationAdapter) setUnsuspended() {
 	obj.Kustomization.Spec.Suspend = false
+	if _, ok := obj.Kustomization.Annotations[SuspendReasonAnnotation]; ok {
+		delete(obj.Kustomization.Annotations, SuspendReasonAnnotation)
+	}
 }
 
 func (obj kustomizationAdapter) successMessage() string {

--- a/cmd/flux/resume_receiver.go
+++ b/cmd/flux/resume_receiver.go
@@ -49,6 +49,9 @@ func (obj receiverAdapter) getObservedGeneration() int64 {
 
 func (obj receiverAdapter) setUnsuspended() {
 	obj.Receiver.Spec.Suspend = false
+	if _, ok := obj.Receiver.Annotations[SuspendReasonAnnotation]; ok {
+		delete(obj.Receiver.Annotations, SuspendReasonAnnotation)
+	}
 }
 
 func (obj receiverAdapter) successMessage() string {

--- a/cmd/flux/resume_source_bucket.go
+++ b/cmd/flux/resume_source_bucket.go
@@ -48,6 +48,9 @@ func (obj bucketAdapter) getObservedGeneration() int64 {
 
 func (obj bucketAdapter) setUnsuspended() {
 	obj.Bucket.Spec.Suspend = false
+	if _, ok := obj.Bucket.Annotations[SuspendReasonAnnotation]; ok {
+		delete(obj.Bucket.Annotations, SuspendReasonAnnotation)
+	}
 }
 
 func (a bucketListAdapter) resumeItem(i int) resumable {

--- a/cmd/flux/resume_source_chart.go
+++ b/cmd/flux/resume_source_chart.go
@@ -50,6 +50,9 @@ func (obj helmChartAdapter) getObservedGeneration() int64 {
 
 func (obj helmChartAdapter) setUnsuspended() {
 	obj.HelmChart.Spec.Suspend = false
+	if _, ok := obj.HelmChart.Annotations[SuspendReasonAnnotation]; ok {
+		delete(obj.HelmChart.Annotations, SuspendReasonAnnotation)
+	}
 }
 
 func (obj helmChartAdapter) successMessage() string {

--- a/cmd/flux/resume_source_git.go
+++ b/cmd/flux/resume_source_git.go
@@ -48,6 +48,9 @@ func (obj gitRepositoryAdapter) getObservedGeneration() int64 {
 
 func (obj gitRepositoryAdapter) setUnsuspended() {
 	obj.GitRepository.Spec.Suspend = false
+	if _, ok := obj.GitRepository.Annotations[SuspendReasonAnnotation]; ok {
+		delete(obj.GitRepository.Annotations, SuspendReasonAnnotation)
+	}
 }
 
 func (a gitRepositoryListAdapter) resumeItem(i int) resumable {

--- a/cmd/flux/resume_source_helm.go
+++ b/cmd/flux/resume_source_helm.go
@@ -48,6 +48,9 @@ func (obj helmRepositoryAdapter) getObservedGeneration() int64 {
 
 func (obj helmRepositoryAdapter) setUnsuspended() {
 	obj.HelmRepository.Spec.Suspend = false
+	if _, ok := obj.HelmRepository.Annotations[SuspendReasonAnnotation]; ok {
+		delete(obj.HelmRepository.Annotations, SuspendReasonAnnotation)
+	}
 }
 
 func (a helmRepositoryListAdapter) resumeItem(i int) resumable {

--- a/cmd/flux/resume_source_oci.go
+++ b/cmd/flux/resume_source_oci.go
@@ -48,6 +48,9 @@ func (obj ociRepositoryAdapter) getObservedGeneration() int64 {
 
 func (obj ociRepositoryAdapter) setUnsuspended() {
 	obj.OCIRepository.Spec.Suspend = false
+	if _, ok := obj.OCIRepository.Annotations[SuspendReasonAnnotation]; ok {
+		delete(obj.OCIRepository.Annotations, SuspendReasonAnnotation)
+	}
 }
 
 func (a ociRepositoryListAdapter) resumeItem(i int) resumable {

--- a/cmd/flux/suspend_alert.go
+++ b/cmd/flux/suspend_alert.go
@@ -47,8 +47,9 @@ func (obj alertAdapter) isSuspended() bool {
 	return obj.Alert.Spec.Suspend
 }
 
-func (obj alertAdapter) setSuspended() {
+func (obj alertAdapter) setSuspended(reason string) {
 	obj.Alert.Spec.Suspend = true
+	obj.Alert.Annotations[SuspendReasonAnnotation] = reason
 }
 
 func (a alertListAdapter) item(i int) suspendable {

--- a/cmd/flux/suspend_helmrelease.go
+++ b/cmd/flux/suspend_helmrelease.go
@@ -48,8 +48,9 @@ func (obj helmReleaseAdapter) isSuspended() bool {
 	return obj.HelmRelease.Spec.Suspend
 }
 
-func (obj helmReleaseAdapter) setSuspended() {
+func (obj helmReleaseAdapter) setSuspended(reason string) {
 	obj.HelmRelease.Spec.Suspend = true
+	obj.HelmRelease.Annotations[SuspendReasonAnnotation] = reason
 }
 
 func (a helmReleaseListAdapter) item(i int) suspendable {

--- a/cmd/flux/suspend_image_repository.go
+++ b/cmd/flux/suspend_image_repository.go
@@ -47,8 +47,9 @@ func (obj imageRepositoryAdapter) isSuspended() bool {
 	return obj.ImageRepository.Spec.Suspend
 }
 
-func (obj imageRepositoryAdapter) setSuspended() {
+func (obj imageRepositoryAdapter) setSuspended(reason string) {
 	obj.ImageRepository.Spec.Suspend = true
+	obj.ImageRepository.Annotations[SuspendReasonAnnotation] = reason
 }
 
 func (a imageRepositoryListAdapter) item(i int) suspendable {

--- a/cmd/flux/suspend_image_updateauto.go
+++ b/cmd/flux/suspend_image_updateauto.go
@@ -47,8 +47,9 @@ func (update imageUpdateAutomationAdapter) isSuspended() bool {
 	return update.ImageUpdateAutomation.Spec.Suspend
 }
 
-func (update imageUpdateAutomationAdapter) setSuspended() {
+func (update imageUpdateAutomationAdapter) setSuspended(reason string) {
 	update.ImageUpdateAutomation.Spec.Suspend = true
+	update.ImageUpdateAutomation.Annotations[SuspendReasonAnnotation] = reason
 }
 
 func (a imageUpdateAutomationListAdapter) item(i int) suspendable {

--- a/cmd/flux/suspend_kustomization.go
+++ b/cmd/flux/suspend_kustomization.go
@@ -48,8 +48,9 @@ func (obj kustomizationAdapter) isSuspended() bool {
 	return obj.Kustomization.Spec.Suspend
 }
 
-func (obj kustomizationAdapter) setSuspended() {
+func (obj kustomizationAdapter) setSuspended(reason string) {
 	obj.Kustomization.Spec.Suspend = true
+	obj.Kustomization.Annotations[SuspendReasonAnnotation] = reason
 }
 
 func (a kustomizationListAdapter) item(i int) suspendable {

--- a/cmd/flux/suspend_receiver.go
+++ b/cmd/flux/suspend_receiver.go
@@ -47,8 +47,9 @@ func (obj receiverAdapter) isSuspended() bool {
 	return obj.Receiver.Spec.Suspend
 }
 
-func (obj receiverAdapter) setSuspended() {
+func (obj receiverAdapter) setSuspended(reason string) {
 	obj.Receiver.Spec.Suspend = true
+	obj.Receiver.Annotations[SuspendReasonAnnotation] = reason
 }
 
 func (a receiverListAdapter) item(i int) suspendable {

--- a/cmd/flux/suspend_source_bucket.go
+++ b/cmd/flux/suspend_source_bucket.go
@@ -47,8 +47,9 @@ func (obj bucketAdapter) isSuspended() bool {
 	return obj.Bucket.Spec.Suspend
 }
 
-func (obj bucketAdapter) setSuspended() {
+func (obj bucketAdapter) setSuspended(reason string) {
 	obj.Bucket.Spec.Suspend = true
+	obj.Bucket.Annotations[SuspendReasonAnnotation] = reason
 }
 
 func (a bucketListAdapter) item(i int) suspendable {

--- a/cmd/flux/suspend_source_chart.go
+++ b/cmd/flux/suspend_source_chart.go
@@ -47,8 +47,9 @@ func (obj helmChartAdapter) isSuspended() bool {
 	return obj.HelmChart.Spec.Suspend
 }
 
-func (obj helmChartAdapter) setSuspended() {
+func (obj helmChartAdapter) setSuspended(reason string) {
 	obj.HelmChart.Spec.Suspend = true
+	obj.HelmChart.Annotations[SuspendReasonAnnotation] = reason
 }
 
 func (a helmChartListAdapter) item(i int) suspendable {

--- a/cmd/flux/suspend_source_git.go
+++ b/cmd/flux/suspend_source_git.go
@@ -47,8 +47,9 @@ func (obj gitRepositoryAdapter) isSuspended() bool {
 	return obj.GitRepository.Spec.Suspend
 }
 
-func (obj gitRepositoryAdapter) setSuspended() {
+func (obj gitRepositoryAdapter) setSuspended(reason string) {
 	obj.GitRepository.Spec.Suspend = true
+	obj.GitRepository.Annotations[SuspendReasonAnnotation] = reason
 }
 
 func (a gitRepositoryListAdapter) item(i int) suspendable {

--- a/cmd/flux/suspend_source_helm.go
+++ b/cmd/flux/suspend_source_helm.go
@@ -47,8 +47,9 @@ func (obj helmRepositoryAdapter) isSuspended() bool {
 	return obj.HelmRepository.Spec.Suspend
 }
 
-func (obj helmRepositoryAdapter) setSuspended() {
+func (obj helmRepositoryAdapter) setSuspended(reason string) {
 	obj.HelmRepository.Spec.Suspend = true
+	obj.HelmRepository.Annotations[SuspendReasonAnnotation] = reason
 }
 
 func (a helmRepositoryListAdapter) item(i int) suspendable {

--- a/cmd/flux/suspend_source_oci.go
+++ b/cmd/flux/suspend_source_oci.go
@@ -47,8 +47,9 @@ func (obj ociRepositoryAdapter) isSuspended() bool {
 	return obj.OCIRepository.Spec.Suspend
 }
 
-func (obj ociRepositoryAdapter) setSuspended() {
+func (obj ociRepositoryAdapter) setSuspended(reason string) {
 	obj.OCIRepository.Spec.Suspend = true
+	obj.OCIRepository.Annotations[SuspendReasonAnnotation] = reason
 }
 
 func (a ociRepositoryListAdapter) item(i int) suspendable {


### PR DESCRIPTION
# User Story

Often there is a purpose behind suspending a resource with the `flux` cli, whether it be during incident response, source manifest cutovers, or various other scenarios.  The `flux diff` command provides a great UX for determining _what will change_ if a suspended resource is resumed, but it doesn't help explain _why_ something is paused or when it would be ok to resume reconciliation.  On distributed teams this can become a point of friction as it needs to be communicated among group stakeholders.

Flux users should have a way to succinctly signal to other users why a resource is suspended on the resource itself.

This PR adds support for an optional `--reason` flag to the `flux suspend` command that adds an annotation to the suspended resource.  The annotation is removed when the resource is targeted by the `flux resume` command.

# Detailed List of Changes

- Adds an optional `reason` cli flag to the `suspend` command that accepts a reason for why the resource was suspended.

- Defines the resource metadata annotation key that stores the reason for the resource suspension.

- Updates the suspend and resume resource patching to add or remove the annotation holding the suspend reason.