### PR TITLE
fix(reconcile): fix HelmChart namespace lookup when HelmRepository is in a different namespace

### DIFF
--- a/cmd/flux/reconcile_helmrelease.go
+++ b/cmd/flux/reconcile_helmrelease.go
@@ -98,11 +98,9 @@ func (obj helmReleaseAdapter) getSource() (reconcileSource, sourceReference) {
 			return nil, srcRef
 		}
 	default:
-		// default case assumes the HelmRelease is using a HelmChartTemplate
-		ns = obj.Spec.Chart.Spec.SourceRef.Namespace
-		if ns == "" {
-			ns = obj.Namespace
-		}
+		// default case assumes the HelmRelease is using a HelmChartTemplate.
+		// The HelmChart is always created in the same namespace as the HelmRelease,
+		// regardless of where the HelmRepository source lives.
 		name = fmt.Sprintf("%s-%s", obj.Namespace, obj.Name)
 		return reconcileWithSourceCommand{
 				apiType: helmChartType,
@@ -111,7 +109,7 @@ func (obj helmReleaseAdapter) getSource() (reconcileSource, sourceReference) {
 			}, sourceReference{
 				kind:      sourcev1.HelmChartKind,
 				name:      name,
-				namespace: ns,
+				namespace: obj.Namespace,
 			}
 	}
 }


### PR DESCRIPTION
fix: resolve HelmChart lookup using wrong namespace with --with-source

When a HelmRelease uses spec.chart (HelmChartTemplate) and the HelmRepository lives in a different namespace (e.g. flux-system), `flux reconcile hr <name> --with-source` was failing with a not found error.

The bug was in reconcile_helmrelease.go — the HelmChart lookup was using the HelmRepository's namespace instead of the HelmRelease's namespace. Since helm-controller always creates the HelmChart in the HelmRelease's namespace, the lookup returned a 404.

Fixed by using obj.Namespace for the lookup. The HelmRepository namespace is correctly handled downstream by helmChartAdapter.getSource().