### PR TITLE
`flux check` should error on unrecognised args

### DIFF
--- a/cmd/flux/check.go
+++ b/cmd/flux/check.go
@@ -40,6 +40,7 @@ import (
 
 var checkCmd = &cobra.Command{
 	Use:   "check",
+	Args:  cobra.NoArgs,
 	Short: "Check requirements and installation",
 	Long: withPreviewNote(`The check command will perform a series of checks to validate that
 the local environment is configured correctly and if the installed components are healthy.`),


### PR DESCRIPTION
flux cli does not properly detect unexpected argument on `flux check` command.