### PR TITLE
Add an en var to use the namespace declared in the kubeconfig context

### DIFF
--- a/cmd/flux/main.go
+++ b/cmd/flux/main.go
@@ -206,19 +206,7 @@ func main() {
 func configureDefaultNamespace() {
 	*kubeconfigArgs.Namespace = rootArgs.defaults.Namespace
 
-	// First check if we should use the namespace from the current context
-	if os.Getenv("FLUX_SYSTEM_NAMESPACE_FROM_CONTEXT") == "true" {
-		// Get the current context's namespace from kubeconfig
-		config, err := kubeconfigArgs.ToRawKubeConfigLoader().RawConfig()
-		if err == nil {
-			if ctx, exists := config.Contexts[config.CurrentContext]; exists && ctx.Namespace != "" {
-				kubeconfigArgs.Namespace = &ctx.Namespace
-				return
-			}
-		}
-	}
-
-	// Fall back to environment variable if set
+	// First the FLUX_SYSTEM_NAMESPACE environment variable
 	fromEnv := os.Getenv("FLUX_SYSTEM_NAMESPACE")
 	if fromEnv != "" {
 		// namespace must be a valid DNS label. Assess against validation
@@ -228,8 +216,20 @@ func configureDefaultNamespace() {
 			logger.Warningf(" ignoring invalid FLUX_SYSTEM_NAMESPACE: %q", fromEnv)
 			return
 		}
-
 		kubeconfigArgs.Namespace = &fromEnv
+		return
+	}
+
+	// If no environment variable, check if we should use the namespace from the current context
+	if os.Getenv("FLUX_SYSTEM_NAMESPACE_FROM_CONTEXT") == "true" {
+		// Get the current context's namespace from kubeconfig
+		config, err := kubeconfigArgs.ToRawKubeConfigLoader().RawConfig()
+		if err == nil {
+			if ctx, exists := config.Contexts[config.CurrentContext]; exists && ctx.Namespace != "" {
+				kubeconfigArgs.Namespace = &ctx.Namespace
+				return
+			}
+		}
 	}
 }
 

--- a/cmd/flux/main.go
+++ b/cmd/flux/main.go
@@ -205,6 +205,20 @@ func main() {
 
 func configureDefaultNamespace() {
 	*kubeconfigArgs.Namespace = rootArgs.defaults.Namespace
+
+	// First check if we should use the namespace from the current context
+	if os.Getenv("FLUX_SYSTEM_NAMESPACE_FROM_CONTEXT") == "true" {
+		// Get the current context's namespace from kubeconfig
+		config, err := kubeconfigArgs.ToRawKubeConfigLoader().RawConfig()
+		if err == nil {
+			if ctx, exists := config.Contexts[config.CurrentContext]; exists && ctx.Namespace != "" {
+				kubeconfigArgs.Namespace = &ctx.Namespace
+				return
+			}
+		}
+	}
+
+	// Fall back to environment variable if set
 	fromEnv := os.Getenv("FLUX_SYSTEM_NAMESPACE")
 	if fromEnv != "" {
 		// namespace must be a valid DNS label. Assess against validation


### PR DESCRIPTION
Allow for `flux` to work seamlessly with tools like `kubens` to avoid having to specify `-n`.

Adds `FLUX_SYSTEM_NAMESPACE_FROM_CONTEXT=true` as suggested in https://github.com/fluxcd/flux2/discussions/2768 to avoid any breaking changes.