### PR TITLE
include source-watcher in install.yaml manifests

### DIFF
--- a/manifests/install/kustomization.yaml
+++ b/manifests/install/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - ../bases/helm-controller
   - ../bases/image-reflector-controller
   - ../bases/image-automation-controller
+  - ../bases/source-watcher
   - ../rbac
   - ../policies
 transformers:
@@ -26,3 +27,6 @@ images:
     newName: ghcr.io/fluxcd/image-reflector-controller
   - name: fluxcd/image-automation-controller
     newName: ghcr.io/fluxcd/image-automation-controller
+  - name: fluxcd/source-watcher
+    newName: ghcr.io/fluxcd/source-watcher
+


### PR DESCRIPTION
The source-watcher controller is currently not included in the manifest.yaml which is part of a release bundle.

Example: https://github.com/fluxcd/flux2/releases/download/v2.8.6/install.yaml

This PR updates the `./manifests/install` kustomization to include the source-watcher, so that an installation done with the `install.yaml` which is part of a release will include this controller.