### PR TITLE
Drop support for Kubernetes EOL versions

### DIFF
--- a/.github/workflows/e2e-arm64.yaml
+++ b/.github/workflows/e2e-arm64.yaml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         # Keep this list up-to-date with https://endoflife.date/kubernetes
         # Check which versions are available on DockerHub with 'crane ls kindest/node'
-        KUBERNETES_VERSION: [ 1.25.11, 1.26.6, 1.27.3, 1.28.0 ]
+        KUBERNETES_VERSION: [ 1.26.6, 1.27.3, 1.28.0 ]
       fail-fast: false
     steps:
       - name: Checkout

--- a/cmd/flux/check.go
+++ b/cmd/flux/check.go
@@ -59,7 +59,7 @@ type checkFlags struct {
 }
 
 var kubernetesConstraints = []string{
-	">=1.25.0-0",
+	">=1.26.0-0",
 }
 
 var checkArgs checkFlags

--- a/cmd/flux/testdata/check/check_pre.golden
+++ b/cmd/flux/testdata/check/check_pre.golden
@@ -1,3 +1,3 @@
 ► checking prerequisites
-✔ Kubernetes {{ .serverVersion }} >=1.25.0-0
+✔ Kubernetes {{ .serverVersion }} >=1.26.0-0
 ✔ prerequisites checks passed


### PR DESCRIPTION
Remove 1.25 from test matrix and bump flux check to min 1.26.  