### PR TITLE
Properly detect unsupported API errors

### DIFF
--- a/cmd/flux/get.go
+++ b/cmd/flux/get.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -28,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/discovery"
 	watchtools "k8s.io/client-go/tools/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -178,8 +176,7 @@ func (get getCommand) run(cmd *cobra.Command, args []string) error {
 
 	err = kubeClient.List(ctx, get.list.asClientList(), listOpts...)
 	if err != nil {
-		var discErr *discovery.ErrGroupDiscoveryFailed
-		if getAll && (strings.Contains(err.Error(), "no matches for kind") || errors.As(err, &discErr)) {
+		if getAll && apimeta.IsNoMatchError(err) {
 			return nil
 		}
 		return err

--- a/cmd/flux/get_all.go
+++ b/cmd/flux/get_all.go
@@ -17,9 +17,8 @@ limitations under the License.
 package main
 
 import (
-	"strings"
-
 	"github.com/spf13/cobra"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2beta2"
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
@@ -87,7 +86,7 @@ var getAllCmd = &cobra.Command{
 }
 
 func logError(err error) {
-	if !strings.Contains(err.Error(), "no matches for kind") {
+	if !apimeta.IsNoMatchError(err) {
 		logger.Failuref(err.Error())
 	}
 }

--- a/cmd/flux/get_source_all.go
+++ b/cmd/flux/get_source_all.go
@@ -17,9 +17,8 @@ limitations under the License.
 package main
 
 import (
-	"strings"
-
 	"github.com/spf13/cobra"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	sourcev1b2 "github.com/fluxcd/source-controller/api/v1beta2"
@@ -65,7 +64,7 @@ var getSourceAllCmd = &cobra.Command{
 
 		for _, c := range allSourceCmd {
 			if err := c.run(cmd, args); err != nil {
-				if !strings.Contains(err.Error(), "no matches for kind") {
+				if !apimeta.IsNoMatchError(err) {
 					logger.Failuref(err.Error())
 				}
 			}


### PR DESCRIPTION
This can happen when Custom Resource Definitions do not exist on the cluster. For example, because only a subset of the Flux controllers are installed on the cluster.

Previously, the detection was based on a combination of error type and string matching. However, a more reliable (and maintained) `apimeta.IsNoMatchError` checker is available upstream. Making it less likely this suddenly stops to matching properly when Kubernetes changes things.

Fixes #4474