### PR TITLE
Run conformance tests for Kubernetes v1.29.0

### DIFF
--- a/.github/workflows/e2e-arm64.yaml
+++ b/.github/workflows/e2e-arm64.yaml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         # Keep this list up-to-date with https://endoflife.date/kubernetes
         # Check which versions are available on DockerHub with 'crane ls kindest/node'
-        KUBERNETES_VERSION: [ 1.26.6, 1.27.3, 1.28.0 ]
+        KUBERNETES_VERSION: [ 1.26.6, 1.27.3, 1.28.0, 1.29.0 ]
       fail-fast: false
     steps:
       - name: Checkout


### PR DESCRIPTION
Add Kubernetes 1.29 to the end-to-end testing matrix.