### PR TITLE
Fix/resume exit code

### DIFF
--- a/cmd/flux/reconcile.go
+++ b/cmd/flux/reconcile.go
@@ -152,7 +152,14 @@ func reconciliationHandled(kubeClient client.Client, namespacedName types.Namesp
 			return false, err
 		}
 
-		return result.Status == kstatus.CurrentStatus, nil
+		switch result.Status {
+		case kstatus.CurrentStatus:
+			return true, nil
+		case kstatus.InProgressStatus:
+			return false, nil
+		default:
+			return false, fmt.Errorf("%s", result.Message)
+		}
 	}
 }
 

--- a/cmd/flux/resume.go
+++ b/cmd/flux/resume.go
@@ -126,6 +126,17 @@ func (resume resumeCommand) run(cmd *cobra.Command, args []string) error {
 
 	resume.printMessage(reconcileResps)
 
+	// Return an error if any reconciliation failed
+	var failedCount int
+	for _, r := range reconcileResps {
+		if r.resumable != nil && r.err != nil {
+			failedCount++
+		}
+	}
+	if failedCount > 0 {
+		return fmt.Errorf("reconciliation failed for %d %s(s)", failedCount, resume.kind)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Fix: `flux resume` reports success even when it fails

### What’s going on
Right now, `flux resume` prints reconciliation errors but still exits with code `0`.  
That makes scripts and CI pipelines think everything worked, even when it didn’t.

### What this changes
If any resource fails to reconcile, the command now exits with a non-zero code.

### Why it matters
Automation relies on exit codes, not logs.  
This makes `flux resume` behave the way people expect and prevents silent failures.
