### PR TITLE
Pin envtest version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,8 @@ install-envtest: setup-envtest
 ENVTEST = $(shell pwd)/bin/setup-envtest
 .PHONY: envtest
 setup-envtest: ## Download envtest-setup locally if necessary.
-	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
+	# replace the commit SHA with 'latest' when https://github.com/kubernetes-sigs/controller-runtime/issues/2720 is fixed
+	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@c7e1dc9b5302d649d5531e19168dd7ea0013736d)
 
 # go-install-tool will 'go install' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))


### PR DESCRIPTION
[This commit](https://github.com/kubernetes-sigs/controller-runtime/commit/4c2442e4d743d172a2e0126a841ecd274fffc228) causes failures to install envtest, see https://github.com/kubernetes-sigs/controller-runtime/issues/2720 for details.

This PR pins envtest to the latest version that still works.
