### PR TITLE
Fix `flux push artifact` not working with `--provider`

### DIFF
--- a/cmd/flux/diff_artifact.go
+++ b/cmd/flux/diff_artifact.go
@@ -93,7 +93,7 @@ func diffArtifactCmdRun(cmd *cobra.Command, args []string) error {
 
 	if diffArtifactArgs.provider.String() != sourcev1.GenericOCIProvider {
 		logger.Actionf("logging in to registry with provider credentials")
-		opt, err := loginWithProvider(ctx, url, diffArtifactArgs.provider.String())
+		opt, _, err := loginWithProvider(ctx, url, diffArtifactArgs.provider.String())
 		if err != nil {
 			return fmt.Errorf("error during login with provider: %w", err)
 		}

--- a/cmd/flux/list_artifact.go
+++ b/cmd/flux/list_artifact.go
@@ -52,7 +52,7 @@ var listArtifactsCmd = &cobra.Command{
 	Long: `The list command fetches the tags and their metadata from a remote OCI repository.
 The command can read the credentials from '~/.docker/config.json' but they can also be passed with --creds. It can also login to a supported provider with the --provider flag.`,
 	Example: `  # List the artifacts stored in an OCI repository
-  flux list artifact oci://ghcr.io/org/config/app
+  flux list artifacts oci://ghcr.io/org/config/app
 `,
 	RunE: listArtifactsCmdRun,
 }
@@ -85,7 +85,7 @@ func listArtifactsCmdRun(cmd *cobra.Command, args []string) error {
 
 	if listArtifactArgs.provider.String() != sourcev1.GenericOCIProvider {
 		logger.Actionf("logging in to registry with provider credentials")
-		ociOpt, err := loginWithProvider(ctx, url, listArtifactArgs.provider.String())
+		ociOpt, _, err := loginWithProvider(ctx, url, listArtifactArgs.provider.String())
 		if err != nil {
 			return fmt.Errorf("error during login with provider: %w", err)
 		}

--- a/cmd/flux/oci.go
+++ b/cmd/flux/oci.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/crane"
 
 	"github.com/fluxcd/pkg/auth"
@@ -28,14 +29,14 @@ import (
 )
 
 // loginWithProvider gets a crane authentication option for the given provider and URL.
-func loginWithProvider(ctx context.Context, url, provider string) (crane.Option, error) {
+func loginWithProvider(ctx context.Context, url, provider string) (crane.Option, authn.Authenticator, error) {
 	var opts []auth.Option
 	if provider == azure.ProviderName {
 		opts = append(opts, auth.WithAllowShellOut())
 	}
 	authenticator, err := authutils.GetArtifactRegistryCredentials(ctx, provider, url, opts...)
 	if err != nil {
-		return nil, fmt.Errorf("could not login to provider %s with url %s: %w", provider, url, err)
+		return nil, nil, fmt.Errorf("could not login to provider %s with url %s: %w", provider, url, err)
 	}
-	return crane.WithAuth(authenticator), nil
+	return crane.WithAuth(authenticator), authenticator, nil
 }

--- a/cmd/flux/pull_artifact.go
+++ b/cmd/flux/pull_artifact.go
@@ -94,7 +94,7 @@ func pullArtifactCmdRun(cmd *cobra.Command, args []string) error {
 
 	if pullArtifactArgs.provider.String() != sourcev1.GenericOCIProvider {
 		logger.Actionf("logging in to registry with provider credentials")
-		opt, err := loginWithProvider(ctx, url, pullArtifactArgs.provider.String())
+		opt, _, err := loginWithProvider(ctx, url, pullArtifactArgs.provider.String())
 		if err != nil {
 			return fmt.Errorf("error during login with provider: %w", err)
 		}

--- a/cmd/flux/push_artifact.go
+++ b/cmd/flux/push_artifact.go
@@ -225,11 +225,12 @@ func pushArtifactCmdRun(cmd *cobra.Command, args []string) error {
 
 	if provider := pushArtifactArgs.provider.String(); provider != sourcev1.GenericOCIProvider {
 		logger.Actionf("logging in to registry with provider credentials")
-		authOpt, err := loginWithProvider(ctx, url, provider)
+		var opt crane.Option
+		opt, authenticator, err = loginWithProvider(ctx, url, provider)
 		if err != nil {
 			return fmt.Errorf("error during login with provider: %w", err)
 		}
-		opts = append(opts, authOpt)
+		opts = append(opts, opt)
 	}
 
 	if rootArgs.timeout != 0 {

--- a/cmd/flux/tag_artifact.go
+++ b/cmd/flux/tag_artifact.go
@@ -82,7 +82,7 @@ func tagArtifactCmdRun(cmd *cobra.Command, args []string) error {
 
 	if tagArtifactArgs.provider.String() != sourcev1.GenericOCIProvider {
 		logger.Actionf("logging in to registry with provider credentials")
-		opt, err := loginWithProvider(ctx, url, tagArtifactArgs.provider.String())
+		opt, _, err := loginWithProvider(ctx, url, tagArtifactArgs.provider.String())
 		if err != nil {
 			return fmt.Errorf("error during login with provider: %w", err)
 		}


### PR DESCRIPTION
Fixes: #5549

While this fix is not released in Flux 2.7.1 (to happen soon), users can use the workarounds described below.

All the workarounds below are based on generating a docker config that `flux push artifact` will detect automatically, in which case the `--provider` flag is not needed. They are standard docker login procedures for the cloud providers, the same procedures you use for pushing app images to container registries. Flux OCI artifacts work seamlessly with these procedures.

## Amazon ECR (alternative for `--provider=aws`)

For GitHub Actions, follow instructions [here](https://github.com/aws-actions/amazon-ecr-login?tab=readme-ov-file#building-and-pushing-an-image). Example:

```yaml
- name: Configure AWS credentials
  uses: aws-actions/configure-aws-credentials@v5
  with:
    role-to-assume: arn:aws:iam::<AWS ACCOUNT ID>:role/<AWS IAM ROLE NAME>
    aws-region: <AWS REGION>
- name: Login to ECR
  uses: aws-actions/amazon-ecr-login@v2
```

For other environments, use the `aws` and `docker` CLIs, like [this](https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html#registry-auth-token). Example:

```bash
aws ecr get-login-password --region <AWS REGION> | docker login \
  <AWS ACCOUNT ID>.dkr.ecr.<AWS REGION>.amazonaws.com \
  --username AWS \
  --password-stdin
```

## Azure Container Registry (alternative for `--provider=azure`)

For GitHub Actions, follow instructions [here](https://github.com/docker/login-action?tab=readme-ov-file#azure-container-registry-acr). Example:

```yaml
- name: Login to ACR
  uses: docker/login-action@v3
  with:
    registry: <AZURE REGISTRY NAME>.azurecr.io
    username: ${{ vars.AZURE_CLIENT_ID }}
    password: ${{ secrets.AZURE_CLIENT_SECRET }}
```

For other environments, use the `az` and `docker` CLIs, like [this](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli#az-acr-login-with---expose-token). Example:

```bash
az acr login \
  --name <ACR NAME> \
  --expose-token \
  --output tsv \
  --query accessToken | docker login \
  <ACR NAME>.azurecr.io \
  --username 00000000-0000-0000-0000-000000000000 \
  --password-stdin
```

## Google Artifact Registry (alternative for `--provider=gcp`)

For GitHub Actions, follow instructions [here](https://github.com/docker/login-action?tab=readme-ov-file#google-artifact-registry-gar). Example:

```yaml
- name: Authenticate to Google Cloud
  id: auth
  uses: google-github-actions/auth@v1
  with:
    token_format: access_token
    workload_identity_provider: projects/<GCP PROJECT NUMBER>/locations/global/workloadIdentityPools/<POOL NAME>/providers/<POOL PROVIDER NAME>
    service_account: <GCP SERVICE ACCOUNT EMAIL>
- name: Login to GAR
  uses: docker/login-action@v3
  with:
    registry: <location>-docker.pkg.dev
    username: oauth2accesstoken
    password: ${{ steps.auth.outputs.access_token }}
```

For other environments, use the `gcloud` and `docker` CLIs, like [this](https://cloud.google.com/artifact-registry/docs/docker/authentication#token). Example:

```bash
gcloud auth print-access-token | docker login \
  <GCP LOCATION>-docker.pkg.dev \
  --username oauth2accesstoken \
  --password-stdin
```