### PR TITLE
Improve "flux resume" error message on non-existent object

### DIFF
--- a/cmd/flux/resume.go
+++ b/cmd/flux/resume.go
@@ -151,6 +151,11 @@ func (resume *resumeCommand) getPatchedResumables(ctx context.Context, args []st
 		}
 		processed[arg] = struct{}{}
 
+		if resume.list.len() == 0 {
+			logger.Failuref("%s object '%s' not found in %s namespace", resume.kind, arg, resume.namespace)
+			continue
+		}
+
 		objs, err := resume.patch(ctx, []client.ListOption{
 			client.InNamespace(resume.namespace),
 			client.MatchingFields{
@@ -172,11 +177,6 @@ func (resume *resumeCommand) getPatchedResumables(ctx context.Context, args []st
 func (resume resumeCommand) patch(ctx context.Context, listOpts []client.ListOption) ([]resumable, error) {
 	if err := resume.client.List(ctx, resume.list.asClientList(), listOpts...); err != nil {
 		return nil, err
-	}
-
-	if resume.list.len() == 0 {
-		logger.Failuref("no %s objects found in %s namespace", resume.kind, resume.namespace)
-		return nil, nil
 	}
 
 	var resumables []resumable

--- a/cmd/flux/resume.go
+++ b/cmd/flux/resume.go
@@ -175,7 +175,11 @@ func (resume resumeCommand) patch(ctx context.Context, args []string, listOpts [
 	}
 
 	if resume.list.len() == 0 {
-		logger.Failuref("%s object '%s' not found in %s namespace", resume.kind, args[0], resume.namespace)
+		if len(args) < 1 {
+			logger.Failuref("no %s objects found in %s namespace", resume.kind, resume.namespace)
+		} else {
+			logger.Failuref("%s object '%s' not found in %s namespace", resume.kind, args[0], resume.namespace)
+		}
 		return nil, nil
 	}
 

--- a/cmd/flux/testdata/kustomization/resume_kustomization_from_git_multiple_args_wait.golden
+++ b/cmd/flux/testdata/kustomization/resume_kustomization_from_git_multiple_args_wait.golden
@@ -1,6 +1,6 @@
 ► resuming kustomization tkfg in {{ .ns }} namespace
 ✔ kustomization resumed
-✗ no Kustomization objects found in {{ .ns }} namespace
+✗ Kustomization object 'tkfg' not found in {{ .ns }} namespace
 ◎ waiting for Kustomization reconciliation
 ✔ Kustomization tkfg reconciliation completed
 ✔ applied revision 6.3.5@sha1:67e2c98a60dc92283531412a9e604dd4bae005a9


### PR DESCRIPTION
Currently, doing a resume operation on non-existent objects, e.g.

`flux resume helmrelease foo bar baz`

results in the error:

```
✗ no HelmRelease objects found in flux-system namespace
✗ no HelmRelease objects found in flux-system namespace
✗ no HelmRelease objects found in flux-system namespace
```
This message could be more helpful. Additionally, when resuming only a single resource, the error message is slightly misleading as there might exist `HelmRelease` objects, just not the ones your provided.

With this PR, the output would become:

```
✗ HelmRelease object 'foo' not found in flux-system namespace
✗ HelmRelease object 'bar' not found in flux-system namespace
✗ HelmRelease object 'baz' not found in flux-system namespace
```

This error message is more descriptive and follows the same format as the one in `cmd/flux/get.go:187`.
