### PR TITLE
ci: Adapt config to GoRelease v2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,7 +82,7 @@ jobs:
         uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
         with:
           version: latest
-          args: release --release-notes=output/notes.md --skip-validate
+          args: release --release-notes=output/notes.md --skip=validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@ builds:
       - arm64
       - arm
     goarm:
-      - 7
+      - "7"
   - <<: *build_defaults
     id: darwin
     goos:
@@ -73,11 +73,11 @@ signs:
     output: true
 brews:
   - name: flux
-    tap:
+    repository:
       owner: fluxcd
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    folder: Formula
+    directory: Formula
     homepage: "https://fluxcd.io/"
     description: "Flux CLI"
     install: |


### PR DESCRIPTION
Deal with breaking changes in https://goreleaser.com/deprecations/?h=changelog#removed-in-v2