### PR TITLE
Add `--show-source` to `flux get ks` and `flux get hr` 

### DIFF
--- a/cmd/flux/get_helmrelease.go
+++ b/cmd/flux/get_helmrelease.go
@@ -28,13 +28,22 @@ import (
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
 )
 
+type getHelmReleaseFlags struct {
+	showSource bool
+}
+
+var getHrArgs getHelmReleaseFlags
+
 var getHelmReleaseCmd = &cobra.Command{
 	Use:     "helmreleases",
 	Aliases: []string{"hr", "helmrelease"},
 	Short:   "Get HelmRelease statuses",
 	Long:    "The get helmreleases command prints the statuses of the resources.",
 	Example: `  # List all Helm releases and their status
-  flux get helmreleases`,
+  flux get helmreleases
+
+  # List all Helm releases with source information
+  flux get helmreleases --show-source`,
 	ValidArgsFunction: resourceNamesCompletionFunc(helmv2.GroupVersion.WithKind(helmv2.HelmReleaseKind)),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		get := getCommand{
@@ -69,6 +78,7 @@ var getHelmReleaseCmd = &cobra.Command{
 }
 
 func init() {
+	getHelmReleaseCmd.Flags().BoolVar(&getHrArgs.showSource, "show-source", false, "show the source reference for each helmrelease")
 	getCmd.AddCommand(getHelmReleaseCmd)
 }
 
@@ -79,16 +89,45 @@ func getHelmReleaseRevision(helmRelease helmv2.HelmRelease) string {
 	return helmRelease.Status.LastAttemptedRevision
 }
 
+func getHelmReleaseSource(item helmv2.HelmRelease) string {
+	if item.Spec.ChartRef != nil {
+		ns := item.Spec.ChartRef.Namespace
+		if ns == "" {
+			ns = item.GetNamespace()
+		}
+		return fmt.Sprintf("%s/%s/%s",
+			item.Spec.ChartRef.Kind,
+			ns,
+			item.Spec.ChartRef.Name)
+	}
+	ns := item.Spec.Chart.Spec.SourceRef.Namespace
+	if ns == "" {
+		ns = item.GetNamespace()
+	}
+	return fmt.Sprintf("%s/%s/%s",
+		item.Spec.Chart.Spec.SourceRef.Kind,
+		ns,
+		item.Spec.Chart.Spec.SourceRef.Name)
+}
+
 func (a helmReleaseListAdapter) summariseItem(i int, includeNamespace bool, includeKind bool) []string {
 	item := a.Items[i]
 	revision := getHelmReleaseRevision(item)
 	status, msg := statusAndMessage(item.Status.Conditions)
-	return append(nameColumns(&item, includeNamespace, includeKind),
+	row := nameColumns(&item, includeNamespace, includeKind)
+	if getHrArgs.showSource {
+		row = append(row, getHelmReleaseSource(item))
+	}
+	return append(row,
 		revision, cases.Title(language.English).String(strconv.FormatBool(item.Spec.Suspend)), status, msg)
 }
 
 func (a helmReleaseListAdapter) headers(includeNamespace bool) []string {
-	headers := []string{"Name", "Revision", "Suspended", "Ready", "Message"}
+	headers := []string{"Name"}
+	if getHrArgs.showSource {
+		headers = append(headers, "Source")
+	}
+	headers = append(headers, "Revision", "Suspended", "Ready", "Message")
 	if includeNamespace {
 		headers = append([]string{"Namespace"}, headers...)
 	}

--- a/cmd/flux/get_kustomization.go
+++ b/cmd/flux/get_kustomization.go
@@ -30,13 +30,22 @@ import (
 	"github.com/fluxcd/flux2/v2/internal/utils"
 )
 
+type getKustomizationFlags struct {
+	showSource bool
+}
+
+var getKsArgs getKustomizationFlags
+
 var getKsCmd = &cobra.Command{
 	Use:     "kustomizations",
 	Aliases: []string{"ks", "kustomization"},
 	Short:   "Get Kustomization statuses",
 	Long:    `The get kustomizations command prints the statuses of the resources.`,
 	Example: `  # List all kustomizations and their status
-  flux get kustomizations`,
+  flux get kustomizations
+
+  # List all kustomizations with source information
+  flux get kustomizations --show-source`,
 	ValidArgsFunction: resourceNamesCompletionFunc(kustomizev1.GroupVersion.WithKind(kustomizev1.KustomizationKind)),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		get := getCommand{
@@ -74,6 +83,7 @@ var getKsCmd = &cobra.Command{
 }
 
 func init() {
+	getKsCmd.Flags().BoolVar(&getKsArgs.showSource, "show-source", false, "show the source reference for each kustomization")
 	getCmd.AddCommand(getKsCmd)
 }
 
@@ -83,12 +93,27 @@ func (a kustomizationListAdapter) summariseItem(i int, includeNamespace bool, in
 	status, msg := statusAndMessage(item.Status.Conditions)
 	revision = utils.TruncateHex(revision)
 	msg = utils.TruncateHex(msg)
-	return append(nameColumns(&item, includeNamespace, includeKind),
+	row := nameColumns(&item, includeNamespace, includeKind)
+	if getKsArgs.showSource {
+		sourceNs := item.Spec.SourceRef.Namespace
+		if sourceNs == "" {
+			sourceNs = item.GetNamespace()
+		}
+		row = append(row, fmt.Sprintf("%s/%s/%s",
+			item.Spec.SourceRef.Kind,
+			sourceNs,
+			item.Spec.SourceRef.Name))
+	}
+	return append(row,
 		revision, cases.Title(language.English).String(strconv.FormatBool(item.Spec.Suspend)), status, msg)
 }
 
 func (a kustomizationListAdapter) headers(includeNamespace bool) []string {
-	headers := []string{"Name", "Revision", "Suspended", "Ready", "Message"}
+	headers := []string{"Name"}
+	if getKsArgs.showSource {
+		headers = append(headers, "Source")
+	}
+	headers = append(headers, "Revision", "Suspended", "Ready", "Message")
 	if includeNamespace {
 		headers = append([]string{"Namespace"}, headers...)
 	}


### PR DESCRIPTION
When looking at a cluster with Kustomizations or HelmReleases from different sources it is hard to identify which source each resource refers to. This adds a `--show-source` flag to both `flux get kustomization` and `flux get helmrelease` that displays the source Kind/Namespace/Name.

Follows the same format used in `get sources external`.

For HelmReleases, supports both `ChartRef` and `Chart.Spec.SourceRef` source references.

Fixes #2692