### PR TITLE
Introduce visibility flag for bootstrap gitlab

### DIFF
--- a/internal/flags/gitlab_visibility.go
+++ b/internal/flags/gitlab_visibility.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2024 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/fluxcd/go-git-providers/gitprovider"
+	"github.com/fluxcd/go-git-providers/validation"
+)
+
+var supportedGitLabVisibilities = map[gitprovider.RepositoryVisibility]struct{}{
+	gitprovider.RepositoryVisibilityPublic:   {},
+	gitprovider.RepositoryVisibilityInternal: {},
+	gitprovider.RepositoryVisibilityPrivate:  {},
+}
+
+// ValidateRepositoryVisibility validates a given RepositoryVisibility.
+func ValidateRepositoryVisibility(r gitprovider.RepositoryVisibility) error {
+	_, ok := supportedGitLabVisibilities[r]
+	if !ok {
+		return validation.ErrFieldEnumInvalid
+	}
+	return nil
+}
+
+type GitLabVisibility gitprovider.RepositoryVisibility
+
+func (d *GitLabVisibility) String() string {
+	return string(*d)
+}
+
+func (d *GitLabVisibility) Set(str string) error {
+	if strings.TrimSpace(str) == "" {
+		str = string(gitprovider.RepositoryVisibilityPrivate)
+	}
+	var visibility = gitprovider.RepositoryVisibility(str)
+	if ValidateRepositoryVisibility(visibility) != nil {
+		return fmt.Errorf("unsupported visibility '%s'", str)
+	}
+	*d = GitLabVisibility(visibility)
+	return nil
+}
+
+func (d *GitLabVisibility) Type() string {
+	return "gitLabVisibility"
+}
+
+func (d *GitLabVisibility) Description() string {
+	return fmt.Sprintf("specifies the visibility of the repository. Valid values are public, private, internal")
+}

--- a/internal/flags/gitlab_visibility_test.go
+++ b/internal/flags/gitlab_visibility_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2024 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"testing"
+)
+
+func TestGitLabVisibility_Set(t *testing.T) {
+	tests := []struct {
+		name      string
+		str       string
+		expect    string
+		expectErr bool
+	}{
+		{"private", "private", "private", false},
+		{"internal", "internal", "internal", false},
+		{"public", "public", "public", false},
+		{"unsupported", "unsupported", "", true},
+		{"default", "", "private", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var p GitLabVisibility
+			if err := p.Set(tt.str); (err != nil) != tt.expectErr {
+				t.Errorf("Set() error = %v, expectErr %v", err, tt.expectErr)
+			}
+			if str := p.String(); str != tt.expect {
+				t.Errorf("Set() = %v, expect %v", str, tt.expect)
+			}
+		})
+	}
+}

--- a/pkg/bootstrap/bootstrap_provider.go
+++ b/pkg/bootstrap/bootstrap_provider.go
@@ -94,6 +94,12 @@ func WithProviderRepository(owner, repositoryName string, personal bool) GitProv
 	}
 }
 
+func WithProviderVisibility(visibility string) GitProviderOption {
+	return providerRepositoryConfigOption{
+		visibility: visibility,
+	}
+}
+
 type providerRepositoryOption struct {
 	owner          string
 	repositoryName string


### PR DESCRIPTION
This MR introduces a `––visibility=private|public|internal` flag for `bootstrap gitlab`.

At the same time it deprecates the `--private` flag.

Related to https://github.com/fluxcd/flux2/issues/3817