### PR TITLE
tests/integration: Run flux check after installation

### DIFF
--- a/tests/integration/suite_test.go
+++ b/tests/integration/suite_test.go
@@ -53,6 +53,9 @@ const (
 	// kubeconfigPath is the path of the file containing the kubeconfig
 	kubeconfigPath = "./build/kubeconfig"
 
+	// fluxBin is the path to the flux binary.
+	fluxBin = "./build/flux"
+
 	// default branch to be used when cloning git repositories
 	defaultBranch = "main"
 
@@ -289,6 +292,13 @@ func TestMain(m *testing.M) {
 	}()
 	if err != nil {
 		panic(fmt.Sprintf("error installing Flux: %v", err))
+	}
+
+	// On check failure, log and continue. Controllers may be ready by the time
+	// tests run.
+	log.Println("Running flux check")
+	if err := runFluxCheck(ctx); err != nil {
+		log.Printf("flux check failed: %v\n", err)
 	}
 
 	log.Println("Running e2e tests")

--- a/tests/integration/util_test.go
+++ b/tests/integration/util_test.go
@@ -92,17 +92,24 @@ func installFlux(ctx context.Context, tmpDir string, kubeconfigPath string) erro
 		bootstrapArgs = fmt.Sprintf("--token-auth --password=%s", cfg.gitPat)
 	}
 
-	bootstrapCmd := fmt.Sprintf("./build/flux bootstrap git  --url=%s %s --kubeconfig=%s --path=clusters/e2e "+
+	bootstrapCmd := fmt.Sprintf("%s bootstrap git  --url=%s %s --kubeconfig=%s --path=clusters/e2e "+
 		" --components-extra image-reflector-controller,image-automation-controller",
-		repoURL, bootstrapArgs, kubeconfigPath)
+		fluxBin, repoURL, bootstrapArgs, kubeconfigPath)
 
 	return tftestenv.RunCommand(ctx, "./", bootstrapCmd, tftestenv.RunCommandOptions{
 		Timeout: 15 * time.Minute,
 	})
 }
 
+func runFluxCheck(ctx context.Context) error {
+	checkCmd := fmt.Sprintf("%s check --kubeconfig %s", fluxBin, kubeconfigPath)
+	return tftestenv.RunCommand(ctx, "./", checkCmd, tftestenv.RunCommandOptions{
+		AttachConsole: true,
+	})
+}
+
 func uninstallFlux(ctx context.Context) error {
-	uninstallCmd := fmt.Sprintf("./build/flux uninstall --kubeconfig %s -s", kubeconfigPath)
+	uninstallCmd := fmt.Sprintf("%s uninstall --kubeconfig %s -s", fluxBin, kubeconfigPath)
 	if err := tftestenv.RunCommand(ctx, "./", uninstallCmd, tftestenv.RunCommandOptions{
 		Timeout: 15 * time.Minute,
 	}); err != nil {


### PR DESCRIPTION
Run `flux check` after installation to show the relevant cluster and resource configurations in the environment.

```console
...
2024/05/10 14:43:02 Installing flux
2024/05/10 14:43:50 Running flux check
► checking prerequisites
✔ Kubernetes 1.28.7-gke.1026000 >=1.26.0-0
► checking version in cluster
✔ distribution: flux-v0.0.0-dev.0
✔ bootstrapped: true
► checking controllers
✔ helm-controller: deployment ready
► ghcr.io/fluxcd/helm-controller:v1.0.0
✔ image-automation-controller: deployment ready
► ghcr.io/fluxcd/image-automation-controller:v0.38.0
✔ image-reflector-controller: deployment ready
► ghcr.io/fluxcd/image-reflector-controller:v0.32.0
✔ kustomize-controller: deployment ready
► ghcr.io/fluxcd/kustomize-controller:v1.3.0
✔ notification-controller: deployment ready
► ghcr.io/fluxcd/notification-controller:v1.3.0
✔ source-controller: deployment ready
► ghcr.io/fluxcd/source-controller:v1.3.0
► checking crds
✔ alerts.notification.toolkit.fluxcd.io/v1beta3
✔ buckets.source.toolkit.fluxcd.io/v1beta2
✔ gitrepositories.source.toolkit.fluxcd.io/v1
✔ helmcharts.source.toolkit.fluxcd.io/v1
✔ helmreleases.helm.toolkit.fluxcd.io/v2
✔ helmrepositories.source.toolkit.fluxcd.io/v1
✔ imagepolicies.image.toolkit.fluxcd.io/v1beta2
✔ imagerepositories.image.toolkit.fluxcd.io/v1beta2
✔ imageupdateautomations.image.toolkit.fluxcd.io/v1beta2
✔ kustomizations.kustomize.toolkit.fluxcd.io/v1
✔ ocirepositories.source.toolkit.fluxcd.io/v1beta2
✔ providers.notification.toolkit.fluxcd.io/v1beta3
✔ receivers.notification.toolkit.fluxcd.io/v1
✔ all checks passed
2024/05/10 14:43:59 Running e2e tests
=== RUN   TestFluxInstallation
...
```

Example run: https://github.com/fluxcd/flux2/actions/runs/9034019891/job/24825614710?pr=4778#step:13:109
