### PR TITLE
Run conformance tests for Kubernetes 1.34.0

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         # Keep this list up-to-date with https://endoflife.date/kubernetes
         # Build images with https://github.com/fluxcd/flux-benchmark/actions/workflows/build-kind.yaml
-        KUBERNETES_VERSION: [1.31.5, 1.32.1, 1.33.0]
+        KUBERNETES_VERSION: [1.31.5, 1.32.1, 1.33.0, 1.34.0]
       fail-fast: false
     steps:
       - name: Checkout


### PR DESCRIPTION
Part of: #5496

Using:
- `ghcr.io/fluxcd/kindest/node:v1.34.0-amd64`
- `ghcr.io/fluxcd/kindest/node:v1.34.0-arm64`