### PR TITLE
diff: report if object is skipped

### DIFF
--- a/internal/build/diff.go
+++ b/internal/build/diff.go
@@ -116,6 +116,9 @@ func (b *Builder) diff() (string, bool, error) {
 			diffErrs = append(diffErrs, err)
 			continue
 		}
+		if change.Action == ssa.SkippedAction {
+			output.WriteString(writeString(fmt.Sprintf("► %s skipped\n", change.Subject), bunt.Orange))
+		}
 
 		// if the object is a sops secret, we need to
 		// make sure we diff only if the keys are different


### PR DESCRIPTION
If an object is skipped during `flux diff` it is not clearly communicated that the object is skipped.
This adds a warning output so that a user sees which resources are skipped.