### PR TITLE
Set Kubernetes 1.28 as min required version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.19 as builder
 RUN apk add --no-cache ca-certificates curl
 
 ARG ARCH=linux/amd64
-ARG KUBECTL_VER=1.28.6
+ARG KUBECTL_VER=1.30.0
 
 RUN curl -sL https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VER}/bin/${ARCH}/kubectl \
     -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl && \

--- a/cmd/flux/check.go
+++ b/cmd/flux/check.go
@@ -60,7 +60,7 @@ type checkFlags struct {
 }
 
 var kubernetesConstraints = []string{
-	">=1.26.0-0",
+	">=1.28.0-0",
 }
 
 var checkArgs checkFlags

--- a/cmd/flux/testdata/check/check_pre.golden
+++ b/cmd/flux/testdata/check/check_pre.golden
@@ -1,3 +1,3 @@
 ► checking prerequisites
-✔ Kubernetes {{ .serverVersion }} >=1.26.0-0
+✔ Kubernetes {{ .serverVersion }} >=1.28.0-0
 ✔ prerequisites checks passed


### PR DESCRIPTION
Changes:
- Update the Kubernetes version check and drop EOL versions
- Update kubectl to 1.30.0 in the flux-cli Dockerfile

Part of: #4712 