### PR TITLE
Allow the Go runtime to dynamically set `GOMAXPROCS`

### DIFF
--- a/manifests/bases/helm-controller/patch.yaml
+++ b/manifests/bases/helm-controller/patch.yaml
@@ -10,14 +10,6 @@
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
-    name: GOMAXPROCS
-    valueFrom:
-      resourceFieldRef:
-        containerName: manager
-        resource: limits.cpu
-- op: add
-  path: /spec/template/spec/containers/0/env/-
-  value:
     name: GOMEMLIMIT
     valueFrom:
       resourceFieldRef:

--- a/manifests/bases/image-automation-controller/patch.yaml
+++ b/manifests/bases/image-automation-controller/patch.yaml
@@ -7,14 +7,6 @@
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
-    name: GOMAXPROCS
-    valueFrom:
-      resourceFieldRef:
-        containerName: manager
-        resource: limits.cpu
-- op: add
-  path: /spec/template/spec/containers/0/env/-
-  value:
     name: GOMEMLIMIT
     valueFrom:
       resourceFieldRef:

--- a/manifests/bases/image-reflector-controller/patch.yaml
+++ b/manifests/bases/image-reflector-controller/patch.yaml
@@ -7,14 +7,6 @@
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
-    name: GOMAXPROCS
-    valueFrom:
-      resourceFieldRef:
-        containerName: manager
-        resource: limits.cpu
-- op: add
-  path: /spec/template/spec/containers/0/env/-
-  value:
     name: GOMEMLIMIT
     valueFrom:
       resourceFieldRef:

--- a/manifests/bases/kustomize-controller/patch.yaml
+++ b/manifests/bases/kustomize-controller/patch.yaml
@@ -10,14 +10,6 @@
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
-    name: GOMAXPROCS
-    valueFrom:
-      resourceFieldRef:
-        containerName: manager
-        resource: limits.cpu
-- op: add
-  path: /spec/template/spec/containers/0/env/-
-  value:
     name: GOMEMLIMIT
     valueFrom:
       resourceFieldRef:

--- a/manifests/bases/notification-controller/patch.yaml
+++ b/manifests/bases/notification-controller/patch.yaml
@@ -4,14 +4,6 @@
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
-    name: GOMAXPROCS
-    valueFrom:
-      resourceFieldRef:
-        containerName: manager
-        resource: limits.cpu
-- op: add
-  path: /spec/template/spec/containers/0/env/-
-  value:
     name: GOMEMLIMIT
     valueFrom:
       resourceFieldRef:

--- a/manifests/bases/source-controller/patch.yaml
+++ b/manifests/bases/source-controller/patch.yaml
@@ -10,14 +10,6 @@
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
-    name: GOMAXPROCS
-    valueFrom:
-      resourceFieldRef:
-        containerName: manager
-        resource: limits.cpu
-- op: add
-  path: /spec/template/spec/containers/0/env/-
-  value:
     name: GOMEMLIMIT
     valueFrom:
       resourceFieldRef:


### PR DESCRIPTION
Remove the `GOMAXPROCS` env var from all controllers to allow the Go 1.25 runtime to dynamically set it from the cgroup CPU limits.

xref: https://github.com/fluxcd/flux2/issues/5481 