### PR TITLE
Fix resume command logging success after reconciliation failure

### DIFF
--- a/cmd/flux/resume.go
+++ b/cmd/flux/resume.go
@@ -251,7 +251,8 @@ func (resume resumeCommand) printMessage(responses []reconcileResponse) {
 			continue
 		}
 		if r.err != nil {
-			logger.Failuref("%s", r.err.Error())
+			logger.Failuref("%s %s reconciliation failed: %s", resume.kind, r.asClientObject().GetName(), r.err.Error())
+			continue
 		}
 		logger.Successf("%s %s reconciliation completed", resume.kind, r.asClientObject().GetName())
 		logger.Successf("%s", r.successMessage())


### PR DESCRIPTION
## Fix `flux resume` success logging and panic on failed reconciliation

### Summary
Fixes a logic bug in the `flux resume` CLI where failed reconciliations were still logged as successful and could trigger a nil-pointer panic when status fields were unset.

### Problem
When a reconciliation fails, `printMessage()` logs the error but continues execution, printing “reconciliation completed” and calling `successMessage()`. Many `successMessage()` implementations assume non-nil status fields, causing misleading output or a CLI crash.

### Fix
Stop execution after logging a reconciliation error so success messages are only printed when reconciliation actually succeeds.

### Impact
- Prevents CLI panics
- Removes misleading success output
- Restores reliable `flux resume` behavior for all resource types
