### PR TITLE
manifests: Add `app.kubernetes.io/part-of: flux` label to controller pods

### DIFF
--- a/manifests/bases/helm-controller/labels.yaml
+++ b/manifests/bases/helm-controller/labels.yaml
@@ -8,3 +8,6 @@ labels:
 fieldSpecs:
   - path: metadata/labels
     create: true
+  - kind: Deployment
+    path: spec/template/metadata/labels
+    create: true

--- a/manifests/bases/image-automation-controller/labels.yaml
+++ b/manifests/bases/image-automation-controller/labels.yaml
@@ -8,3 +8,6 @@ labels:
 fieldSpecs:
   - path: metadata/labels
     create: true
+  - kind: Deployment
+    path: spec/template/metadata/labels
+    create: true

--- a/manifests/bases/image-reflector-controller/labels.yaml
+++ b/manifests/bases/image-reflector-controller/labels.yaml
@@ -8,3 +8,6 @@ labels:
 fieldSpecs:
   - path: metadata/labels
     create: true
+  - kind: Deployment
+    path: spec/template/metadata/labels
+    create: true

--- a/manifests/bases/kustomize-controller/labels.yaml
+++ b/manifests/bases/kustomize-controller/labels.yaml
@@ -8,3 +8,6 @@ labels:
 fieldSpecs:
   - path: metadata/labels
     create: true
+  - kind: Deployment
+    path: spec/template/metadata/labels
+    create: true

--- a/manifests/bases/notification-controller/labels.yaml
+++ b/manifests/bases/notification-controller/labels.yaml
@@ -8,3 +8,6 @@ labels:
 fieldSpecs:
   - path: metadata/labels
     create: true
+  - kind: Deployment
+    path: spec/template/metadata/labels
+    create: true

--- a/manifests/bases/source-controller/labels.yaml
+++ b/manifests/bases/source-controller/labels.yaml
@@ -8,3 +8,6 @@ labels:
 fieldSpecs:
   - path: metadata/labels
     create: true
+  - kind: Deployment
+    path: spec/template/metadata/labels
+    create: true

--- a/manifests/install/labels.yaml
+++ b/manifests/install/labels.yaml
@@ -8,3 +8,6 @@ labels:
 fieldSpecs:
   - path: metadata/labels
     create: true
+  - kind: Deployment
+    path: spec/template/metadata/labels
+    create: true

--- a/manifests/openshift/labels.yaml
+++ b/manifests/openshift/labels.yaml
@@ -8,3 +8,6 @@ labels:
 fieldSpecs:
   - path: metadata/labels
     create: true
+  - kind: Deployment
+    path: spec/template/metadata/labels
+    create: true

--- a/pkg/manifestgen/install/templates.go
+++ b/pkg/manifestgen/install/templates.go
@@ -156,6 +156,9 @@ labels:
 fieldSpecs:
   - path: metadata/labels
     create: true
+  - kind: Deployment
+    path: spec/template/metadata/labels
+    create: true
 `
 
 var namespaceTmpl = `---


### PR DESCRIPTION
Ensure also pods contain the relevant labels inherited from parent Deployment object, this makes it easier to select and filter the pods using the labels eg. when scraping for metrics.