### PR TITLE
ci: Set `GITHUB_TOKEN` in the `release-flux-manifests` workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -104,6 +104,8 @@ jobs:
         uses: fluxcd/pkg/actions/kustomize@bf02f0a2d612cc07e0892166369fa8f63246aabb # main
       - name: Setup Flux CLI
         uses: ./action/
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Prepare
         id: prep
         run: |


### PR DESCRIPTION
Turns out #5509 broke our release workflow, the public endpoint does not return the latest Flux release, instead it serves `latest` from cache, which will always be one version behind at release time. This PR switches back to using the GitHub API by passing the `GITHUB_TOKEN` to the action.

Closes: #5546