### PR TITLE
fix: align `flux diff` skipping with kustomize-controller

### DIFF
--- a/internal/build/diff.go
+++ b/internal/build/diff.go
@@ -100,6 +100,10 @@ func (b *Builder) diff() (string, bool, error) {
 		diffOptions := ssa.DiffOptions{
 			Exclusions: map[string]string{
 				"kustomize.toolkit.fluxcd.io/reconcile": "disabled",
+				"kustomize.toolkit.fluxcd.io/ssa":       "ignore",
+			},
+			IfNotPresentSelector: map[string]string{
+				"kustomize.toolkit.fluxcd.io/ssa": "ifnotpresent",
 			},
 		}
 		change, liveObject, mergedObject, err := resourceManager.Diff(ctx, obj, diffOptions)


### PR DESCRIPTION
Fixes: https://github.com/fluxcd/flux2/issues/5163

Following https://github.com/fluxcd/pkg/pull/862