### PR TITLE
fix: handle error when writing password prompt to stdout

### DIFF
--- a/cmd/flux/main.go
+++ b/cmd/flux/main.go
@@ -180,7 +180,7 @@ func main() {
 
 	// This is required because controller-runtime expects its consumers to
 	// set a logger through log.SetLogger within 30 seconds of the program's
-	// initalization. If not set, the entire debug stack is printed as an
+	// initialization. If not set, the entire debug stack is printed as an
 	// error, see: https://github.com/kubernetes-sigs/controller-runtime/blob/ed8be90/pkg/log/log.go#L59
 	// Since we have our own logging and don't care about controller-runtime's
 	// logger, we configure it's logger to do nothing.
@@ -225,7 +225,9 @@ func configureDefaultNamespace() {
 func readPasswordFromStdin(prompt string) (string, error) {
 	var out string
 	var err error
-	fmt.Fprint(os.Stdout, prompt)
+	if _, err := fmt.Fprint(os.Stdout, prompt); err != nil {
+		return "", fmt.Errorf("failed to write prompt: %w", err)
+	}
 	stdinFD := int(os.Stdin.Fd())
 	if term.IsTerminal(stdinFD) {
 		var inBytes []byte


### PR DESCRIPTION
The readPasswordFromStdin funcn ignored the error from fmt.Fprint,which could cause silent failures if stdout is closed or redirected.

Signed-off-by: akshatsinha0