### PR TITLE
Fix manifest generation for `--storage-adv-addr` and `--events-addr` flags

### DIFF
--- a/pkg/manifestgen/install/manifests.go
+++ b/pkg/manifestgen/install/manifests.go
@@ -75,7 +75,7 @@ func generate(base string, options Options) error {
 		// traffic from going through http proxy. Without fully specified
 		// domain they need to mention `notifications-controller` explicitly in
 		// `no_proxy` variable after debugging http proxy logs.
-		options.EventsAddr = fmt.Sprintf("http://%s.%s.svc.%s./", options.NotificationController, options.Namespace, options.ClusterDomain)
+		options.EventsAddr = fmt.Sprintf("http://%s.$(RUNTIME_NAMESPACE).svc.%s./", options.NotificationController, options.ClusterDomain)
 	}
 
 	if err := execTemplate(options, namespaceTmpl, path.Join(base, "namespace.yaml")); err != nil {

--- a/pkg/manifestgen/install/templates.go
+++ b/pkg/manifestgen/install/templates.go
@@ -83,7 +83,7 @@ patches:
       value: --log-level={{$logLevel}}
     - op: replace
       path: /spec/template/spec/containers/0/args/6
-      value: --storage-adv-addr=source-controller.$(RUNTIME_NAMESPACE).svc.{{$clusterDomain}}.
+      value: --storage-adv-addr={{$component}}.$(RUNTIME_NAMESPACE).svc.{{$clusterDomain}}.
 {{- else }}
 - target:
     group: apps


### PR DESCRIPTION
Changes:
- Fix `--storage-adv-addr` in source-watcher deployment (fix: #5573)
- Use `RUNTIME_NAMESPACE` when setting `--events-addr` (fix: #5567)