### PR TITLE
fix(events): respect `--all-namespaces` flag

### DIFF
--- a/cmd/flux/events.go
+++ b/cmd/flux/events.go
@@ -112,7 +112,12 @@ func eventsCmdRun(cmd *cobra.Command, args []string) error {
 	}
 
 	var diffRefNs bool
-	clientListOpts := []client.ListOption{client.InNamespace(*kubeconfigArgs.Namespace)}
+	// Build the base list options. When --all-namespaces is set we must NOT constrain the
+	// query to a single namespace, otherwise we silently return a partial result set.
+	clientListOpts := []client.ListOption{}
+	if !eventArgs.allNamespaces {
+		clientListOpts = append(clientListOpts, client.InNamespace(*kubeconfigArgs.Namespace))
+	}
 	var refListOpts [][]client.ListOption
 	if eventArgs.forSelector != "" {
 		kind, name := getKindNameFromSelector(eventArgs.forSelector)


### PR DESCRIPTION
The `flux events` command always applied a namespace filter, even when `--all-namespaces` was set.  
This produced incomplete results and confused users expecting cluster-wide events.

Changes made:
* Build `clientListOpts` dynamically.
* Omit `client.InNamespace(...)` when `eventArgs.allNamespaces` is true, ensuring no namespace constraint.

Impact:
`flux events --all-namespaces` now returns events from every namespace, restoring expected functionality without affecting other options.