### PR TITLE
internal/build: handle ignored errors

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -689,7 +689,9 @@ func maskSopsData(res *resource.Resource) error {
 		// assume that both data and stringdata are encrypted
 		if bytes.Contains(asYaml, []byte("sops:")) && bytes.Contains(asYaml, []byte("mac: ENC[")) {
 			// delete the sops object
-			res.PipeE(yaml.FieldClearer{Name: "sops"})
+			if err := res.PipeE(yaml.FieldClearer{Name: "sops"}); err != nil {
+				return fmt.Errorf("failed to delete the sops object: %w", err)
+			}
 
 			secretType, err := res.GetFieldValue(typeField)
 			// If the intended type is Opaque, then it can be omitted from the manifest, since it's the default

--- a/internal/build/diff.go
+++ b/internal/build/diff.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/fluxcd/cli-utils/pkg/kstatus/polling"
 	"github.com/fluxcd/cli-utils/pkg/object"
+	"github.com/fluxcd/flux2/v2/pkg/log"
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
 	"github.com/fluxcd/pkg/ssa"
 	"github.com/fluxcd/pkg/ssa/normalize"
@@ -46,6 +47,8 @@ import (
 
 	"github.com/fluxcd/flux2/v2/pkg/printers"
 )
+
+var logger log.Logger
 
 func (b *Builder) Manager() (*ssa.ResourceManager, error) {
 	statusPoller := polling.NewStatusPoller(b.client, b.restMapper, polling.Options{})
@@ -141,14 +144,22 @@ func (b *Builder) diff() (string, bool, error) {
 			err = diff(liveFile, mergedFile, &output)
 			if err != nil {
 				cleanupDir(tmpDir)
+				if err := cleanupDir(tmpDir); err != nil {
+					logger.Warningf("failed to clean up directory %s: %s", tmpDir, err)
+				}
 				return "", createdOrDrifted, err
 			}
 
-			cleanupDir(tmpDir)
+			if err := cleanupDir(tmpDir); err != nil {
+				logger.Warningf("failed to clean up directory %s: %s", tmpDir, err)
+			}
 			createdOrDrifted = true
 		}
 
-		addObjectsToInventory(newInventory, change)
+		if err := addObjectsToInventory(newInventory, change); err != nil {
+			err = fmt.Errorf("failed to add %s to inventory: %w", change, err)
+			return "", createdOrDrifted, err
+		}
 
 		if b.recursive && isKustomization(obj) && change.Action != ssa.CreatedAction {
 			k, err := toKustomization(obj)


### PR DESCRIPTION
This logs two `cleanupDir()` calls that are worthy of indicating a `tmpdir` leak without stopping the show. I tried to use the `log.Logger` semantics seen elsewhere in the project.

A failure of `addObjectsToInventory()` seemed worthy of an `error` return.