### PR TITLE
fix: allow recursive dry-run over local sources

### DIFF
--- a/cmd/flux/build_kustomization_test.go
+++ b/cmd/flux/build_kustomization_test.go
@@ -169,6 +169,12 @@ spec:
 			resultFile: "./testdata/build-kustomization/podinfo-with-my-app-result.yaml",
 			assertFunc: "assertGoldenTemplateFile",
 		},
+		{
+			name:       "build with recursive in dry-run mode",
+			args:       "build kustomization podinfo --kustomization-file " + tmpFile + " --path ./testdata/build-kustomization/podinfo-with-my-app --recursive --local-sources GitRepository/default/podinfo=./testdata/build-kustomization --dry-run",
+			resultFile: "./testdata/build-kustomization/podinfo-with-my-app-result.yaml",
+			assertFunc: "assertGoldenTemplateFile",
+		},
 	}
 
 	tmpl := map[string]string{


### PR DESCRIPTION
This PR tries to fix the issue using `flux build` with dry-run and recursion.

We have a setup with nested kustomizations and want to render the whole tree 
as yaml files, including `postBuild` substitutions. Afterwards, this should be
checked via kube-linter.

Currently this seems not possible(?) with the flux-cli together with dry-run, 
therefore I made some changes.
Since I don't know all the use cases for `flux build`, it is hard to tell if this
breaks anything.

Maybe someone with deeper knowledge can review the changes.

The command I use is similar to this:

    flux build kustomization flux-system \
    --recursive \
    --path ./clusters/dev/mykustomizations \
    -n flux-system \
    --local-sources GitRepository/flux-system/flux-system=./ \
    --dry-run \
    --kustomization-file ./clusters/dev/flux-system/gotk-sync.yaml
