### PR TITLE
Add flags for issuer/subject OCI signature verification

### DIFF
--- a/cmd/flux/create_source_oci_test.go
+++ b/cmd/flux/create_source_oci_test.go
@@ -37,9 +37,34 @@ func TestCreateSourceOCI(t *testing.T) {
 			assertFunc: assertError("url is required"),
 		},
 		{
-			name:       "verify provider not specified",
+			name:       "verify secret specified but provider missing",
 			args:       "create source oci podinfo --url=oci://ghcr.io/stefanprodan/manifests/podinfo --tag=6.3.5 --verify-secret-ref=cosign-pub",
 			assertFunc: assertError("a verification provider must be specified when a secret is specified"),
+		},
+		{
+			name:       "verify issuer specified but provider missing",
+			args:       "create source oci podinfo --url=oci://ghcr.io/stefanprodan/manifests/podinfo --tag=6.3.5 --verify-issuer=github.com",
+			assertFunc: assertError("a verification provider must be specified when OIDC issuer/subject is specified"),
+		},
+		{
+			name:       "verify identity specified but provider missing",
+			args:       "create source oci podinfo --url=oci://ghcr.io/stefanprodan/manifests/podinfo --tag=6.3.5 --verify-subject=developer",
+			assertFunc: assertError("a verification provider must be specified when OIDC issuer/subject is specified"),
+		},
+		{
+			name:       "verify issuer specified but subject missing",
+			args:       "create source oci podinfo --url=oci://ghcr.io/stefanprodan/manifests/podinfo --tag=6.3.5 --verify-issuer=github --verify-provider=cosign --export",
+			assertFunc: assertGoldenFile("./testdata/oci/export_with_issuer.golden"),
+		},
+		{
+			name:       "all verify fields set",
+			args:       "create source oci podinfo --url=oci://ghcr.io/stefanprodan/manifests/podinfo --tag=6.3.5 --verify-issuer=github verify-subject=stefanprodan --verify-provider=cosign --export",
+			assertFunc: assertGoldenFile("./testdata/oci/export_with_issuer.golden"),
+		},
+		{
+			name:       "verify subject specified but issuer missing",
+			args:       "create source oci podinfo --url=oci://ghcr.io/stefanprodan/manifests/podinfo --tag=6.3.5 --verify-subject=stefanprodan --verify-provider=cosign --export",
+			assertFunc: assertGoldenFile("./testdata/oci/export_with_subject.golden"),
 		},
 		{
 			name:       "export manifest",

--- a/cmd/flux/testdata/oci/export_with_complete_verification.golden
+++ b/cmd/flux/testdata/oci/export_with_complete_verification.golden
@@ -1,0 +1,16 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: podinfo
+  namespace: flux-system
+spec:
+  interval: 0s
+  ref:
+    tag: 6.3.5
+  url: oci://ghcr.io/stefanprodan/manifests/podinfo
+  verify:
+    matchOIDCIdentity:
+    - issuer: github
+      subject: stefanprodan
+    provider: cosign

--- a/cmd/flux/testdata/oci/export_with_issuer.golden
+++ b/cmd/flux/testdata/oci/export_with_issuer.golden
@@ -1,0 +1,16 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: podinfo
+  namespace: flux-system
+spec:
+  interval: 0s
+  ref:
+    tag: 6.3.5
+  url: oci://ghcr.io/stefanprodan/manifests/podinfo
+  verify:
+    matchOIDCIdentity:
+    - issuer: github
+      subject: ""
+    provider: cosign

--- a/cmd/flux/testdata/oci/export_with_subject.golden
+++ b/cmd/flux/testdata/oci/export_with_subject.golden
@@ -1,0 +1,16 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: podinfo
+  namespace: flux-system
+spec:
+  interval: 0s
+  ref:
+    tag: 6.3.5
+  url: oci://ghcr.io/stefanprodan/manifests/podinfo
+  verify:
+    matchOIDCIdentity:
+    - issuer: ""
+      subject: stefanprodan
+    provider: cosign


### PR DESCRIPTION
This change introduces two new flags to `create source oci` for providing the values to the `OCIRepository.spec.verify.matchOIDCIdentity.(issuer,subject)` fields.
