### PR TITLE
Update Equinix ARM64 GitHub runners

### DIFF
--- a/.github/runners/README.md
+++ b/.github/runners/README.md
@@ -4,16 +4,18 @@ The Flux ARM64 end-to-end tests run on Equinix Metal instances provisioned with 
 
 ## Current instances
 
-| Repository                  | Runner           | Instance               | Location      |
-|-----------------------------|------------------|------------------------|---------------|
-| flux2                       | equinix-arm-dc-1 | flux-equinix-arm-dc-01 | Washington DC |
-| flux2                       | equinix-arm-dc-2 | flux-equinix-arm-dc-01 | Washington DC |
-| flux2                       | equinix-arm-da-1 | flux-equinix-arm-da-01 | Dallas        |
-| flux2                       | equinix-arm-da-2 | flux-equinix-arm-da-01 | Dallas        |
-| source-controller           | equinix-arm-dc-1 | flux-equinix-arm-dc-01 | Washington DC |
-| source-controller           | equinix-arm-da-1 | flux-equinix-arm-da-01 | Dallas        |
-| image-automation-controller | equinix-arm-dc-1 | flux-equinix-arm-dc-01 | Washington DC |
-| image-automation-controller | equinix-arm-da-1 | flux-equinix-arm-da-01 | Dallas        |
+| Repository                  | Runner           | Instance       | Location      |
+|-----------------------------|------------------|----------------|---------------|
+| flux2                       | equinix-arm-dc-1 | flux-arm-dc-01 | Washington DC |
+| flux2                       | equinix-arm-dc-2 | flux-arm-dc-01 | Washington DC |
+| flux2                       | equinix-arm-da-1 | flux-arm-da-01 | Dallas        |
+| flux2                       | equinix-arm-da-2 | flux-arm-da-01 | Dallas        |
+| flux-benchmark              | equinix-arm-dc-1 | flux-arm-dc-01 | Washington DC |
+| flux-benchmark              | equinix-arm-da-1 | flux-arm-da-01 | Dallas        |
+| source-controller           | equinix-arm-dc-1 | flux-arm-dc-01 | Washington DC |
+| source-controller           | equinix-arm-da-1 | flux-arm-da-01 | Dallas        |
+| image-automation-controller | equinix-arm-dc-1 | flux-arm-dc-01 | Washington DC |
+| image-automation-controller | equinix-arm-da-1 | flux-arm-da-01 | Dallas        |
 
 Instance spec:
 - Ampere Altra Q80-30 80-core processor @ 2.8GHz

--- a/.github/runners/prereq.sh
+++ b/.github/runners/prereq.sh
@@ -18,11 +18,11 @@
 
 set -eu
 
-KIND_VERSION=0.17.0
-KUBECTL_VERSION=1.24.0
-KUSTOMIZE_VERSION=4.5.7
-HELM_VERSION=3.10.1
-GITHUB_RUNNER_VERSION=2.298.2
+KIND_VERSION=0.22.0
+KUBECTL_VERSION=1.29.0
+KUSTOMIZE_VERSION=5.3.0
+HELM_VERSION=3.14.1
+GITHUB_RUNNER_VERSION=2.313.0
 PACKAGES="apt-transport-https ca-certificates software-properties-common build-essential libssl-dev gnupg lsb-release jq pkg-config"
 
 # install prerequisites

--- a/.github/runners/runner-setup.sh
+++ b/.github/runners/runner-setup.sh
@@ -22,7 +22,7 @@ RUNNER_NAME=$1
 REPOSITORY_TOKEN=$2
 REPOSITORY_URL=${3:-https://github.com/fluxcd/flux2}
 
-GITHUB_RUNNER_VERSION=2.298.2
+GITHUB_RUNNER_VERSION=2.313.0
 
 # download runner
 curl -o actions-runner-linux-arm64.tar.gz -L https://github.com/actions/runner/releases/download/v${GITHUB_RUNNER_VERSION}/actions-runner-linux-arm64-${GITHUB_RUNNER_VERSION}.tar.gz \


### PR DESCRIPTION
At Equinix suport team request, I have created new baremetal servers to host our GitHub runners. The new machines are using the latest Kubernetes Kind release and latest Docker engine. I have also created dedicated runners for the benchmark repo.