### PR TITLE
Make service-account name configurable in `flux create tenant`

### DIFF
--- a/cmd/flux/create_tenant.go
+++ b/cmd/flux/create_tenant.go
@@ -293,9 +293,9 @@ func exportTenant(namespace corev1.Namespace, account corev1.ServiceAccount, rol
 		return err
 	}
 
-	fmt.Println("---")
+	rootCmd.Println("---")
 	data = bytes.Replace(data, []byte("spec: {}\n"), []byte(""), 1)
-	fmt.Println(resourceToString(data))
+	rootCmd.Println(resourceToString(data))
 
 	account.TypeMeta = metav1.TypeMeta{
 		APIVersion: "v1",
@@ -306,9 +306,9 @@ func exportTenant(namespace corev1.Namespace, account corev1.ServiceAccount, rol
 		return err
 	}
 
-	fmt.Println("---")
+	rootCmd.Println("---")
 	data = bytes.Replace(data, []byte("spec: {}\n"), []byte(""), 1)
-	fmt.Println(resourceToString(data))
+	rootCmd.Println(resourceToString(data))
 
 	roleBinding.TypeMeta = metav1.TypeMeta{
 		APIVersion: "rbac.authorization.k8s.io/v1",
@@ -319,8 +319,8 @@ func exportTenant(namespace corev1.Namespace, account corev1.ServiceAccount, rol
 		return err
 	}
 
-	fmt.Println("---")
-	fmt.Println(resourceToString(data))
+	rootCmd.Println("---")
+	rootCmd.Println(resourceToString(data))
 
 	return nil
 }

--- a/cmd/flux/create_tenant_test.go
+++ b/cmd/flux/create_tenant_test.go
@@ -1,0 +1,68 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2025 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+)
+
+func TestCreateTenant(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   string
+		assert assertFunc
+	}{
+		{
+			name:   "no args",
+			args:   "create tenant",
+			assert: assertError("name is required"),
+		},
+		{
+			name:   "no namespace",
+			args:   "create tenant dev-team --cluster-role=cluster-admin",
+			assert: assertError("with-namespace is required"),
+		},
+		{
+			name:   "basic tenant",
+			args:   "create tenant dev-team --with-namespace=apps --cluster-role=cluster-admin --export",
+			assert: assertGoldenFile("./testdata/create_tenant/tenant-basic.yaml"),
+		},
+		{
+			name:   "tenant with custom serviceaccount",
+			args:   "create tenant dev-team --with-namespace=apps --cluster-role=cluster-admin --with-service-account=flux-tenant --export",
+			assert: assertGoldenFile("./testdata/create_tenant/tenant-with-service-account.yaml"),
+		},
+		{
+			name:   "tenant with custom cluster role",
+			args:   "create tenant dev-team --with-namespace=apps --cluster-role=custom-role --export",
+			assert: assertGoldenFile("./testdata/create_tenant/tenant-with-cluster-role.yaml"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := cmdTestCase{
+				args:   tt.args,
+				assert: tt.assert,
+			}
+			cmd.runTestCmd(t)
+		})
+	}
+}

--- a/cmd/flux/testdata/create_tenant/tenant-basic.yaml
+++ b/cmd/flux/testdata/create_tenant/tenant-basic.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    toolkit.fluxcd.io/tenant: dev-team
+  name: apps
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    toolkit.fluxcd.io/tenant: dev-team
+  name: dev-team
+  namespace: apps
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    toolkit.fluxcd.io/tenant: dev-team
+  name: dev-team-reconciler
+  namespace: apps
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: gotk:apps:reconciler
+- kind: ServiceAccount
+  name: dev-team
+  namespace: apps

--- a/cmd/flux/testdata/create_tenant/tenant-with-cluster-role.yaml
+++ b/cmd/flux/testdata/create_tenant/tenant-with-cluster-role.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    toolkit.fluxcd.io/tenant: dev-team
+  name: apps
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    toolkit.fluxcd.io/tenant: dev-team
+  name: dev-team
+  namespace: apps
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    toolkit.fluxcd.io/tenant: dev-team
+  name: dev-team-reconciler
+  namespace: apps
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: custom-role
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: gotk:apps:reconciler
+- kind: ServiceAccount
+  name: dev-team
+  namespace: apps

--- a/cmd/flux/testdata/create_tenant/tenant-with-service-account.yaml
+++ b/cmd/flux/testdata/create_tenant/tenant-with-service-account.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    toolkit.fluxcd.io/tenant: dev-team
+  name: apps
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    toolkit.fluxcd.io/tenant: dev-team
+  name: flux-tenant
+  namespace: apps
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    toolkit.fluxcd.io/tenant: dev-team
+  name: dev-team-reconciler
+  namespace: apps
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: gotk:apps:reconciler
+- kind: ServiceAccount
+  name: flux-tenant
+  namespace: apps


### PR DESCRIPTION
This PR adds an optional cli flag `--with-service-account` to the `flux create tenant` command. The flag allows to configure the name of the ServiceAccount, which is created by the cli command.

If the flag is not given, the current default is used (tenant name).

Closes #5400
