### PR TITLE
fix: only wait for changeset if the result is not empty

### DIFF
--- a/internal/utils/apply.go
+++ b/internal/utils/apply.go
@@ -76,8 +76,10 @@ func Apply(ctx context.Context, rcg genericclioptions.RESTClientGetter, opts *ru
 		changeSet.Append(cs.Entries)
 	}
 
-	if err := waitForSet(rcg, opts, changeSet); err != nil {
-		return "", err
+	if len(changeSet.Entries) > 0 {
+		if err := waitForSet(rcg, opts, changeSet); err != nil {
+			return "", err
+		}
 	}
 
 	if len(stageTwo) > 0 {


### PR DESCRIPTION
When using Apply with a set of files that end up with an empty first change set, wait will timeout waiting for nothing.

Only wait if the changeSet isn't empty.