### PR TITLE
Run conformance tests for Kubernetes 1.30.0

### DIFF
--- a/.github/workflows/e2e-arm64.yaml
+++ b/.github/workflows/e2e-arm64.yaml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         # Keep this list up-to-date with https://endoflife.date/kubernetes
         # Build images with https://github.com/fluxcd/flux-benchmark/actions/workflows/build-kind.yaml
-        KUBERNETES_VERSION: [ 1.26.6, 1.27.3, 1.28.0, 1.29.0 ]
+        KUBERNETES_VERSION: [ 1.28.9, 1.29.4, 1.30.0 ]
       fail-fast: false
     steps:
       - name: Checkout

--- a/.github/workflows/e2e-arm64.yaml
+++ b/.github/workflows/e2e-arm64.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         # Keep this list up-to-date with https://endoflife.date/kubernetes
-        # Check which versions are available on DockerHub with 'crane ls kindest/node'
+        # Build images with https://github.com/fluxcd/flux-benchmark/actions/workflows/build-kind.yaml
         KUBERNETES_VERSION: [ 1.26.6, 1.27.3, 1.28.0, 1.29.0 ]
       fail-fast: false
     steps:
@@ -43,7 +43,7 @@ jobs:
           --wait 5m \
           --name ${{ steps.prep.outputs.CLUSTER }} \
           --kubeconfig=/tmp/${{ steps.prep.outputs.CLUSTER }} \
-          --image=kindest/node:v${{ matrix.KUBERNETES_VERSION }}
+          --image=ghcr.io/fluxcd/kindest/node:v${{ matrix.KUBERNETES_VERSION }}-arm64
       - name: Run e2e tests
         run: TEST_KUBECONFIG=/tmp/${{ steps.prep.outputs.CLUSTER }} make e2e
       - name: Run multi-tenancy tests


### PR DESCRIPTION
Changes:
- Run conformance tests for Kubernetes `1.28.9`, `1.29.4` and `1.30.0`
- Drop support for Kubernetes `1.26` and `1.27`
- Use Kubernetes KinD node images from [ghcr.io/fluxcd/kindest/node](https://github.com/fluxcd/flux-benchmark/pkgs/container/kindest%2Fnode)

Part of: #4712