### PR TITLE
Fix event listing ignoring pagination token

### DIFF
--- a/cmd/flux/events.go
+++ b/cmd/flux/events.go
@@ -196,11 +196,14 @@ func getRows(ctx context.Context, kubeclient client.Client, clientListOpts []cli
 
 func addEventsToList(ctx context.Context, kubeclient client.Client, el *corev1.EventList, clientListOpts []client.ListOption) error {
 	listOpts := &metav1.ListOptions{}
-	clientListOpts = append(clientListOpts, client.Limit(cmdutil.DefaultChunkSize))
 	err := runtimeresource.FollowContinue(listOpts,
 		func(options metav1.ListOptions) (runtime.Object, error) {
 			newEvents := &corev1.EventList{}
-			if err := kubeclient.List(ctx, newEvents, clientListOpts...); err != nil {
+			opts := append(clientListOpts, client.Limit(cmdutil.DefaultChunkSize))
+			if options.Continue != "" {
+				opts = append(opts, client.Continue(options.Continue))
+			}
+			if err := kubeclient.List(ctx, newEvents, opts...); err != nil {
 				return nil, fmt.Errorf("error getting events: %w", err)
 			}
 			el.Items = append(el.Items, newEvents.Items...)


### PR DESCRIPTION
Fixes: #5683

We were ignoring the pagination token, so namespaces with more events than the page size were getting stuck in infinite loop.

The test I added fails without the fix.