### PR TITLE
Stop spinner on cancel of flux diff kustomization

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -583,9 +583,43 @@ func (b *Builder) Cancel() error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	err := kustomize.CleanDirectory(b.resourcesPath, b.action)
+	err := b.stopSpinner()
 	if err != nil {
 		return err
+	}
+
+	err = kustomize.CleanDirectory(b.resourcesPath, b.action)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (b *Builder) startSpinner() error {
+	if b.spinner == nil {
+		return nil
+	}
+
+	err := b.spinner.Start()
+	if err != nil {
+		return fmt.Errorf("failed to start spinner: %w", err)
+	}
+
+	return nil
+}
+
+func (b *Builder) stopSpinner() error {
+	if b.spinner == nil {
+		return nil
+	}
+
+	status := b.spinner.Status()
+	if status == yacspin.SpinnerRunning || status == yacspin.SpinnerPaused {
+		err := b.spinner.Stop()
+		if err != nil {
+			return fmt.Errorf("failed to stop spinner: %w", err)
+		}
 	}
 
 	return nil

--- a/internal/build/diff.go
+++ b/internal/build/diff.go
@@ -77,11 +77,9 @@ func (b *Builder) Diff() (string, bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), b.timeout)
 	defer cancel()
 
-	if b.spinner != nil {
-		err = b.spinner.Start()
-		if err != nil {
-			return "", false, fmt.Errorf("failed to start spinner: %w", err)
-		}
+	err = b.startSpinner()
+	if err != nil {
+		return "", false, err
 	}
 
 	var diffErrs []error
@@ -151,11 +149,9 @@ func (b *Builder) Diff() (string, bool, error) {
 		}
 	}
 
-	if b.spinner != nil {
-		err = b.spinner.Stop()
-		if err != nil {
-			return "", createdOrDrifted, fmt.Errorf("failed to stop spinner: %w", err)
-		}
+	err = b.stopSpinner()
+	if err != nil {
+		return "", createdOrDrifted, err
 	}
 
 	return output.String(), createdOrDrifted, errors.Reduce(errors.Flatten(errors.NewAggregate(diffErrs)))


### PR DESCRIPTION
This PR stops spinner on cancel of `flux diff kustomization` command - otherwise cursor (hidden by spinner package) remains invisible.

`stopSpinner()` is called before `CleanDirectory()` since later happens to return an error if _kustomize.yaml_ doesn't exist and then `Cancel()` exits still leaving cursor invisible.