### PR TITLE
fix: handle multiple symlinks to same target in build artifact

### DIFF
--- a/cmd/flux/build_artifact.go
+++ b/cmd/flux/build_artifact.go
@@ -172,7 +172,7 @@ func copyDir(srcDir, dstDir string, visited map[string]bool) error {
 		return nil // break the cycle
 	}
 	visited[abs] = true
-
+	defer delete(visited, abs)
 	entries, err := os.ReadDir(srcDir)
 	if err != nil {
 		return err

--- a/cmd/flux/build_artifact_test.go
+++ b/cmd/flux/build_artifact_test.go
@@ -179,3 +179,39 @@ func Test_resolveSymlinks_cycle(t *testing.T) {
 	_, err = os.Stat(filepath.Join(resolved, "cycle", "cycle", "cycle"))
 	g.Expect(os.IsNotExist(err)).To(BeTrue())
 }
+
+func Test_resolveSymlinks_multipleLinksSameTarget(t *testing.T) {
+	g := NewWithT(t)
+
+	// Create source directory with a real file inside a dir
+	srcDir := t.TempDir()
+	targetDir := filepath.Join(srcDir, "target")
+	g.Expect(os.MkdirAll(targetDir, 0o755)).To(Succeed())
+	g.Expect(os.WriteFile(filepath.Join(targetDir, "file.yaml"), []byte("data"), 0o644)).To(Succeed())
+
+	// Create a directory with multiple symlinks pointing to targetDir
+	symlinkDir := t.TempDir()
+
+	// Link 1
+	link1 := filepath.Join(symlinkDir, "link1")
+	g.Expect(os.Symlink(targetDir, link1)).To(Succeed())
+
+	// Link 2
+	link2 := filepath.Join(symlinkDir, "link2")
+	g.Expect(os.Symlink(targetDir, link2)).To(Succeed())
+
+	// Resolve symlinks
+	resolved, cleanupDir, err := resolveSymlinks(symlinkDir)
+	g.Expect(err).To(BeNil())
+	t.Cleanup(func() { os.RemoveAll(cleanupDir) })
+
+	// Verify link1 has the file
+	content, err := os.ReadFile(filepath.Join(resolved, "link1", "file.yaml"))
+	g.Expect(err).To(BeNil())
+	g.Expect(string(content)).To(Equal("data"))
+
+	// Verify link2 ALSO has the file
+	content2, err := os.ReadFile(filepath.Join(resolved, "link2", "file.yaml"))
+	g.Expect(err).To(BeNil())
+	g.Expect(string(content2)).To(Equal("data"))
+}


### PR DESCRIPTION
### Summary

Fixes an issue where `flux build artifact --resolve-symlinks` fails to include contents when multiple symlinks point to the same target directory.

Followup: #5724

---

### Problem

The `copyDir` function uses a global `visited` map to track visited absolute paths and prevent cycles. However, when a directory is referenced by multiple symlinks:

* The first traversal marks the path as visited
* Subsequent traversals treat it as a cycle
* This results in skipped content and empty directories in the final artifact

---

### Root Cause

The `visited` map is used globally across the entire traversal instead of being scoped to the current recursion path. This causes valid paths to be incorrectly skipped.

---

### Solution

Scope the `visited` map to the current recursion path by removing entries after traversal using `defer`.

```go
visited[abs] = true
defer delete(visited, abs)
```

This ensures:

* Cycles are still prevented
* Multiple valid symlink paths are processed correctly

---

### Reproduction Steps

```bash
mkdir -p repro/base
echo "apiVersion: v1" > repro/base/manifest.yaml

ln -s ./base repro/app-a
ln -s ./base repro/app-b

./bin/flux build artifact --path ./repro --output repro.tgz --resolve-symlinks
tar -ztvf repro.tgz
```

---

### Expected Behavior

All directories should contain the file:

* `app-a/manifest.yaml`
* `app-b/manifest.yaml`
* `base/manifest.yaml`

---

### Actual Behavior (before fix)

* `app-a/manifest.yaml` ✅
* `app-b/` ❌ empty
* `base/` ❌ empty

---

### Testing

* Verified fix using local build of Flux CLI
* Confirmed all symlink paths are correctly included in the artifact
* Ensured no regression in cycle detection

---

closes: #5832