### PR TITLE
build: Update alpine and kubectl in flux-cli image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM alpine:3.18 as builder
+FROM alpine:3.19 as builder
 
 RUN apk add --no-cache ca-certificates curl
 
 ARG ARCH=linux/amd64
-ARG KUBECTL_VER=1.27.3
+ARG KUBECTL_VER=1.28.4
 
 RUN curl -sL https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VER}/bin/${ARCH}/kubectl \
     -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl && \
     kubectl version --client=true
 
-FROM alpine:3.18 as flux-cli
+FROM alpine:3.19 as flux-cli
 
 RUN apk add --no-cache ca-certificates
 


### PR DESCRIPTION
Bump Alpine to 3.19 and kubectl to 1.28.4 in the flux-cli Dockerfile