### PR TITLE
[RFC-0013] Flux CLI Plugin System

### DIFF
--- a/rfcs/0013-cli-plugin-system/README.md
+++ b/rfcs/0013-cli-plugin-system/README.md
@@ -1,10 +1,10 @@
-# RFC-XXXX Flux CLI Plugin System
+# RFC-0013 Flux CLI Plugin System
 
-**Status:** provisional
+**Status:** implementable
 
 **Creation date:** 2026-03-30
 
-**Last update:** 2026-04-01
+**Last update:** 2026-04-13
 
 ## Summary
 


### PR DESCRIPTION
This RFC proposes a plugin system for the Flux CLI that allows external CLI tools to be discoverable and invocable as `flux <name>` subcommands. Plugins are installed from a centralized catalog hosted on GitHub, with SHA-256 checksum verification and automatic version updates.

The implementation of this RFC can be tests here: https://github.com/fluxcd/flux2/tree/plugin-system