### PR TITLE
Fix flux install command so it returns an error when unexpected arguments are passed

### DIFF
--- a/cmd/flux/install.go
+++ b/cmd/flux/install.go
@@ -36,6 +36,7 @@ import (
 
 var installCmd = &cobra.Command{
 	Use:   "install",
+	Args:  cobra.NoArgs,
 	Short: "Install or upgrade Flux",
 	Long: `The install command deploys Flux in the specified namespace.
 If a previous version is installed, then an in-place upgrade will be performed.`,

--- a/cmd/flux/install_test.go
+++ b/cmd/flux/install_test.go
@@ -37,6 +37,11 @@ func TestInstall(t *testing.T) {
 			args:   "install --namespace='@#[]'",
 			assert: assertError("namespace must be a valid DNS label: \"@#[]\""),
 		},
+		{
+			name:   "invalid sub-command",
+			args:   "install unexpectedPosArg --namespace=example",
+			assert: assertError(`unknown command "unexpectedPosArg" for "flux install"`),
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR was implemented to address the issue reported by myself on #4403.

I made sure that it is working on the cases where there are only flag arguments, or no arguments.

I wanted to add a test for a successful run, but when I tried I actually got an "install failed" error. So I figured that maybe there was a reason why no successful tests were present.

I can add more tests, but I would need some guidance.