### PR TITLE
fix: #5654 by checking if both --chart and --chart-ref are set

### DIFF
--- a/cmd/flux/create_helmrelease.go
+++ b/cmd/flux/create_helmrelease.go
@@ -182,6 +182,10 @@ func createHelmReleaseCmdRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("chart or chart-ref is required")
 	}
 
+	if helmReleaseArgs.chart != "" && helmReleaseArgs.chartRef != "" {
+		return fmt.Errorf("cannot use --chart in combination with --chart-ref")
+	}
+
 	sourceLabels, err := parseLabels()
 	if err != nil {
 		return err

--- a/cmd/flux/create_helmrelease_test.go
+++ b/cmd/flux/create_helmrelease_test.go
@@ -43,6 +43,11 @@ func TestCreateHelmRelease(t *testing.T) {
 			assert: assertError("chart or chart-ref is required"),
 		},
 		{
+			name:   "chart and chartRef used in combination",
+			args:   "create helmrelease podinfo --chart podinfo --chart-ref foobar/podinfo --export",
+			assert: assertError("cannot use --chart in combination with --chart-ref"),
+		},
+		{
 			name:   "unknown source kind",
 			args:   "create helmrelease podinfo --source foobar/podinfo --chart podinfo --export",
 			assert: assertError(`invalid argument "foobar/podinfo" for "--source" flag: source kind 'foobar' is not supported, must be one of: HelmRepository, GitRepository, Bucket`),


### PR DESCRIPTION
Add a test to see if --chart and --chart ref are set at the same time.
Implement check in `createHelmReleaseCmdRun` to make sure CLI returns error if both flags are set at the same time.
Fixes #5654