### PR TITLE
Confirm before overriding installation by another manager

### DIFF
--- a/cmd/flux/bootstrap_bitbucket_server.go
+++ b/cmd/flux/bootstrap_bitbucket_server.go
@@ -124,6 +124,13 @@ func bootstrapBServerCmdRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if !bootstrapArgs.force {
+		err = confirmBootstrap(ctx, kubeClient)
+		if err != nil {
+			return err
+		}
+	}
+
 	// Manifest base
 	if ver, err := getVersion(bootstrapArgs.version); err != nil {
 		return err

--- a/cmd/flux/bootstrap_git.go
+++ b/cmd/flux/bootstrap_git.go
@@ -146,6 +146,13 @@ func bootstrapGitCmdRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if !bootstrapArgs.force {
+		err = confirmBootstrap(ctx, kubeClient)
+		if err != nil {
+			return err
+		}
+	}
+
 	// Manifest base
 	if ver, err := getVersion(bootstrapArgs.version); err != nil {
 		return err

--- a/cmd/flux/bootstrap_github.go
+++ b/cmd/flux/bootstrap_github.go
@@ -128,6 +128,13 @@ func bootstrapGitHubCmdRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if !bootstrapArgs.force {
+		err = confirmBootstrap(ctx, kubeClient)
+		if err != nil {
+			return err
+		}
+	}
+
 	// Manifest base
 	if ver, err := getVersion(bootstrapArgs.version); err != nil {
 		return err

--- a/cmd/flux/bootstrap_gitlab.go
+++ b/cmd/flux/bootstrap_gitlab.go
@@ -145,6 +145,13 @@ func bootstrapGitLabCmdRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if !bootstrapArgs.force {
+		err = confirmBootstrap(ctx, kubeClient)
+		if err != nil {
+			return err
+		}
+	}
+
 	// Manifest base
 	if ver, err := getVersion(bootstrapArgs.version); err != nil {
 		return err

--- a/cmd/flux/cluster_info.go
+++ b/cmd/flux/cluster_info.go
@@ -91,7 +91,7 @@ func getFluxClusterInfo(ctx context.Context, c client.Client) (fluxClusterInfo, 
 // promptui.ErrAbort if the user doesn't confirm, or an error encountered.
 func confirmFluxInstallOverride(info fluxClusterInfo) error {
 	// no need to display prompt if installation is managed by Flux
-	if info.managedBy == "" || info.managedBy == "flux" {
+	if installManagedByFlux(info.managedBy) {
 		return nil
 	}
 
@@ -103,4 +103,8 @@ func confirmFluxInstallOverride(info fluxClusterInfo) error {
 	}
 	_, err := prompt.Run()
 	return err
+}
+
+func installManagedByFlux(manager string) bool {
+	return manager == "" || manager == "flux"
 }

--- a/cmd/flux/uninstall.go
+++ b/cmd/flux/uninstall.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/fluxcd/flux2/v2/internal/utils"
 	"github.com/fluxcd/flux2/v2/pkg/uninstall"
@@ -59,22 +60,33 @@ func init() {
 }
 
 func uninstallCmdRun(cmd *cobra.Command, args []string) error {
-	if !uninstallArgs.dryRun && !uninstallArgs.silent {
-		prompt := promptui.Prompt{
-			Label:     "Are you sure you want to delete Flux and its custom resource definitions",
-			IsConfirm: true,
-		}
-		if _, err := prompt.Run(); err != nil {
-			return fmt.Errorf("aborting")
-		}
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
 	defer cancel()
 
 	kubeClient, err := utils.KubeClient(kubeconfigArgs, kubeclientOptions)
 	if err != nil {
 		return err
+	}
+
+	if !uninstallArgs.dryRun && !uninstallArgs.silent {
+		info, err := getFluxClusterInfo(ctx, kubeClient)
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				return fmt.Errorf("cluster info unavailable: %w", err)
+			}
+		}
+
+		promptLabel := "Are you sure you want to delete Flux and its custom resource definitions"
+		if !installManagedByFlux(info.managedBy) {
+			promptLabel = fmt.Sprintf("Flux is managed by %s! Are you sure you want to delete Flux and its CRDs using Flux CLI", info.managedBy)
+		}
+		prompt := promptui.Prompt{
+			Label:     promptLabel,
+			IsConfirm: true,
+		}
+		if _, err := prompt.Run(); err != nil {
+			return fmt.Errorf("aborting")
+		}
 	}
 
 	logger.Actionf("deleting components in %s namespace", *kubeconfigArgs.Namespace)


### PR DESCRIPTION
This pull request prompts a user to confirm before overriding an existing Flux installation that's not managed by flux when running `install` or `bootstrap`.

The pull request also adds a better uninstallation prompt when flux is managed by some other tool.

Fixes: https://github.com/fluxcd/flux2/issues/4342