### PR TITLE
Disable AUR publishing

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -88,22 +88,6 @@ brews:
       generate_completions_from_executable(bin/"flux", "completion")
     test: |
       system "#{bin}/flux --version"
-publishers:
-  - name: aur-pkg-bin
-    env:
-      - AUR_BOT_SSH_PRIVATE_KEY={{ .Env.AUR_BOT_SSH_PRIVATE_KEY }}
-    cmd: |
-      .github/aur/flux-bin/publish.sh {{ .Version }}
-  - name: aur-pkg-scm
-    env:
-      - AUR_BOT_SSH_PRIVATE_KEY={{ .Env.AUR_BOT_SSH_PRIVATE_KEY }}
-    cmd: |
-      .github/aur/flux-scm/publish.sh {{ .Version }}
-  - name: aur-pkg-go
-    env:
-      - AUR_BOT_SSH_PRIVATE_KEY={{ .Env.AUR_BOT_SSH_PRIVATE_KEY }}
-    cmd: |
-      .github/aur/flux-go/publish.sh {{ .Version }}
 dockers:
 - image_templates:
     - 'fluxcd/flux-cli:{{ .Tag }}-amd64'


### PR DESCRIPTION
AUR is now publishing Flux CLI, dropping our packages from the release workflow.

https://archlinux.org/packages/extra/x86_64/fluxcd/