### PR TITLE
Add `--proxy-secret-ref` to `flux create source` commands

### DIFF
--- a/cmd/flux/create_source_bucket.go
+++ b/cmd/flux/create_source_bucket.go
@@ -63,15 +63,16 @@ For Buckets with static authentication, the credentials are stored in a Kubernet
 }
 
 type sourceBucketFlags struct {
-	name        string
-	provider    flags.SourceBucketProvider
-	endpoint    string
-	accessKey   string
-	secretKey   string
-	region      string
-	insecure    bool
-	secretRef   string
-	ignorePaths []string
+	name           string
+	provider       flags.SourceBucketProvider
+	endpoint       string
+	accessKey      string
+	secretKey      string
+	region         string
+	insecure       bool
+	secretRef      string
+	proxySecretRef string
+	ignorePaths    []string
 }
 
 var sourceBucketArgs = newSourceBucketFlags()
@@ -85,6 +86,7 @@ func init() {
 	createSourceBucketCmd.Flags().StringVar(&sourceBucketArgs.region, "region", "", "the bucket region")
 	createSourceBucketCmd.Flags().BoolVar(&sourceBucketArgs.insecure, "insecure", false, "for when connecting to a non-TLS S3 HTTP endpoint")
 	createSourceBucketCmd.Flags().StringVar(&sourceBucketArgs.secretRef, "secret-ref", "", "the name of an existing secret containing credentials")
+	createSourceBucketCmd.Flags().StringVar(&sourceBucketArgs.proxySecretRef, "proxy-secret-ref", "", "the name of an existing secret containing the proxy address and credentials")
 	createSourceBucketCmd.Flags().StringSliceVar(&sourceBucketArgs.ignorePaths, "ignore-paths", nil, "set paths to ignore in bucket resource (can specify multiple paths with commas: path1,path2)")
 
 	createSourceCmd.AddCommand(createSourceBucketCmd)
@@ -150,6 +152,12 @@ func createSourceBucketCmdRun(cmd *cobra.Command, args []string) error {
 	if sourceBucketArgs.secretRef != "" {
 		bucket.Spec.SecretRef = &meta.LocalObjectReference{
 			Name: sourceBucketArgs.secretRef,
+		}
+	}
+
+	if sourceBucketArgs.proxySecretRef != "" {
+		bucket.Spec.ProxySecretRef = &meta.LocalObjectReference{
+			Name: sourceBucketArgs.proxySecretRef,
 		}
 	}
 

--- a/cmd/flux/create_source_git.go
+++ b/cmd/flux/create_source_git.go
@@ -56,6 +56,7 @@ type sourceGitFlags struct {
 	keyRSABits        flags.RSAKeyBits
 	keyECDSACurve     flags.ECDSACurve
 	secretRef         string
+	proxySecretRef    string
 	provider          flags.SourceGitProvider
 	caFile            string
 	privateKeyFile    string
@@ -145,6 +146,7 @@ func init() {
 	createSourceGitCmd.Flags().Var(&sourceGitArgs.keyRSABits, "ssh-rsa-bits", sourceGitArgs.keyRSABits.Description())
 	createSourceGitCmd.Flags().Var(&sourceGitArgs.keyECDSACurve, "ssh-ecdsa-curve", sourceGitArgs.keyECDSACurve.Description())
 	createSourceGitCmd.Flags().StringVar(&sourceGitArgs.secretRef, "secret-ref", "", "the name of an existing secret containing SSH or basic credentials")
+	createSourceGitCmd.Flags().StringVar(&sourceGitArgs.proxySecretRef, "proxy-secret-ref", "", "the name of an existing secret containing the proxy address and credentials")
 	createSourceGitCmd.Flags().Var(&sourceGitArgs.provider, "provider", sourceGitArgs.provider.Description())
 	createSourceGitCmd.Flags().StringVar(&sourceGitArgs.caFile, "ca-file", "", "path to TLS CA file used for validating self-signed certificates")
 	createSourceGitCmd.Flags().StringVar(&sourceGitArgs.privateKeyFile, "private-key-file", "", "path to a passwordless private key file used for authenticating to the Git SSH server")
@@ -241,6 +243,12 @@ func createSourceGitCmdRun(cmd *cobra.Command, args []string) error {
 	if sourceGitArgs.secretRef != "" {
 		gitRepository.Spec.SecretRef = &meta.LocalObjectReference{
 			Name: sourceGitArgs.secretRef,
+		}
+	}
+
+	if sourceGitArgs.proxySecretRef != "" {
+		gitRepository.Spec.ProxySecretRef = &meta.LocalObjectReference{
+			Name: sourceGitArgs.proxySecretRef,
 		}
 	}
 

--- a/cmd/flux/create_source_oci.go
+++ b/cmd/flux/create_source_oci.go
@@ -65,6 +65,7 @@ type sourceOCIRepositoryFlags struct {
 	semver           string
 	digest           string
 	secretRef        string
+	proxySecretRef   string
 	serviceAccount   string
 	certSecretRef    string
 	verifyProvider   flags.SourceOCIVerifyProvider
@@ -91,6 +92,7 @@ func init() {
 	createSourceOCIRepositoryCmd.Flags().StringVar(&sourceOCIRepositoryArgs.semver, "tag-semver", "", "the OCI artifact tag semver range")
 	createSourceOCIRepositoryCmd.Flags().StringVar(&sourceOCIRepositoryArgs.digest, "digest", "", "the OCI artifact digest")
 	createSourceOCIRepositoryCmd.Flags().StringVar(&sourceOCIRepositoryArgs.secretRef, "secret-ref", "", "the name of the Kubernetes image pull secret (type 'kubernetes.io/dockerconfigjson')")
+	createSourceOCIRepositoryCmd.Flags().StringVar(&sourceOCIRepositoryArgs.proxySecretRef, "proxy-secret-ref", "", "the name of an existing secret containing the proxy address and credentials")
 	createSourceOCIRepositoryCmd.Flags().StringVar(&sourceOCIRepositoryArgs.serviceAccount, "service-account", "", "the name of the Kubernetes service account that refers to an image pull secret")
 	createSourceOCIRepositoryCmd.Flags().StringVar(&sourceOCIRepositoryArgs.certSecretRef, "cert-ref", "", "the name of a secret to use for TLS certificates")
 	createSourceOCIRepositoryCmd.Flags().Var(&sourceOCIRepositoryArgs.verifyProvider, "verify-provider", sourceOCIRepositoryArgs.verifyProvider.Description())
@@ -163,6 +165,12 @@ func createSourceOCIRepositoryCmdRun(cmd *cobra.Command, args []string) error {
 
 	if secretName := sourceOCIRepositoryArgs.secretRef; secretName != "" {
 		repository.Spec.SecretRef = &meta.LocalObjectReference{
+			Name: secretName,
+		}
+	}
+
+	if secretName := sourceOCIRepositoryArgs.proxySecretRef; secretName != "" {
+		repository.Spec.ProxySecretRef = &meta.LocalObjectReference{
 			Name: secretName,
 		}
 	}


### PR DESCRIPTION
Add the `--proxy-secret-ref` flag to:
- `flux create source bucket`
-  `flux create source git`
-  `flux create source oci`

Part of: #4947 