### PR TITLE
fix: return error immediately on failed reconciliation status

### DIFF
--- a/cmd/flux/reconcile.go
+++ b/cmd/flux/reconcile.go
@@ -152,7 +152,14 @@ func reconciliationHandled(kubeClient client.Client, namespacedName types.Namesp
 			return false, err
 		}
 
-		return result.Status == kstatus.CurrentStatus, nil
+		switch result.Status {
+		case kstatus.CurrentStatus:
+			return true, nil
+		case kstatus.InProgressStatus:
+			return false, nil
+		default:
+			return false, fmt.Errorf("%s", result.Message)
+		}
 	}
 }
 


### PR DESCRIPTION
## Flux reconcile does not fail fast on Failed status

`flux reconcile` does not fail fast when a resource is already in `Failed` status.

The polling condition treats `FailedStatus` the same as `InProgressStatus`, so the command waits until the full timeout (default 5 minutes) before reporting an error.

This causes unnecessary delays and poor UX. The fix is to return an error for terminal failure states, matching the behavior of `isObjectReady()`.
