### PR TITLE
Fix `flux push artifact` for insecure registries

### DIFF
--- a/cmd/flux/push_artifact.go
+++ b/cmd/flux/push_artifact.go
@@ -250,7 +250,13 @@ func pushArtifactCmdRun(cmd *cobra.Command, args []string) error {
 				return err
 			}
 		}
-		transportOpts, err := oci.WithRetryTransport(ctx, ref, authenticator, backoff, []string{ref.Context().Scope(transport.PushScope)})
+		transportOpts, err := oci.WithRetryTransport(ctx,
+			ref,
+			authenticator,
+			backoff,
+			[]string{ref.Context().Scope(transport.PushScope)},
+			pushArtifactArgs.insecure,
+		)
 		if err != nil {
 			return fmt.Errorf("error setting up transport: %w", err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/fluxcd/pkg/git v0.32.0
 	github.com/fluxcd/pkg/git/gogit v0.35.1
 	github.com/fluxcd/pkg/kustomize v1.18.0
-	github.com/fluxcd/pkg/oci v0.49.0
+	github.com/fluxcd/pkg/oci v0.50.0
 	github.com/fluxcd/pkg/runtime v0.60.0
 	github.com/fluxcd/pkg/sourceignore v0.12.0
 	github.com/fluxcd/pkg/ssa v0.49.0

--- a/go.sum
+++ b/go.sum
@@ -197,8 +197,8 @@ github.com/fluxcd/pkg/gittestserver v0.17.0 h1:JlBvWZQTDOI+np5Z+084m3DkeAH1hMusE
 github.com/fluxcd/pkg/gittestserver v0.17.0/go.mod h1:E/40EmLoXcMqd6gLuLDC9F6KJxqHVGbBBeMNKk5XdxU=
 github.com/fluxcd/pkg/kustomize v1.18.0 h1:wWK+qYwmBmba3N3VAqZ9ijnfVGGaIjcaHWo033URZTw=
 github.com/fluxcd/pkg/kustomize v1.18.0/go.mod h1:Ij9722MdWIE6B1EPg2ZJUf6npycgfRfN4Lohi7D/Kic=
-github.com/fluxcd/pkg/oci v0.49.0 h1:L8/dmNSIzqu6X8vzIkPLrW8NAF7Et/SnOuI8WJkXeq8=
-github.com/fluxcd/pkg/oci v0.49.0/go.mod h1:iZkF4bQTpc6YOU5IJWMBp0Q8voGm7bkMYiAarJ9407U=
+github.com/fluxcd/pkg/oci v0.50.0 h1:oEBfiv7SHi/wrKThov+QbwbzRnGepUAvKsBd4PdIQdY=
+github.com/fluxcd/pkg/oci v0.50.0/go.mod h1:iZkF4bQTpc6YOU5IJWMBp0Q8voGm7bkMYiAarJ9407U=
 github.com/fluxcd/pkg/runtime v0.60.0 h1:d++EkV3FlycB+bzakB5NumwY4J8xts8i7lbvD6jBLeU=
 github.com/fluxcd/pkg/runtime v0.60.0/go.mod h1:UeU0/eZLErYC/1bTmgzBfNXhiHy9fuQzjfLK0HxRgxY=
 github.com/fluxcd/pkg/sourceignore v0.12.0 h1:jCIe6d50rQ3wdXPF0+PhhqN0XrTRIq3upMomPelI8Mw=


### PR DESCRIPTION
Fix: #5448 