### PR TITLE
add: OSSF scorecard configuration file - ignore false-positive

### DIFF
--- a/.scorecard.yml
+++ b/.scorecard.yml
@@ -1,0 +1,5 @@
+annotations:
+  - checks:
+      - dangerous-workflow
+    reasons:
+      - reason: not-applicable # This workflow does not run untrusted code, the bot will only backport a code if the a PR was approved and merged into main.


### PR DESCRIPTION
According to the [docs](https://github.com/ossf/scorecard/tree/main/config), we should be able to put in place annotations about why the check should be ignored. Unfortunately, I failed to confirm this with a local run - maybe it will work fine when it runs for a real repository.
closes #5257 