### PR TITLE
ci: add top-level permissions to upgrade-fluxcd-pkg workflow

### DIFF
--- a/.github/workflows/upgrade-fluxcd-pkg.yaml
+++ b/.github/workflows/upgrade-fluxcd-pkg.yaml
@@ -3,6 +3,9 @@ name: upgrade-fluxcd-pkg
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   upgrade-fluxcd-pkg:
     uses: fluxcd/gha-workflows/.github/workflows/upgrade-fluxcd-pkg.yaml@v0.9.0


### PR DESCRIPTION
Fixes #5762

## Motivation

The OpenSSF Scorecard reports a Token-Permissions warning for the `upgrade-fluxcd-pkg.yaml` workflow because it lacks top-level `permissions`. Without explicit permissions, the workflow token gets default permissions that may be broader than necessary.

## Modifications

- Added `permissions: contents: read` at the top level of `.github/workflows/upgrade-fluxcd-pkg.yaml` to follow the principle of least privilege.

## Verification

- Verified the YAML syntax is valid.
- The change only restricts default token permissions and does not affect the workflow's functionality, as it uses a separate `BOT_GITHUB_TOKEN` secret.