### PR TITLE
Add backport label for `v2.6.x`

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -44,12 +44,12 @@
   description: Feature request proposals in the RFC format
   color: '#D621C3'
   aliases: ['area/RFC']
-- name: backport:release/v2.3.x
-  description: To be backported to release/v2.3.x
-  color: '#ffd700'
 - name: backport:release/v2.4.x
   description: To be backported to release/v2.4.x
   color: '#ffd700'
 - name: backport:release/v2.5.x
   description: To be backported to release/v2.5.x
+  color: '#ffd700'
+- name: backport:release/v2.6.x
+  description: To be backported to release/v2.6.x
   color: '#ffd700'


### PR DESCRIPTION
ref: #5363