### PR TITLE
Allow option to skip tenant namespace creation

### DIFF
--- a/cmd/flux/create_tenant_test.go
+++ b/cmd/flux/create_tenant_test.go
@@ -54,6 +54,11 @@ func TestCreateTenant(t *testing.T) {
 			args:   "create tenant dev-team --with-namespace=apps --cluster-role=custom-role --export",
 			assert: assertGoldenFile("./testdata/create_tenant/tenant-with-cluster-role.yaml"),
 		},
+		{
+			name:   "tenant with skip namespace",
+			args:   "create tenant dev-team --with-namespace=apps --cluster-role=cluster-admin --skip-namespace --export",
+			assert: assertGoldenFile("./testdata/create_tenant/tenant-with-skip-namespace.yaml"),
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/flux/testdata/create_tenant/tenant-with-skip-namespace.yaml
+++ b/cmd/flux/testdata/create_tenant/tenant-with-skip-namespace.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    toolkit.fluxcd.io/tenant: dev-team
+  name: dev-team
+  namespace: apps
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    toolkit.fluxcd.io/tenant: dev-team
+  name: dev-team-reconciler
+  namespace: apps
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: gotk:apps:reconciler
+- kind: ServiceAccount
+  name: dev-team
+  namespace: apps


### PR DESCRIPTION
## Issue
When flux onboards tenants in multitenant setup, it always creates manifest for namespace with no option to skip it.

## When this is needed?
In a shared cluster, for example in a customer environment, namespaces are managed at infra level by cluster admin. 
This means we receive a namespace already created and we don't want flux platform-admin to manage it or delete it in case of tenant removal. 

## What's in this PR?
This allows a flag to flux create tenant command to optionally skip namespace creation by flux. Default behaviour remains unchanged. 

