### PR TITLE
ci: sw to goreleaser changlog gen

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,23 +66,12 @@ jobs:
       - name: Archive the OpenAPI JSON schemas
         run: |
           tar -czvf ./output/crd-schemas.tar.gz -C schemas .
-      - name: Download release notes utility
-        env:
-          GH_REL_URL: https://github.com/buchanae/github-release-notes/releases/download/0.2.0/github-release-notes-linux-amd64-0.2.0.tar.gz
-        run: cd /tmp && curl -sSL ${GH_REL_URL} | tar xz && sudo mv github-release-notes /usr/local/bin/
-      - name: Generate release notes
-        run: |
-          NOTES="./output/notes.md"
-          echo '## CLI Changelog' > ${NOTES}
-          github-release-notes -org fluxcd -repo flux2 -since-latest-release -include-author >> ${NOTES}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run GoReleaser
         id: run-goreleaser
         uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf # v6.1.0
         with:
           version: latest
-          args: release --release-notes=output/notes.md --skip=validate
+          args: release --skip=validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,6 @@
 project_name: flux
+changelog:
+  use: github-native
 builds:
   - <<: &build_defaults
       binary: flux


### PR DESCRIPTION
Closing #5283 to switch to GoReleaser Changelog generation and rm depricated github-release-notes generation.