### PR TITLE
Update conformance tests to Kubernetes v1.30.2

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         # Keep this list up-to-date with https://endoflife.date/kubernetes
         # Build images with https://github.com/fluxcd/flux-benchmark/actions/workflows/build-kind.yaml
-        KUBERNETES_VERSION: [ 1.28.9, 1.29.4, 1.30.0 ]
+        KUBERNETES_VERSION: [ 1.28.11, 1.29.6, 1.30.2 ]
       fail-fast: false
     steps:
       - name: Checkout


### PR DESCRIPTION
Bump Kind node images to latest minor versions of Kubernetes.