### PR TITLE
Recursively diff Kustomizations

### DIFF
--- a/cmd/flux/build_kustomization_test.go
+++ b/cmd/flux/build_kustomization_test.go
@@ -70,6 +70,12 @@ func TestBuildKustomization(t *testing.T) {
 			resultFile: "./testdata/build-kustomization/podinfo-with-ignore-result.yaml",
 			assertFunc: "assertGoldenTemplateFile",
 		},
+		{
+			name:       "build with recursive",
+			args:       "build kustomization podinfo --path ./testdata/build-kustomization/podinfo-with-my-app --recursive --local-sources GitRepository/default/podinfo=./testdata/build-kustomization",
+			resultFile: "./testdata/build-kustomization/podinfo-with-my-app-result.yaml",
+			assertFunc: "assertGoldenTemplateFile",
+		},
 	}
 
 	tmpl := map[string]string{
@@ -155,6 +161,12 @@ spec:
 			name:       "build deployment and configmap with var substitution in dry-run mode",
 			args:       "build kustomization podinfo --kustomization-file " + tmpFile + " --path ./testdata/build-kustomization/var-substitution --dry-run",
 			resultFile: "./testdata/build-kustomization/podinfo-with-var-substitution-result.yaml",
+			assertFunc: "assertGoldenTemplateFile",
+		},
+		{
+			name:       "build with recursive",
+			args:       "build kustomization podinfo --kustomization-file " + tmpFile + " --path ./testdata/build-kustomization/podinfo-with-my-app --recursive --local-sources GitRepository/default/podinfo=./testdata/build-kustomization",
+			resultFile: "./testdata/build-kustomization/podinfo-with-my-app-result.yaml",
 			assertFunc: "assertGoldenTemplateFile",
 		},
 	}

--- a/cmd/flux/diff_kustomization_test.go
+++ b/cmd/flux/diff_kustomization_test.go
@@ -97,6 +97,12 @@ func TestDiffKustomization(t *testing.T) {
 			objectFile: "",
 			assert:     assertGoldenFile("./testdata/diff-kustomization/nothing-is-deployed.golden"),
 		},
+		{
+			name:       "diff with recursive",
+			args:       "diff kustomization podinfo --path ./testdata/build-kustomization/podinfo-with-my-app --progress-bar=false --recursive --local-sources GitRepository/default/podinfo=./testdata/build-kustomization",
+			objectFile: "./testdata/diff-kustomization/my-app.yaml",
+			assert:     assertGoldenFile("./testdata/diff-kustomization/diff-with-recursive.golden"),
+		},
 	}
 
 	tmpl := map[string]string{

--- a/cmd/flux/main_test.go
+++ b/cmd/flux/main_test.go
@@ -429,7 +429,9 @@ func resetCmdArgs() {
 		tail:          -1,
 		fluxNamespace: rootArgs.defaults.Namespace,
 	}
-	buildKsArgs = buildKsFlags{}
+	buildKsArgs = buildKsFlags{
+		localSources: map[string]string{},
+	}
 	checkArgs = checkFlags{}
 	createArgs = createFlags{}
 	deleteArgs = deleteFlags{}

--- a/cmd/flux/testdata/build-kustomization/my-app/configmap.yaml
+++ b/cmd/flux/testdata/build-kustomization/my-app/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+data:
+  var: test
+kind: ConfigMap
+metadata:
+  name: my-app

--- a/cmd/flux/testdata/build-kustomization/podinfo-with-my-app-result.yaml
+++ b/cmd/flux/testdata/build-kustomization/podinfo-with-my-app-result.yaml
@@ -1,0 +1,29 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  labels:
+    kustomize.toolkit.fluxcd.io/name: podinfo
+    kustomize.toolkit.fluxcd.io/namespace: {{ .fluxns }}
+  name: my-app
+  namespace: default
+spec:
+  force: true
+  interval: 5m0s
+  path: ./my-app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: podinfo
+  targetNamespace: default
+---
+apiVersion: v1
+data:
+  var: test
+kind: ConfigMap
+metadata:
+  labels:
+    kustomize.toolkit.fluxcd.io/name: my-app
+    kustomize.toolkit.fluxcd.io/namespace: default
+  name: my-app
+  namespace: default
+---

--- a/cmd/flux/testdata/build-kustomization/podinfo-with-my-app/kustomization.yaml
+++ b/cmd/flux/testdata/build-kustomization/podinfo-with-my-app/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ./my-app.yaml

--- a/cmd/flux/testdata/build-kustomization/podinfo-with-my-app/my-app.yaml
+++ b/cmd/flux/testdata/build-kustomization/podinfo-with-my-app/my-app.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: my-app
+spec:
+  interval: 5m0s
+  path: ./my-app
+  force: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: podinfo
+  targetNamespace: default

--- a/cmd/flux/testdata/diff-kustomization/diff-with-recursive.golden
+++ b/cmd/flux/testdata/diff-kustomization/diff-with-recursive.golden
@@ -1,0 +1,2 @@
+📁 Kustomization/default/my-app changed
+► ConfigMap/default/my-app created

--- a/cmd/flux/testdata/diff-kustomization/my-app.yaml
+++ b/cmd/flux/testdata/diff-kustomization/my-app.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  labels:
+    kustomize.toolkit.fluxcd.io/name: podinfo
+    kustomize.toolkit.fluxcd.io/namespace: {{ .fluxns }}
+  name: my-app
+  namespace: default
+spec:
+  interval: 5m0s
+  path: ./my-app
+  force: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: podinfo
+  targetNamespace: default


### PR DESCRIPTION
This PR will add `--recursive` flag to recursively diff encountered Kustomizations similar to discussions https://github.com/fluxcd/flux2/discussions/2466, https://github.com/fluxcd/flux2/discussions/2434, https://github.com/fluxcd/flux2/discussions/820. (Currently it doesn't expand HelmReleases, probably could be added later).

Sources of additional repositories can be provided as comma-separated list by `--local-sources Kind/namespace/name=path` (i.e. `--local-sources GitRepository/flux-system/flux-gitops=$HOME/git/flux-gitops`)

Couple of words on our use case and motivation. We have number of clusters of different kinds sharing common GitOps repository with Kustomizations and overrides. To avoid unexpected changes most clusters are locked to a specific SHA instead of main branch. So promoting to a new SHA requires comparing the changes in Git and figuring out how it will affect the specific cluster.

This feature will allow to run on all applicable to the cluster Kustomizations indicating only ones that have the actual change. Example of the output:

```
$ flux diff kustomization flux-system --path ~/git/flux-system/clusters/eks/dev/ie1 --recursive \
> --local-sources GitRepository/flux-system/flux-gitops=$HOME/git/flux-gitops
✓  Kustomization diffing...
► ConfigMap/flux-system/cluster-vars drifted

data.kube_cluster_env
  ± value change
    - dev
    + test

📁 Kustomization/flux-system/flux-gitops changed
📁 Kustomization/flux-system/ebs changed
► HelmRelease/kube-system/aws-ebs-csi-driver drifted

metadata.generation
  ± value change
    - 2
    + 3

spec.chart.spec.version
  ± value change
    - 2.29.0
    + 2.33.0

► Kustomization/flux-system/docker-registry deleted
► Namespace/test created
► Kustomization/flux-system/tigera-operator created
► Kustomization/flux-system/tigera-policies created
⚠️ identified at least one change, exiting with non-zero exit code
```