### PR TITLE
fix: validate --source flag in create kustomization command

### DIFF
--- a/cmd/flux/create_kustomization.go
+++ b/cmd/flux/create_kustomization.go
@@ -136,6 +136,9 @@ func createKsCmdRun(cmd *cobra.Command, args []string) error {
 	if !strings.HasPrefix(kustomizationArgs.path.String(), "./") {
 		return fmt.Errorf("path must begin with ./")
 	}
+	if kustomizationArgs.source.Name == "" {
+		return fmt.Errorf("source is required")
+	}
 
 	if !createArgs.export {
 		logger.Generatef("generating Kustomization")

--- a/cmd/flux/create_kustomization_test.go
+++ b/cmd/flux/create_kustomization_test.go
@@ -1,0 +1,48 @@
+//go:build unit
+// +build unit
+
+/*
+Copyright 2026 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+func TestCreateKustomization(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   string
+		assert assertFunc
+	}{
+		{
+			// A user creating a kustomization without --source gets a confusing
+			// API-level error about spec.sourceRef.kind instead of a clear message.
+			name:   "missing source",
+			args:   "create kustomization my-app --path=./deploy --export",
+			assert: assertError("source is required"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := cmdTestCase{
+				args:   tt.args,
+				assert: tt.assert,
+			}
+			cmd.runTestCmd(t)
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Running `flux create kustomization` without `--source` silently accepts the command and forwards a broken Kustomization to the API server with empty `sourceRef` fields. The API server then returns:
A user seeing this has no indication that `--source` is the missing flag. The error refers to an internal API field they never set directly.

## Fix

Validate `--source` before generating or applying the resource:
`source is required`

Follows the same pattern used in `create helmrelease`.

## Testing

Added `TestCreateKustomization` covering the missing `--source` scenario.