### PR TITLE
fix: return clear error when --private-key-file path starts with '~'

### DIFF
--- a/cmd/flux/bootstrap_git.go
+++ b/cmd/flux/bootstrap_git.go
@@ -364,6 +364,9 @@ func getAuthOpts(u *url.URL, caBundle []byte) (*git.AuthOptions, error) {
 			Password:  gitArgs.password,
 		}
 		if bootstrapArgs.privateKeyFile != "" {
+			if strings.HasPrefix(bootstrapArgs.privateKeyFile, "~") {
+				return nil, fmt.Errorf("failed to open private key file: path %q starts with '~' which is not expanded; use an absolute path or $HOME", bootstrapArgs.privateKeyFile)
+			}
 			pk, err := os.ReadFile(bootstrapArgs.privateKeyFile)
 			if err != nil {
 				return nil, err

--- a/cmd/flux/create_secret_git_test.go
+++ b/cmd/flux/create_secret_git_test.go
@@ -56,6 +56,11 @@ func TestCreateGitSecret(t *testing.T) {
 			args:   "create secret git podinfo-auth --url=https://github.com/stefanprodan/podinfo --username=aaa --password=zzzz --bearer-token=aaaa --namespace=my-namespace --export",
 			assert: assertError("user credentials and bearer token cannot be used together"),
 		},
+		{
+			name:   "ssh key with tilde path",
+			args:   "create secret git podinfo-auth --url=ssh://git@github.com/stefanprodan/podinfo --private-key-file=~/.ssh/id_ecdsa --namespace=my-namespace --export",
+			assert: assertError(`failed to open private key file: path "~/.ssh/id_ecdsa" starts with '~' which is not expanded; use an absolute path or $HOME`),
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/manifestgen/sourcesecret/sourcesecret.go
+++ b/pkg/manifestgen/sourcesecret/sourcesecret.go
@@ -24,6 +24,7 @@ import (
 	"net"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	cryptssh "golang.org/x/crypto/ssh"
@@ -263,6 +264,10 @@ func GenerateGitHubApp(options Options) (*manifestgen.Manifest, error) {
 func LoadKeyPairFromPath(path, password string) (*ssh.KeyPair, error) {
 	if path == "" {
 		return nil, nil
+	}
+
+	if strings.HasPrefix(path, "~") {
+		return nil, fmt.Errorf("failed to open private key file: path %q starts with '~' which is not expanded; use an absolute path or $HOME", path)
 	}
 
 	b, err := os.ReadFile(path)


### PR DESCRIPTION
## Summary

The tilde character is expanded by the shell, not by the Flux CLI, so paths like `~/.ssh/id_ecdsa` passed with `=value` syntax (e.g. `--private-key-file=~/.ssh/id_ecdsa`) were opened verbatim and failed with a confusing `no such file or directory` error.

This change detects a leading `~` up front in `LoadKeyPairFromPath` and in the `getAuthOpts` code path used by `bootstrap git`, and returns a clear error pointing users at absolute paths or `\$HOME` instead. Behavior for normal paths is unchanged.

Maintainers' position in #5591 was to not auto-expand `~` but to surface a better error message, which is what this PR implements.

Fixes #5591.

## Test plan

- [x] New test case `ssh key with tilde path` in `create_secret_git_test.go` asserting the new error
- [x] `go test ./cmd/flux/... ./pkg/manifestgen/sourcesecret/...` passes
- [x] Manual repro: `flux create secret git ... --private-key-file=~/.ssh/id_ecdsa` now returns the clear message
- [x] Regression check: passing a regular relative path still works