### PR TITLE
fix: return accepted values for flags when calling Values.Type()

### DIFF
--- a/internal/flags/crds.go
+++ b/internal/flags/crds.go
@@ -52,9 +52,9 @@ func (a *CRDsPolicy) Set(str string) error {
 }
 
 func (a *CRDsPolicy) Type() string {
-	return "crds"
+	return strings.Join(supportedCRDsPolicies, "|")
 }
 
 func (a *CRDsPolicy) Description() string {
-	return fmt.Sprintf("upgrade CRDs policy, available options are: (%s)", strings.Join(supportedCRDsPolicies, ", "))
+	return "upgrade CRDs policy"
 }

--- a/internal/flags/ecdsa_curve.go
+++ b/internal/flags/ecdsa_curve.go
@@ -49,11 +49,16 @@ func (c *ECDSACurve) Set(str string) error {
 }
 
 func (c *ECDSACurve) Type() string {
-	return "ecdsaCurve"
+	keys := make([]string, 0, len(supportedECDSACurves))
+	for k := range supportedECDSACurves {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, "|")
 }
 
 func (c *ECDSACurve) Description() string {
-	return fmt.Sprintf("SSH ECDSA public key curve (%s)", strings.Join(ecdsaCurves(), ", "))
+	return "SSH ECDSA public key curve"
 }
 
 func ecdsaCurves() []string {

--- a/internal/flags/gitlab_visibility.go
+++ b/internal/flags/gitlab_visibility.go
@@ -58,9 +58,13 @@ func (d *GitLabVisibility) Set(str string) error {
 }
 
 func (d *GitLabVisibility) Type() string {
-	return "gitLabVisibility"
+	keys := make([]string, 0, len(supportedGitLabVisibilities))
+	for v := range supportedGitLabVisibilities {
+		keys = append(keys, string(v))
+	}
+	return strings.Join(keys, "|")
 }
 
 func (d *GitLabVisibility) Description() string {
-	return fmt.Sprintf("specifies the visibility of the repository. Valid values are public, private, internal")
+	return "specifies the visibility of the repository"
 }

--- a/internal/flags/helm_chart_source.go
+++ b/internal/flags/helm_chart_source.go
@@ -64,7 +64,7 @@ func (s *HelmChartSource) Set(str string) error {
 }
 
 func (s *HelmChartSource) Type() string {
-	return "helmChartSource"
+	return "string"
 }
 
 func (s *HelmChartSource) Description() string {

--- a/internal/flags/kustomization_source.go
+++ b/internal/flags/kustomization_source.go
@@ -70,7 +70,7 @@ func (s *KustomizationSource) Set(str string) error {
 }
 
 func (s *KustomizationSource) Type() string {
-	return "kustomizationSource"
+	return "string"
 }
 
 func (s *KustomizationSource) Description() string {

--- a/internal/flags/log_level.go
+++ b/internal/flags/log_level.go
@@ -46,9 +46,9 @@ func (l *LogLevel) Set(str string) error {
 }
 
 func (l *LogLevel) Type() string {
-	return "logLevel"
+	return strings.Join(supportedLogLevels, "|")
 }
 
 func (l *LogLevel) Description() string {
-	return fmt.Sprintf("log level, available options are: (%s)", strings.Join(supportedLogLevels, ", "))
+	return "log level"
 }

--- a/internal/flags/public_key_algorithm.go
+++ b/internal/flags/public_key_algorithm.go
@@ -45,9 +45,9 @@ func (a *PublicKeyAlgorithm) Set(str string) error {
 }
 
 func (a *PublicKeyAlgorithm) Type() string {
-	return "publicKeyAlgorithm"
+	return strings.Join(supportedPublicKeyAlgorithms, "|")
 }
 
 func (a *PublicKeyAlgorithm) Description() string {
-	return fmt.Sprintf("SSH public key algorithm (%s)", strings.Join(supportedPublicKeyAlgorithms, ", "))
+	return "SSH public key algorithm"
 }

--- a/internal/flags/source_bucket_provider.go
+++ b/internal/flags/source_bucket_provider.go
@@ -52,12 +52,9 @@ func (p *SourceBucketProvider) Set(str string) error {
 }
 
 func (p *SourceBucketProvider) Type() string {
-	return "sourceBucketProvider"
+	return strings.Join(supportedSourceBucketProviders, "|")
 }
 
 func (p *SourceBucketProvider) Description() string {
-	return fmt.Sprintf(
-		"the S3 compatible storage provider name, available options are: (%s)",
-		strings.Join(supportedSourceBucketProviders, ", "),
-	)
+	return "the S3 compatible storage provider name"
 }

--- a/internal/flags/source_oci_provider.go
+++ b/internal/flags/source_oci_provider.go
@@ -52,12 +52,9 @@ func (p *SourceOCIProvider) Set(str string) error {
 }
 
 func (p *SourceOCIProvider) Type() string {
-	return "sourceOCIProvider"
+	return strings.Join(supportedSourceOCIProviders, "|")
 }
 
 func (p *SourceOCIProvider) Description() string {
-	return fmt.Sprintf(
-		"the OCI provider name, available options are: (%s)",
-		strings.Join(supportedSourceOCIProviders, ", "),
-	)
+	return "the OCI provider name"
 }


### PR DESCRIPTION
Resolves: #5066 which requested each flags implementation of Values.Type() should return the accepted values.

Feedback welcome.

Notes:
1. I have not done any changes to flags which only has a single accepted value. This is to not confuse the user. Let me know if I need to change this
2. I could not find a reference for `internal/flags/local_helm_chart_source.go` and it seems the `supportedHelmChartSourceKinds` is never defined in the file