### PR TITLE
Add k3s to the conformance test suite

### DIFF
--- a/.github/workflows/e2e-k3s.yaml
+++ b/.github/workflows/e2e-k3s.yaml
@@ -1,0 +1,102 @@
+name: e2e-k3s
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ 'main', 'update-components', 'k3s-*', 'release/**' ]
+
+permissions:
+  contents: read
+
+jobs:
+  e2e-k3s:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Keep this list up-to-date with https://endoflife.date/kubernetes
+        # Available versions can be found with "replicated cluster versions"
+        K3S_VERSION: [ 1.28.7,  1.29.2 ]
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - name: Setup Go
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        with:
+          go-version: 1.22.x
+          cache-dependency-path: |
+            **/go.sum
+            **/go.mod
+      - name: Prepare
+        id: prep
+        run: |
+          ID=${GITHUB_SHA:0:7}-${{ matrix.K3S_VERSION }}-$(date +%s)
+          PSEUDO_RAND_SUFFIX=$(echo "${ID}" | shasum | awk '{print $1}')
+          echo "cluster=flux2-k3s-${PSEUDO_RAND_SUFFIX}" >> $GITHUB_OUTPUT
+          KUBECONFIG_PATH="$(git rev-parse --show-toplevel)/bin/kubeconfig.yaml"
+          echo "kubeconfig-path=${KUBECONFIG_PATH}" >> $GITHUB_OUTPUT
+      - name: Setup Kustomize
+        uses: fluxcd/pkg/actions/kustomize@main
+      - name: Build
+        run: make build-dev
+      - name: Create repository
+        run: |
+          gh repo create --private --add-readme fluxcd-testing/${{ steps.prep.outputs.cluster }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITPROVIDER_BOT_TOKEN }}
+      - name: Create cluster
+        id: create-cluster
+        uses: replicatedhq/compatibility-actions/create-cluster@v1
+        with:
+          api-token: ${{ secrets.REPLICATED_API_TOKEN }}
+          kubernetes-distribution: "k3s"
+          kubernetes-version: ${{ matrix.K3S_VERSION }}
+          ttl: 20m
+          cluster-name: "${{ steps.prep.outputs.cluster }}"
+          kubeconfig-path: ${{ steps.prep.outputs.kubeconfig-path }}
+          export-kubeconfig: true
+      - name: Run flux bootstrap
+        run: |
+          ./bin/flux bootstrap git --manifests ./manifests/install/ \
+          --components-extra=image-reflector-controller,image-automation-controller \
+          --url=https://github.com/fluxcd-testing/${{ steps.prep.outputs.cluster }} \
+          --branch=main \
+          --path=clusters/k3s \
+          --token-auth
+        env:
+          GIT_PASSWORD: ${{ secrets.GITPROVIDER_BOT_TOKEN }}
+      - name: Run flux check
+        run: |
+          ./bin/flux check
+      - name: Run flux reconcile
+        run: |
+          ./bin/flux reconcile ks flux-system --with-source
+          ./bin/flux get all
+          ./bin/flux events
+      - name: Collect reconcile logs
+        if: ${{ always() }}
+        continue-on-error: true
+        run: |
+          kubectl -n flux-system get all
+          kubectl -n flux-system describe pods
+          kubectl -n flux-system logs deploy/source-controller
+          kubectl -n flux-system logs deploy/kustomize-controller
+          kubectl -n flux-system logs deploy/notification-controller
+      - name: Delete flux
+        run: |
+          ./bin/flux uninstall -s --keep-namespace
+          kubectl delete ns flux-system --wait
+      - name: Delete cluster
+        if: ${{ always() }}
+        uses: replicatedhq/replicated-actions/remove-cluster@v1
+        continue-on-error: true
+        with:
+          api-token: ${{ secrets.REPLICATED_API_TOKEN }}
+          cluster-id: ${{ steps.create-cluster.outputs.cluster-id }}
+      - name: Delete repository
+        if: ${{ always() }}
+        continue-on-error: true
+        run: |
+          gh repo delete fluxcd-testing/${{ steps.prep.outputs.cluster }} --yes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITPROVIDER_BOT_TOKEN }}


### PR DESCRIPTION
This PR adds end-to-end tests for bootstrapping Flux on k3s clusters (latest two minor versions corresponding to Kubernetes to 1.28 and 1.29).

Big thanks to @marccampbell and [Replicated](https://www.replicated.com/) for sponsoring the Flux project with on-demand k3s clusters 🤗 

Part of: https://github.com/fluxcd/flux2/issues/4712