### PR TITLE
fix: skip remote Kustomizations on recursive diff

### DIFF
--- a/internal/build/diff.go
+++ b/internal/build/diff.go
@@ -146,14 +146,18 @@ func (b *Builder) diff() (string, bool, error) {
 			}
 
 			if !kustomizationsEqual(k, b.kustomization) {
-				subOutput, subCreatedOrDrifted, err := b.kustomizationDiff(k)
-				if err != nil {
-					diffErrs = append(diffErrs, err)
-				}
-				if subCreatedOrDrifted {
-					createdOrDrifted = true
-					output.WriteString(bunt.Sprint(fmt.Sprintf("📁 %s changed\n", ssautil.FmtUnstructured(obj))))
-					output.WriteString(subOutput)
+				if k.Spec.KubeConfig != nil {
+					output.WriteString(writeString(fmt.Sprintf("⚠️ %s skipped: diff not supported for remote clusters\n", ssautil.FmtUnstructured(obj)), bunt.Orange))
+				} else {
+					subOutput, subCreatedOrDrifted, err := b.kustomizationDiff(k)
+					if err != nil {
+						diffErrs = append(diffErrs, err)
+					}
+					if subCreatedOrDrifted {
+						createdOrDrifted = true
+						output.WriteString(bunt.Sprint(fmt.Sprintf("📁 %s changed\n", ssautil.FmtUnstructured(obj))))
+						output.WriteString(subOutput)
+					}
 				}
 
 				// finished with Kustomization diff


### PR DESCRIPTION
When recursively diffing Kustomization objects on a cluster, each Kustomization is built and then a server-side dry-run apply is performed. This isn't practical to perform if the Kustomization references a remote cluster via `kubeConfig.secretRef`.

Currently, because it's not skipped, it's treated as though it's being applied to the context cluster, not the remote cluster, which results in an incorrect diff.

Instead, write out special message / warnings indicating that it has been skipped:
```
► Kustomization/my-ns/my-kst skipped: diff not supported for remote clusters
```

See also:
 * https://github.com/fluxcd/flux2/discussions/5065