### PR TITLE
Fix e2e workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -247,7 +247,7 @@ jobs:
       - name: Debug failure
         if: failure()
         run: |
-          kubectl version --client --short
+          kubectl version --client
           kubectl -n flux-system get all
           kubectl -n flux-system describe pods
           kubectl -n flux-system get kustomizations -oyaml


### PR DESCRIPTION
The `--short` flag has been [removed from kubectl with 1.28.0](https://github.com/kubernetes/kubernetes/blob/49945dbfab342a6d7dee7e83778bb1cc3886bdbe/CHANGELOG/CHANGELOG-1.28.md#deprecation).
