### PR TITLE
Don't swallow errors when uninstalling FluxCD

### DIFF
--- a/cmd/flux/uninstall.go
+++ b/cmd/flux/uninstall.go
@@ -90,16 +90,24 @@ func uninstallCmdRun(cmd *cobra.Command, args []string) error {
 	}
 
 	logger.Actionf("deleting components in %s namespace", *kubeconfigArgs.Namespace)
-	uninstall.Components(ctx, logger, kubeClient, *kubeconfigArgs.Namespace, uninstallArgs.dryRun)
+	if err := uninstall.Components(ctx, logger, kubeClient, *kubeconfigArgs.Namespace, uninstallArgs.dryRun); err != nil {
+		return err
+	}
 
 	logger.Actionf("deleting toolkit.fluxcd.io finalizers in all namespaces")
-	uninstall.Finalizers(ctx, logger, kubeClient, uninstallArgs.dryRun)
+	if err := uninstall.Finalizers(ctx, logger, kubeClient, uninstallArgs.dryRun); err != nil {
+		return err
+	}
 
 	logger.Actionf("deleting toolkit.fluxcd.io custom resource definitions")
-	uninstall.CustomResourceDefinitions(ctx, logger, kubeClient, uninstallArgs.dryRun)
+	if err := uninstall.CustomResourceDefinitions(ctx, logger, kubeClient, uninstallArgs.dryRun); err != nil {
+		return err
+	}
 
 	if !uninstallArgs.keepNamespace {
-		uninstall.Namespace(ctx, logger, kubeClient, *kubeconfigArgs.Namespace, uninstallArgs.dryRun)
+		if err := uninstall.Namespace(ctx, logger, kubeClient, *kubeconfigArgs.Namespace, uninstallArgs.dryRun); err != nil {
+			return err
+		}
 	}
 
 	logger.Successf("uninstall finished")


### PR DESCRIPTION
The functions called via the `uninstall` command might return errors, which are ignored right now. I think users prefer to get noticed about issues, when uninstalling FluxCD.

This was originally brought up by @darkowlzz in the last Bugscrub Meeting.

I wasn't sure how to write an adequate test, so i tested the change adding some random error to https://github.com/fluxcd/flux2/blob/3c8072d0e6c3809af226880a866e22c5d76964ad/pkg/uninstall/uninstall.go#L138

which resulted in
```
panic: uninstall failed: ► deleting components in flux-system namespace                                        
✔ Deployment/flux-system/helm-controller deleted         
✔ Deployment/flux-system/image-automation-controller deleted 
✔ Deployment/flux-system/image-reflector-controller deleted  
✔ Deployment/flux-system/kustomize-controller deleted    
✔ Deployment/flux-system/notification-controller deleted 
✔ Deployment/flux-system/source-controller deleted       
✔ Service/flux-system/notification-controller deleted    
✔ Service/flux-system/source-controller deleted          
✔ Service/flux-system/webhook-receiver deleted           
✔ NetworkPolicy/flux-system/allow-egress deleted         
✔ NetworkPolicy/flux-system/allow-scraping deleted       
✔ NetworkPolicy/flux-system/allow-webhooks deleted       
✔ ServiceAccount/flux-system/helm-controller deleted     
✔ ServiceAccount/flux-system/image-automation-controller deleted                                               
✔ ServiceAccount/flux-system/image-reflector-controller deleted                                                
✔ ServiceAccount/flux-system/kustomize-controller deleted
✔ ServiceAccount/flux-system/notification-controller deleted 
✔ ServiceAccount/flux-system/source-controller deleted   
✔ ClusterRole/crd-controller-flux-system deleted         
✔ ClusterRole/flux-edit-flux-system deleted              
✔ ClusterRole/flux-view-flux-system deleted              
✔ ClusterRoleBinding/cluster-reconciler-flux-system deleted  
✔ ClusterRoleBinding/crd-controller-flux-system deleted  
► deleting toolkit.fluxcd.io finalizers in all namespaces
 error:'this is a new error'
```
when running the `e2e` tests. 
