### PR TITLE
refactor: cleanup GetArtifactRegistryCredentials error handling

### DIFF
--- a/cmd/flux/oci.go
+++ b/cmd/flux/oci.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/google/go-containerregistry/pkg/crane"
@@ -37,9 +36,6 @@ func loginWithProvider(ctx context.Context, url, provider string) (crane.Option,
 	authenticator, err := authutils.GetArtifactRegistryCredentials(ctx, provider, url, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("could not login to provider %s with url %s: %w", provider, url, err)
-	}
-	if authenticator == nil {
-		return nil, errors.New("unsupported provider")
 	}
 	return crane.WithAuth(authenticator), nil
 }

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/fluxcd/notification-controller/api v1.6.0
 	github.com/fluxcd/pkg/apis/event v0.17.0
 	github.com/fluxcd/pkg/apis/meta v1.12.0
-	github.com/fluxcd/pkg/auth v0.17.0
+	github.com/fluxcd/pkg/auth v0.18.0
 	github.com/fluxcd/pkg/chartutil v1.3.0
 	github.com/fluxcd/pkg/envsubst v1.4.0
 	github.com/fluxcd/pkg/git v0.32.0

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,8 @@ github.com/fluxcd/pkg/apis/kustomize v1.10.0 h1:47EeSzkQvlQZdH92vHMe2lK2iR8aOSEJ
 github.com/fluxcd/pkg/apis/kustomize v1.10.0/go.mod h1:UsqMV4sqNa1Yg0pmTsdkHRJr7bafBOENIJoAN+3ezaQ=
 github.com/fluxcd/pkg/apis/meta v1.12.0 h1:XW15TKZieC2b7MN8VS85stqZJOx+/b8jATQ/xTUhVYg=
 github.com/fluxcd/pkg/apis/meta v1.12.0/go.mod h1:+son1Va60x2eiDcTwd7lcctbI6C+K3gM7R+ULmEq1SI=
-github.com/fluxcd/pkg/auth v0.17.0 h1:jgum55f5K7Db6yI2bi4WeKojTzQS9KxlHCC0CsFs5x8=
-github.com/fluxcd/pkg/auth v0.17.0/go.mod h1:4h6s8VBNuec3tWd4xIReLw8BYPOKaIegjNMEbA4ikTU=
+github.com/fluxcd/pkg/auth v0.18.0 h1:71pGdKe0PVKWQvM3hEuyd3FD9dEUHtMuKMbUeiMl4aA=
+github.com/fluxcd/pkg/auth v0.18.0/go.mod h1:4h6s8VBNuec3tWd4xIReLw8BYPOKaIegjNMEbA4ikTU=
 github.com/fluxcd/pkg/cache v0.9.0 h1:EGKfOLMG3fOwWnH/4Axl5xd425mxoQbZzlZoLfd8PDk=
 github.com/fluxcd/pkg/cache v0.9.0/go.mod h1:jMwabjWfsC5lW8hE7NM3wtGNwSJ38Javx6EKbEi7INU=
 github.com/fluxcd/pkg/chartutil v1.3.0 h1:Zoc+AIyKL4YU4PaLL/iGv9VRLujeWT2Mvj4BLGFGKlg=


### PR DESCRIPTION
## Summary

This PR updates the error handling for `GetArtifactRegistryCredentials()` following the improvements in fluxcd/pkg/auth v0.18.0.

As mentioned in https://github.com/fluxcd/image-reflector-controller/pull/786#issuecomment-2993234261, this removes unnecessary nil checks
as the function now returns errors directly for unsupported providers.

## Changes

- Update fluxcd/pkg/auth to v0.18.0
- Replace authentication code in push_artifact.go with `loginWithProvider()`
- Remove unnecessary authenticator nil check in oci.go

## Related

- Implements cleanup mentioned in fluxcd/image-reflector-controller#786
- Part of the broader effort to simplify error handling after fluxcd/pkg#946
