### PR TITLE
Add OpenShift 4.16 & 4.17 to conformance testing

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -169,7 +169,7 @@ jobs:
     strategy:
       matrix:
         # Keep this list up-to-date with https://endoflife.date/red-hat-openshift
-        OPENSHIFT_VERSION: [ 4.15.0-okd ]
+        OPENSHIFT_VERSION: [ 4.15.0-okd, 4.16.0-okd, 4.17.0-okd ]
       fail-fast: false
     steps:
       - name: Checkout


### PR DESCRIPTION
OpenShift 4.16 & 4.17 are also now available to add to the existing conformance testing.
See https://github.com/fluxcd/flux2/pull/4729#issuecomment-2578138218