### PR TITLE
Add `--registry-creds` flag to bootstrap and install commands

### DIFF
--- a/.github/workflows/e2e-bootstrap.yaml
+++ b/.github/workflows/e2e-bootstrap.yaml
@@ -53,16 +53,22 @@ jobs:
         run: |
           /tmp/flux bootstrap github --manifests ./manifests/install/ \
           --owner=fluxcd-testing \
+          --image-pull-secret=ghcr-auth \
+          --registry-creds=fluxcd:$GITHUB_TOKEN \
           --repository=${{ steps.vars.outputs.test_repo_name }} \
           --branch=main \
           --path=test-cluster \
           --team=team-z
         env:
           GITHUB_TOKEN: ${{ secrets.GITPROVIDER_BOT_TOKEN }}
+      - name: verify image pull secret
+        run: |
+          kubectl -n flux-system get secret ghcr-auth | grep dockerconfigjson
       - name: bootstrap no-op
         run: |
           /tmp/flux bootstrap github --manifests ./manifests/install/ \
           --owner=fluxcd-testing \
+          --image-pull-secret=ghcr-auth \
           --repository=${{ steps.vars.outputs.test_repo_name }} \
           --branch=main \
           --path=test-cluster \

--- a/cmd/flux/bootstrap_bitbucket_server.go
+++ b/cmd/flux/bootstrap_bitbucket_server.go
@@ -196,6 +196,7 @@ func bootstrapBServerCmdRun(cmd *cobra.Command, args []string) error {
 		Namespace:              *kubeconfigArgs.Namespace,
 		Components:             bootstrapComponents(),
 		Registry:               bootstrapArgs.registry,
+		RegistryCredential:     bootstrapArgs.registryCredential,
 		ImagePullSecret:        bootstrapArgs.imagePullSecret,
 		WatchAllNamespaces:     bootstrapArgs.watchAllNamespaces,
 		NetworkPolicy:          bootstrapArgs.networkPolicy,

--- a/cmd/flux/bootstrap_git.go
+++ b/cmd/flux/bootstrap_git.go
@@ -28,6 +28,9 @@ import (
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/fluxcd/pkg/git"
+	"github.com/fluxcd/pkg/git/gogit"
+
 	"github.com/fluxcd/flux2/v2/internal/flags"
 	"github.com/fluxcd/flux2/v2/internal/utils"
 	"github.com/fluxcd/flux2/v2/pkg/bootstrap"
@@ -35,8 +38,6 @@ import (
 	"github.com/fluxcd/flux2/v2/pkg/manifestgen/install"
 	"github.com/fluxcd/flux2/v2/pkg/manifestgen/sourcesecret"
 	"github.com/fluxcd/flux2/v2/pkg/manifestgen/sync"
-	"github.com/fluxcd/pkg/git"
-	"github.com/fluxcd/pkg/git/gogit"
 )
 
 var bootstrapGitCmd = &cobra.Command{
@@ -201,6 +202,7 @@ func bootstrapGitCmdRun(cmd *cobra.Command, args []string) error {
 		Namespace:              *kubeconfigArgs.Namespace,
 		Components:             bootstrapComponents(),
 		Registry:               bootstrapArgs.registry,
+		RegistryCredential:     bootstrapArgs.registryCredential,
 		ImagePullSecret:        bootstrapArgs.imagePullSecret,
 		WatchAllNamespaces:     bootstrapArgs.watchAllNamespaces,
 		NetworkPolicy:          bootstrapArgs.networkPolicy,

--- a/cmd/flux/bootstrap_gitea.go
+++ b/cmd/flux/bootstrap_gitea.go
@@ -184,6 +184,7 @@ func bootstrapGiteaCmdRun(cmd *cobra.Command, args []string) error {
 		Namespace:              *kubeconfigArgs.Namespace,
 		Components:             bootstrapComponents(),
 		Registry:               bootstrapArgs.registry,
+		RegistryCredential:     bootstrapArgs.registryCredential,
 		ImagePullSecret:        bootstrapArgs.imagePullSecret,
 		WatchAllNamespaces:     bootstrapArgs.watchAllNamespaces,
 		NetworkPolicy:          bootstrapArgs.networkPolicy,

--- a/cmd/flux/bootstrap_github.go
+++ b/cmd/flux/bootstrap_github.go
@@ -191,6 +191,7 @@ func bootstrapGitHubCmdRun(cmd *cobra.Command, args []string) error {
 		Namespace:              *kubeconfigArgs.Namespace,
 		Components:             bootstrapComponents(),
 		Registry:               bootstrapArgs.registry,
+		RegistryCredential:     bootstrapArgs.registryCredential,
 		ImagePullSecret:        bootstrapArgs.imagePullSecret,
 		WatchAllNamespaces:     bootstrapArgs.watchAllNamespaces,
 		NetworkPolicy:          bootstrapArgs.networkPolicy,

--- a/cmd/flux/bootstrap_gitlab.go
+++ b/cmd/flux/bootstrap_gitlab.go
@@ -216,6 +216,7 @@ func bootstrapGitLabCmdRun(cmd *cobra.Command, args []string) error {
 		Namespace:              *kubeconfigArgs.Namespace,
 		Components:             bootstrapComponents(),
 		Registry:               bootstrapArgs.registry,
+		RegistryCredential:     bootstrapArgs.registryCredential,
 		ImagePullSecret:        bootstrapArgs.imagePullSecret,
 		WatchAllNamespaces:     bootstrapArgs.watchAllNamespaces,
 		NetworkPolicy:          bootstrapArgs.networkPolicy,

--- a/cmd/flux/install_test.go
+++ b/cmd/flux/install_test.go
@@ -42,6 +42,11 @@ func TestInstall(t *testing.T) {
 			args:   "install unexpectedPosArg --namespace=example",
 			assert: assertError(`unknown command "unexpectedPosArg" for "flux install"`),
 		},
+		{
+			name:   "missing image pull secret",
+			args:   "install --registry-creds=fluxcd:test",
+			assert: assertError(`--registry-creds requires --image-pull-secret to be set`),
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/bootstrap/bootstrap_plain_git.go
+++ b/pkg/bootstrap/bootstrap_plain_git.go
@@ -207,6 +207,14 @@ func (b *PlainGitBootstrapper) ReconcileComponents(ctx context.Context, manifest
 		b.logger.Successf("installed components")
 	}
 
+	// Reconcile image pull secret if needed
+	if options.ImagePullSecret != "" && options.RegistryCredential != "" {
+		if err := reconcileImagePullSecret(ctx, b.kube, options); err != nil {
+			return fmt.Errorf("failed to reconcile image pull secret: %w", err)
+		}
+		b.logger.Successf("reconciled image pull secret %s", options.ImagePullSecret)
+	}
+
 	b.logger.Successf("reconciled components")
 	return nil
 }

--- a/pkg/manifestgen/install/options.go
+++ b/pkg/manifestgen/install/options.go
@@ -26,6 +26,7 @@ type Options struct {
 	ComponentsExtra        []string
 	EventsAddr             string
 	Registry               string
+	RegistryCredential     string
 	ImagePullSecret        string
 	WatchAllNamespaces     bool
 	NetworkPolicy          bool
@@ -46,6 +47,7 @@ func MakeDefaultOptions() Options {
 		ComponentsExtra:        []string{"image-reflector-controller", "image-automation-controller"},
 		EventsAddr:             "",
 		Registry:               "ghcr.io/fluxcd",
+		RegistryCredential:     "",
 		ImagePullSecret:        "",
 		WatchAllNamespaces:     true,
 		NetworkPolicy:          true,

--- a/pkg/manifestgen/sourcesecret/sourcesecret.go
+++ b/pkg/manifestgen/sourcesecret/sourcesecret.go
@@ -83,7 +83,7 @@ func Generate(options Options) (*manifestgen.Manifest, error) {
 
 	var dockerCfgJson []byte
 	if options.Registry != "" {
-		dockerCfgJson, err = generateDockerConfigJson(options.Registry, options.Username, options.Password)
+		dockerCfgJson, err = GenerateDockerConfigJson(options.Registry, options.Username, options.Password)
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate json for docker config: %w", err)
 		}
@@ -223,7 +223,7 @@ func resourceToString(data []byte) string {
 	return string(data)
 }
 
-func generateDockerConfigJson(url, username, password string) ([]byte, error) {
+func GenerateDockerConfigJson(url, username, password string) ([]byte, error) {
 	cred := fmt.Sprintf("%s:%s", username, password)
 	auth := base64.StdEncoding.EncodeToString([]byte(cred))
 	cfg := DockerConfigJSON{


### PR DESCRIPTION
Add an optional flag called `--registry-creds` to the `flux bootstrap` and `flux install` commands for generating an image pull secret for container images stored in private registries.

TODO (after merge):
- Update the air-gapped installation guide https://fluxcd.io/flux/installation/configuration/air-gapped/
- Expose the new option in Flux Terraform provider https://github.com/fluxcd/terraform-provider-flux/blob/8733e7566bd505616fc9562988f7196607ade593/internal/provider/resource_bootstrap_git.go#L90

Closes: #4621