### PR TITLE
[RFC-0007] Add `--provider` flag to `flux create source git`

### DIFF
--- a/cmd/flux/create_source_git_test.go
+++ b/cmd/flux/create_source_git_test.go
@@ -134,6 +134,31 @@ func TestCreateSourceGitExport(t *testing.T) {
 			args:   "create source git podinfo --namespace=flux-system --url=https://github.com/stefanprodan/podinfo --branch=test --interval=1m0s --export",
 			assert: assertGoldenFile("testdata/create_source_git/source-git-branch.yaml"),
 		},
+		{
+			name:   "source with generic provider",
+			args:   "create source git podinfo --namespace=flux-system --url=https://github.com/stefanprodan/podinfo --provider generic --branch=test --interval=1m0s --export",
+			assert: assertGoldenFile("testdata/create_source_git/source-git-provider-generic.yaml"),
+		},
+		{
+			name:   "source with azure provider",
+			args:   "create source git podinfo --namespace=flux-system --url=https://dev.azure.com/foo/bar/_git/podinfo --provider azure --branch=test --interval=1m0s --export",
+			assert: assertGoldenFile("testdata/create_source_git/source-git-provider-azure.yaml"),
+		},
+		{
+			name:   "source with invalid provider",
+			args:   "create source git podinfo --namespace=flux-system --url=https://dev.azure.com/foo/bar/_git/podinfo --provider dummy --branch=test --interval=1m0s --export",
+			assert: assertError("invalid argument \"dummy\" for \"--provider\" flag: source Git provider 'dummy' is not supported, must be one of: generic|azure"),
+		},
+		{
+			name:   "source with empty provider",
+			args:   "create source git podinfo --namespace=flux-system --url=https://dev.azure.com/foo/bar/_git/podinfo --provider \"\" --branch=test --interval=1m0s --export",
+			assert: assertError("invalid argument \"\" for \"--provider\" flag: no source Git provider given, please specify the Git provider name"),
+		},
+		{
+			name:   "source with no provider",
+			args:   "create source git podinfo --namespace=flux-system --url=https://dev.azure.com/foo/bar/_git/podinfo --branch=test --interval=1m0s --export --provider",
+			assert: assertError("flag needs an argument: --provider"),
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/flux/testdata/create_source_git/source-git-provider-azure.yaml
+++ b/cmd/flux/testdata/create_source_git/source-git-provider-azure.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: podinfo
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  provider: azure
+  ref:
+    branch: test
+  url: https://dev.azure.com/foo/bar/_git/podinfo

--- a/cmd/flux/testdata/create_source_git/source-git-provider-generic.yaml
+++ b/cmd/flux/testdata/create_source_git/source-git-provider-generic.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: podinfo
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  provider: generic
+  ref:
+    branch: test
+  url: https://github.com/stefanprodan/podinfo

--- a/internal/flags/source_git_provider.go
+++ b/internal/flags/source_git_provider.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2024 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/fluxcd/flux2/v2/internal/utils"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+)
+
+var supportedSourceGitProviders = []string{
+	sourcev1.GitProviderGeneric,
+	sourcev1.GitProviderAzure,
+}
+
+type SourceGitProvider string
+
+func (p *SourceGitProvider) String() string {
+	return string(*p)
+}
+
+func (p *SourceGitProvider) Set(str string) error {
+	if strings.TrimSpace(str) == "" {
+		return fmt.Errorf("no source Git provider given, please specify %s",
+			p.Description())
+	}
+	if !utils.ContainsItemString(supportedSourceGitProviders, str) {
+		return fmt.Errorf("source Git provider '%s' is not supported, must be one of: %v",
+			str, p.Type())
+	}
+	*p = SourceGitProvider(str)
+	return nil
+}
+
+func (p *SourceGitProvider) Type() string {
+	return strings.Join(supportedSourceGitProviders, "|")
+}
+
+func (p *SourceGitProvider) Description() string {
+	return "the Git provider name"
+}


### PR DESCRIPTION
- Add provider flag to `flux create source git` command with supported values: `azure`, `generic`.
- Unit tests validating the generated yaml with supported provider and error conditions.