### PR TITLE
Add support for AWS CodeCommit to `flux bootstrap git`

### DIFF
--- a/cmd/flux/bootstrap_git.go
+++ b/cmd/flux/bootstrap_git.go
@@ -28,6 +28,9 @@ import (
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/fluxcd/pkg/auth"
+	"github.com/fluxcd/pkg/auth/aws"
+	authutils "github.com/fluxcd/pkg/auth/utils"
 	"github.com/fluxcd/pkg/git"
 	"github.com/fluxcd/pkg/git/gogit"
 
@@ -62,8 +65,11 @@ command will perform an upgrade if needed.`,
   # Run bootstrap for a Git repository with a private key and password
   flux bootstrap git --url=ssh://git@example.com/repository.git --private-key-file=<path/to/private.key> --password=<password> --path=clusters/my-cluster
 
-  # Run bootstrap for a Git repository on AWS CodeCommit
+  # Run bootstrap for a Git repository on AWS CodeCommit using SSH
   flux bootstrap git --url=ssh://<SSH-Key-ID>@git-codecommit.<region>.amazonaws.com/v1/repos/<repository> --private-key-file=<path/to/private.key> --password=<SSH-passphrase> --path=clusters/my-cluster
+
+  # Run bootstrap for a Git repository on AWS CodeCommit using HTTPS (requires AWS IAM credentials)
+  flux bootstrap git --url=https://git-codecommit.<region>.amazonaws.com/v1/repos/<repository> --path=clusters/my-cluster
 
   # Run bootstrap for a Git repository on Azure Devops
   flux bootstrap git --url=ssh://git@ssh.dev.azure.com/v3/<org>/<project>/<repository> --private-key-file=<path/to/rsa-sha2-private.key> --ssh-hostkey-algos=rsa-sha2-512,rsa-sha2-256 --path=clusters/my-cluster
@@ -109,6 +115,7 @@ func bootstrapGitCmdRun(cmd *cobra.Command, args []string) error {
 		bootstrapArgs.tokenAuth = true
 	}
 
+	var gitProvider string
 	gitPassword := os.Getenv(gitPasswordEnvVar)
 	if gitPassword != "" && gitArgs.password == "" {
 		gitArgs.password = gitPassword
@@ -131,8 +138,12 @@ func bootstrapGitCmdRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
 	if strings.Contains(repositoryURL.Hostname(), "git-codecommit") && strings.Contains(repositoryURL.Hostname(), "amazonaws.com") {
-		if repositoryURL.Scheme == string(git.SSH) {
+		// https://docs.aws.amazon.com/codecommit/latest/userguide/auth-and-access-control.html
+		if repositoryURL.Scheme == string(git.SSH) { // IAM user + SSH
 			if repositoryURL.User == nil {
 				return fmt.Errorf("invalid AWS CodeCommit url: ssh username should be specified in the url")
 			}
@@ -142,14 +153,18 @@ func bootstrapGitCmdRun(cmd *cobra.Command, args []string) error {
 			if bootstrapArgs.privateKeyFile == "" {
 				return fmt.Errorf("private key file is required for bootstrapping against AWS CodeCommit using ssh")
 			}
+		} else if repositoryURL.Scheme == string(git.HTTPS) && !bootstrapArgs.tokenAuth { // IAM role + HTTPS
+			creds, err := authutils.GetGitCredentials(ctx, "aws", auth.WithGitURL(*repositoryURL))
+			if err != nil {
+				return fmt.Errorf("failed to get AWS CodeCommit IAM git credentials: %w", err)
+			}
+			gitArgs.username = creds.Username
+			gitArgs.password = creds.Password
+			bootstrapArgs.tokenAuth = true
+			gitProvider = aws.ProviderName
 		}
-		if repositoryURL.Scheme == string(git.HTTPS) && !bootstrapArgs.tokenAuth {
-			return fmt.Errorf("--token-auth=true must be specified for using an HTTPS AWS CodeCommit url")
-		}
-	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
-	defer cancel()
+	}
 
 	kubeClient, err := utils.KubeClient(kubeconfigArgs, kubeclientOptions)
 	if err != nil {
@@ -296,6 +311,9 @@ func bootstrapGitCmdRun(cmd *cobra.Command, args []string) error {
 		TargetPath:        gitArgs.path.ToSlash(),
 		ManifestFile:      sync.MakeDefaultOptions().ManifestFile,
 		RecurseSubmodules: bootstrapArgs.recurseSubmodules,
+	}
+	if gitProvider != "" {
+		syncOpts.Provider = gitProvider
 	}
 
 	entityList, err := bootstrap.LoadEntityListFromPath(bootstrapArgs.gpgKeyRingPath)

--- a/cmd/flux/create_source_git.go
+++ b/cmd/flux/create_source_git.go
@@ -124,6 +124,12 @@ For private Git repositories, the basic authentication credentials are stored in
     --username=username \
     --password=password
 
+  # Create a source for a Git repository using AWS CodeCommit with IAM credentials
+  flux create source git podinfo \
+    --url=https://git-codecommit.<region>.amazonaws.com/v1/repos/podinfo \
+    --branch=master \
+    --provider=aws
+
   # Create a source for a Git repository using azure provider
   flux create source git podinfo \
     --url=https://dev.azure.com/foo/bar/_git/podinfo \

--- a/cmd/flux/create_source_git_test.go
+++ b/cmd/flux/create_source_git_test.go
@@ -152,7 +152,7 @@ func TestCreateSourceGitExport(t *testing.T) {
 		{
 			name:   "source with invalid provider",
 			args:   "create source git podinfo --namespace=flux-system --url=https://dev.azure.com/foo/bar/_git/podinfo --provider dummy --branch=test --interval=1m0s --export",
-			assert: assertError("invalid argument \"dummy\" for \"--provider\" flag: source Git provider 'dummy' is not supported, must be one of: generic|azure|github"),
+			assert: assertError("invalid argument \"dummy\" for \"--provider\" flag: source Git provider 'dummy' is not supported, must be one of: generic|github|aws|azure"),
 		},
 		{
 			name:   "source with empty provider",

--- a/internal/flags/source_git_provider.go
+++ b/internal/flags/source_git_provider.go
@@ -21,13 +21,16 @@ import (
 	"strings"
 
 	"github.com/fluxcd/flux2/v2/internal/utils"
+	"github.com/fluxcd/pkg/auth/aws"
+	"github.com/fluxcd/pkg/auth/azure"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 )
 
 var supportedSourceGitProviders = []string{
 	sourcev1.GitProviderGeneric,
-	sourcev1.GitProviderAzure,
 	sourcev1.GitProviderGitHub,
+	aws.ProviderName,
+	azure.ProviderName,
 }
 
 type SourceGitProvider string

--- a/pkg/manifestgen/sync/options.go
+++ b/pkg/manifestgen/sync/options.go
@@ -33,6 +33,7 @@ type Options struct {
 	TargetPath        string
 	ManifestFile      string
 	RecurseSubmodules bool
+	Provider          string
 }
 
 func MakeDefaultOptions() Options {

--- a/pkg/manifestgen/sync/sync.go
+++ b/pkg/manifestgen/sync/sync.go
@@ -68,6 +68,7 @@ func Generate(options Options) (*manifestgen.Manifest, error) {
 				Name: options.Secret,
 			},
 			RecurseSubmodules: options.RecurseSubmodules,
+			Provider:          options.Provider,
 		},
 	}
 


### PR DESCRIPTION
### Summary

AWS CodeCommit bootstrap with IAM auth:
- https://github.com/fluxcd/flux2/issues/5866

### Testing

```bash
➜ bin/flux bootstrap git --url=https://git-codecommit.eu-west-1.amazonaws.com/v1/repos/taras-test-flux-iam                                           
► cloning branch "main" from Git repository "https://git-codecommit.eu-west-1.amazonaws.com/v1/repos/taras-test-flux-iam"
✔ cloned repository
► generating component manifests
✔ generated component manifests
✔ committed component manifests to "main" ("8bdc8842e51e73ec3db54b0361327d3688a11438")
► pushing component manifests to "https://git-codecommit.eu-west-1.amazonaws.com/v1/repos/taras-test-flux-iam"
► installing components in "flux-system" namespace
✔ installed components
✔ reconciled components
► determining if source secret "flux-system/flux-system" exists
► generating source secret
► applying source secret "flux-system/flux-system"
✔ reconciled source secret
► generating sync manifests
✔ generated sync manifests
✔ committed sync manifests to "main" ("619bc60b1b366662b8e401ddd5fcb25bd693ce79")
► pushing sync manifests to "https://git-codecommit.eu-west-1.amazonaws.com/v1/repos/taras-test-flux-iam"
► applying sync manifests
```