### PR TITLE
Fix exit code handling in get command

### DIFF
--- a/cmd/flux/get.go
+++ b/cmd/flux/get.go
@@ -184,13 +184,13 @@ func (get getCommand) run(cmd *cobra.Command, args []string) error {
 
 	if get.list.len() == 0 {
 		if len(args) > 0 {
-			logger.Failuref("%s object '%s' not found in %s namespace",
+			return fmt.Errorf("%s object '%s' not found in %s namespace",
 				get.kind,
 				args[0],
 				namespaceNameOrAny(getArgs.allNamespaces, *kubeconfigArgs.Namespace),
 			)
 		} else if !getAll {
-			logger.Failuref("no %s objects found in %s namespace",
+			return fmt.Errorf("no %s objects found in %s namespace",
 				get.kind,
 				namespaceNameOrAny(getArgs.allNamespaces, *kubeconfigArgs.Namespace),
 			)


### PR DESCRIPTION
## What this PR does

Fixes #5330 - Changes the error handling in the `get` command to properly return non-zero exit codes when resources are not found, instead of just logging errors.

## How I tested it

I tested both the original and modified behaviour with the following test script (I compiled before to compare to the version in .bin/flux):

```
#!/bin/bash

echo "Test 1: Specific object not found - original flux command (should return 0 exit code)"
flux get kustomization non-existent-resource
echo "Exit code: $?"

echo -e "\nTest 2: No objects found in namespace - original flux command (should return 0 exit code)"
flux get helmrelease -n kube-system
echo "Exit code: $?"

echo -e "\nTest 3: Specific object not found - modified ./bin/flux command (should return 1 exit code)"
./bin/flux get kustomization non-existent-resource
echo "Exit code: $?"

echo -e "\nTest 4: No objects found in namespace - modified ./bin/flux command (should return 1 exit code)"
./bin/flux get helmrelease -n kube-system 
echo "Exit code: $?"
```

## Output

```
Test 1: Specific object not found - original flux command (should return 0 exit code)
✗ Kustomization object 'non-existent-resource' not found in "flux-system" namespace
Exit code: 0

Test 2: No objects found in namespace - original flux command (should return 0 exit code)
✗ no HelmRelease objects found in "kube-system" namespace
Exit code: 0

Test 3: Specific object not found - modified ./bin/flux command (should return 1 exit code)
✗ Kustomization object 'non-existent-resource' not found in "flux-system" namespace
Exit code: 1

Test 4: No objects found in namespace - modified ./bin/flux command (should return 1 exit code)
✗ no HelmRelease objects found in "kube-system" namespace
Exit code: 1
```