### PR TITLE
Run conformance tests for Kubernetes 1.29-1.31

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         # Keep this list up-to-date with https://endoflife.date/kubernetes
         # Build images with https://github.com/fluxcd/flux-benchmark/actions/workflows/build-kind.yaml
-        KUBERNETES_VERSION: [ 1.28.11, 1.29.6, 1.30.2, 1.31.0 ]
+        KUBERNETES_VERSION: [1.29.7, 1.30.2, 1.31.1 ]
       fail-fast: false
     steps:
       - name: Checkout
@@ -76,7 +76,7 @@ jobs:
       matrix:
         # Keep this list up-to-date with https://endoflife.date/kubernetes
         # Available versions can be found with "replicated cluster versions"
-        K3S_VERSION: [ 1.28.7,  1.29.2 ]
+        K3S_VERSION: [ 1.29.9, 1.30.5, 1.31.1 ]
       fail-fast: false
     steps:
       - name: Checkout

--- a/.github/workflows/e2e-bootstrap.yaml
+++ b/.github/workflows/e2e-bootstrap.yaml
@@ -28,12 +28,12 @@ jobs:
       - name: Setup Kubernetes
         uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
         with:
-          version: v0.22.0
+          version: v0.24.0
           cluster_name: kind
           # The versions below should target the newest Kubernetes version
           # Keep this up-to-date with https://endoflife.date/kubernetes
-          node_image: ghcr.io/fluxcd/kindest/node:v1.30.0-amd64
-          kubectl_version: v1.30.0
+          node_image: ghcr.io/fluxcd/kindest/node:v1.31.0-amd64
+          kubectl_version: v1.31.0
       - name: Setup Kustomize
         uses: fluxcd/pkg/actions/kustomize@30c101fc7c9fac4d84937ff4890a3da46a9db2dd # main
       - name: Setup yq

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -34,14 +34,14 @@ jobs:
       - name: Setup Kubernetes
         uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
         with:
-          version: v0.22.0
+          version: v0.24.0
           cluster_name: kind
           wait: 5s
           config: .github/kind/config.yaml # disable KIND-net
           # The versions below should target the oldest supported Kubernetes version
           # Keep this up-to-date with https://endoflife.date/kubernetes
-          node_image: ghcr.io/fluxcd/kindest/node:v1.28.9-amd64
-          kubectl_version: v1.28.9
+          node_image: ghcr.io/fluxcd/kindest/node:v1.29.7-amd64
+          kubectl_version: v1.29.7
       - name: Setup Calico for network policy
         run: |
           kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.27.3/manifests/calico.yaml


### PR DESCRIPTION
Update conformance tests matrix to the latest supported Kubernetes versions.

Kubernetes 1.28 active supported ended https://endoflife.date/kubernetes so this PR removes 1.28 from the test suite.

Part of: #4947 