### PR TITLE
Add permissions required for flow control

### DIFF
--- a/manifests/rbac/controller.yaml
+++ b/manifests/rbac/controller.yaml
@@ -69,6 +69,11 @@ rules:
   - update
   - patch
   - delete
+# required for flow control
+- nonResourceURLs:
+  - /livez/ping
+  verbs:
+  - head
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
As mentioned in the linked issue, all components use HEAD requests to /livez/ping to determine rate limits. This PR adds the required permissions to call the endpoint.

Fixes fluxcd/source-controller#1411