### PR TITLE
[RFC-0010] Add RBAC for creating service account tokens

### DIFF
--- a/manifests/rbac/controller.yaml
+++ b/manifests/rbac/controller.yaml
@@ -69,6 +69,13 @@ rules:
   - update
   - patch
   - delete
+# required for object-level workload identity
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
 # required for flow control
 - nonResourceURLs:
   - /livez/ping


### PR DESCRIPTION
Part of: #5022

All the six controllers will eventually implement object-level workload identity so this should be fine.