### PR TITLE
Add `part-of` label to controllers base

### DIFF
--- a/manifests/bases/helm-controller/labels.yaml
+++ b/manifests/bases/helm-controller/labels.yaml
@@ -4,6 +4,7 @@ metadata:
   name: labels
 labels:
   app.kubernetes.io/component: helm-controller
+  app.kubernetes.io/part-of: flux
 fieldSpecs:
   - path: metadata/labels
     create: true

--- a/manifests/bases/image-automation-controller/labels.yaml
+++ b/manifests/bases/image-automation-controller/labels.yaml
@@ -4,6 +4,7 @@ metadata:
   name: labels
 labels:
   app.kubernetes.io/component: image-automation-controller
+  app.kubernetes.io/part-of: flux
 fieldSpecs:
   - path: metadata/labels
     create: true

--- a/manifests/bases/image-reflector-controller/labels.yaml
+++ b/manifests/bases/image-reflector-controller/labels.yaml
@@ -4,6 +4,7 @@ metadata:
   name: labels
 labels:
   app.kubernetes.io/component: image-reflector-controller
+  app.kubernetes.io/part-of: flux
 fieldSpecs:
   - path: metadata/labels
     create: true

--- a/manifests/bases/kustomize-controller/labels.yaml
+++ b/manifests/bases/kustomize-controller/labels.yaml
@@ -4,6 +4,7 @@ metadata:
   name: labels
 labels:
   app.kubernetes.io/component: kustomize-controller
+  app.kubernetes.io/part-of: flux
 fieldSpecs:
   - path: metadata/labels
     create: true

--- a/manifests/bases/notification-controller/labels.yaml
+++ b/manifests/bases/notification-controller/labels.yaml
@@ -4,6 +4,7 @@ metadata:
   name: labels
 labels:
   app.kubernetes.io/component: notification-controller
+  app.kubernetes.io/part-of: flux
 fieldSpecs:
   - path: metadata/labels
     create: true

--- a/manifests/bases/source-controller/labels.yaml
+++ b/manifests/bases/source-controller/labels.yaml
@@ -4,6 +4,7 @@ metadata:
   name: labels
 labels:
   app.kubernetes.io/component: source-controller
+  app.kubernetes.io/part-of: flux
 fieldSpecs:
   - path: metadata/labels
     create: true


### PR DESCRIPTION
Add `app.kubernetes.io/part-of: flux` label to controllers base to allow targeting all deployments by label in the install kustomization.