### PR TITLE
Fix typos in flux bootstrap documentation

### DIFF
--- a/cmd/flux/bootstrap_bitbucket_server.go
+++ b/cmd/flux/bootstrap_bitbucket_server.go
@@ -56,7 +56,7 @@ the bootstrap command will perform an upgrade if needed.`,
   # Run bootstrap for a public repository on a personal account
   flux bootstrap bitbucket-server --owner=<user> --repository=<repository name> --private=false --personal --hostname=<domain> --token-auth --path=clusters/my-cluster
 
-  # Run bootstrap for a an existing repository with a branch named main
+  # Run bootstrap for an existing repository with a branch named main
   flux bootstrap bitbucket-server --owner=<project> --username=<user> --repository=<repository name> --branch=main --hostname=<domain> --token-auth --path=clusters/my-cluster`,
 	RunE: bootstrapBServerCmdRun,
 }

--- a/cmd/flux/bootstrap_gitlab.go
+++ b/cmd/flux/bootstrap_gitlab.go
@@ -64,7 +64,7 @@ the bootstrap command will perform an upgrade if needed.`,
   # Run bootstrap for a private repository hosted on a GitLab server
   flux bootstrap gitlab --owner=<group> --repository=<repository name> --hostname=<domain> --token-auth
 
-  # Run bootstrap for a an existing repository with a branch named main
+  # Run bootstrap for an existing repository with a branch named main
   flux bootstrap gitlab --owner=<organization> --repository=<repository name> --branch=main --token-auth
 
   # Run bootstrap for a private repository using Deploy Token authentication


### PR DESCRIPTION
Fix minor typos in the flux bootstrap command documentation for Bitbucket Server and GitLab.
