### PR TITLE
Add environment variable flag to CLI in order to respect kubeconfig namespace

### DIFF
--- a/cmd/flux/main.go
+++ b/cmd/flux/main.go
@@ -205,6 +205,23 @@ func main() {
 
 func configureDefaultNamespace() {
 	*kubeconfigArgs.Namespace = rootArgs.defaults.Namespace
+
+	if _, has := os.LookupEnv("FLUX_NS_FOLLOW_KUBECONTEXT"); has {
+		rawCfg, err := kubeconfigArgs.ToRawKubeConfigLoader().RawConfig()
+		if err != nil {
+			logger.Warningf(" failed parsing kubeconfig: %s", err)
+		} else {
+			ctx := *kubeconfigArgs.Context
+			if ctx == "" {
+				ctx = rawCfg.CurrentContext
+			}
+			ns := rawCfg.Contexts[ctx].Namespace
+			if ns != "" {
+				kubeconfigArgs.Namespace = &ns
+			}
+		}
+	}
+
 	fromEnv := os.Getenv("FLUX_SYSTEM_NAMESPACE")
 	if fromEnv != "" {
 		// namespace must be a valid DNS label. Assess against validation


### PR DESCRIPTION
This PR is a follow-up from the following issue: https://github.com/fluxcd/flux2/issues/3453

Since this is my first contribution, I probably need some help in order to get this merged.

For example: Where should I add documentation?  
For the already existing flag `FLUX_SYSTEM_NAMESPACE` I didn't found any reference in the repository. 