### PR TITLE
[RFC-0012] Add command `flux export source external`

### DIFF
--- a/cmd/flux/export_source_external.go
+++ b/cmd/flux/export_source_external.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2025 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+)
+
+var exportSourceExternalCmd = &cobra.Command{
+	Use:   "external [name]",
+	Short: "Export ExternalArtifact sources in YAML format",
+	Long:  "The export source external command exports one or all ExternalArtifact sources in YAML format.",
+	Example: `  # Export all ExternalArtifact sources
+  flux export source external --all > sources.yaml
+
+  # Export a specific ExternalArtifact
+  flux export source external my-artifact > source.yaml`,
+	ValidArgsFunction: resourceNamesCompletionFunc(sourcev1.GroupVersion.WithKind(sourcev1.ExternalArtifactKind)),
+	RunE: exportWithSecretCommand{
+		list:   externalArtifactListAdapter{&sourcev1.ExternalArtifactList{}},
+		object: externalArtifactAdapter{&sourcev1.ExternalArtifact{}},
+	}.run,
+}
+
+func init() {
+	exportSourceCmd.AddCommand(exportSourceExternalCmd)
+}
+
+func exportExternalArtifact(source *sourcev1.ExternalArtifact) any {
+	gvk := sourcev1.GroupVersion.WithKind(sourcev1.ExternalArtifactKind)
+	export := sourcev1.ExternalArtifact{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       gvk.Kind,
+			APIVersion: gvk.GroupVersion().String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        source.Name,
+			Namespace:   source.Namespace,
+			Labels:      source.Labels,
+			Annotations: source.Annotations,
+		},
+		Spec: source.Spec,
+	}
+	return export
+}
+
+func getExternalArtifactSecret(source *sourcev1.ExternalArtifact) *types.NamespacedName {
+	// ExternalArtifact does not have a secretRef in its spec, this satisfies the interface
+	return nil
+}
+
+func (ex externalArtifactAdapter) secret() *types.NamespacedName {
+	return getExternalArtifactSecret(ex.ExternalArtifact)
+}
+
+func (ex externalArtifactListAdapter) secretItem(i int) *types.NamespacedName {
+	return getExternalArtifactSecret(&ex.ExternalArtifactList.Items[i])
+}
+
+func (ex externalArtifactAdapter) export() any {
+	return exportExternalArtifact(ex.ExternalArtifact)
+}
+
+func (ex externalArtifactListAdapter) exportItem(i int) any {
+	return exportExternalArtifact(&ex.ExternalArtifactList.Items[i])
+}

--- a/cmd/flux/export_test.go
+++ b/cmd/flux/export_test.go
@@ -110,6 +110,12 @@ func TestExport(t *testing.T) {
 			"testdata/export/bucket.yaml",
 			tmpl,
 		},
+		{
+			"source external",
+			"export source external flux-system",
+			"testdata/export/external-artifact.yaml",
+			tmpl,
+		},
 	}
 
 	for _, tt := range cases {

--- a/cmd/flux/testdata/export/external-artifact.yaml
+++ b/cmd/flux/testdata/export/external-artifact.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: ExternalArtifact
+metadata:
+  name: flux-system
+  namespace: {{ .fluxns }}
+spec:
+  sourceRef:
+    apiVersion: source.example.com/v1alpha1
+    kind: GitHubRelease
+    name: flux-system
+    namespace: {{ .fluxns }}

--- a/cmd/flux/testdata/export/objects.yaml
+++ b/cmd/flux/testdata/export/objects.yaml
@@ -165,3 +165,15 @@ spec:
   endpoint: s3.amazonaws.com
   region: us-east-1
   timeout: 30s
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: ExternalArtifact
+metadata:
+  name: flux-system
+  namespace: {{ .fluxns }}
+spec:
+  sourceRef:
+    apiVersion: source.example.com/v1alpha1
+    kind: GitHubRelease
+    name: flux-system
+    namespace: {{ .fluxns }}


### PR DESCRIPTION
Part of: https://github.com/fluxcd/flux2/issues/5504
[RFC-0012] Add command flux export source external

@stefanprodan  - I added this, one thing I am not sure about is there is no `SecretRef` so I am just returning `nil` 
let me know if there is a better way to go about this. 

```
~/OpenSource/flux/flux2-fork add-export-source-external ?1 ❯ ./bin/flux export source external --all -n decomposition                                                     ⎈ kind-flux-test
---
apiVersion: source.toolkit.fluxcd.io/v1
kind: ExternalArtifact
metadata:
  labels:
    app.kubernetes.io/managed-by: source-watcher
    source.extensions.fluxcd.io/generator: 4b83e39f-4032-4808-a66f-3adea8878a37
  name: podinfo-backend
  namespace: decomposition
spec:
  sourceRef:
    apiVersion: source.extensions.fluxcd.io/v1beta1
    kind: ArtifactGenerator
    name: app-gen
    namespace: decomposition
---
apiVersion: source.toolkit.fluxcd.io/v1
kind: ExternalArtifact
metadata:
  labels:
    app.kubernetes.io/managed-by: source-watcher
    source.extensions.fluxcd.io/generator: 4b83e39f-4032-4808-a66f-3adea8878a37
  name: podinfo-cache
  namespace: decomposition
spec:
  sourceRef:
    apiVersion: source.extensions.fluxcd.io/v1beta1
    kind: ArtifactGenerator
    name: app-gen
    namespace: decomposition
---
apiVersion: source.toolkit.fluxcd.io/v1
kind: ExternalArtifact
metadata:
  labels:
    app.kubernetes.io/managed-by: source-watcher
    source.extensions.fluxcd.io/generator: 4b83e39f-4032-4808-a66f-3adea8878a37
  name: podinfo-frontend
  namespace: decomposition
spec:
  sourceRef:
    apiVersion: source.extensions.fluxcd.io/v1beta1
    kind: ArtifactGenerator
    name: app-gen
    namespace: decomposition
```    