### PR TITLE
Add `--layer-index` and `--layer-type` flags to pull artifact

### DIFF
--- a/cmd/flux/pull_artifact.go
+++ b/cmd/flux/pull_artifact.go
@@ -34,25 +34,32 @@ var pullArtifactCmd = &cobra.Command{
 	Use:   "artifact",
 	Short: "Pull artifact",
 	Long: `The pull artifact command downloads and extracts the OCI artifact content to the given path.
-The command can read the credentials from '~/.docker/config.json' but they can also be passed with --creds. It can also login to a supported provider with the --provider flag.`,
+The command can read the credentials from '~/.docker/config.json' but they can also be passed with --creds. It can also login to a supported provider with the --provider flag.
+
+By default the first layer of the OCI manifest is extracted; use --layer-index to select a different layer of an arbitrary OCI artifact.`,
 	Example: `  # Pull an OCI artifact created by flux from GHCR
   flux pull artifact oci://ghcr.io/org/manifests/app:v0.0.1 --output ./path/to/local/manifests
+
+  # Pull layer index 1 from an arbitrary OCI artifact
+  flux pull artifact oci://ghcr.io/org/charts/app:v0.0.1 --output ./path/to/local/extracted --layer-index 1
 `,
 	RunE: pullArtifactCmdRun,
 }
 
 type pullArtifactFlags struct {
-	output   string
-	creds    string
-	insecure bool
-	provider flags.SourceOCIProvider
+	output     string
+	creds      string
+	insecure   bool
+	layerIndex int
+	provider   flags.SourceOCIProvider
 }
 
 var pullArtifactArgs = newPullArtifactFlags()
 
 func newPullArtifactFlags() pullArtifactFlags {
 	return pullArtifactFlags{
-		provider: flags.SourceOCIProvider(sourcev1.GenericOCIProvider),
+		provider:   flags.SourceOCIProvider(sourcev1.GenericOCIProvider),
+		layerIndex: -1,
 	}
 }
 
@@ -61,6 +68,7 @@ func init() {
 	pullArtifactCmd.Flags().StringVar(&pullArtifactArgs.creds, "creds", "", "credentials for OCI registry in the format <username>[:<password>] if --provider is generic")
 	pullArtifactCmd.Flags().Var(&pullArtifactArgs.provider, "provider", sourceOCIRepositoryArgs.provider.Description())
 	pullArtifactCmd.Flags().BoolVar(&pullArtifactArgs.insecure, "insecure-registry", false, "allows artifacts to be pulled without TLS")
+	pullArtifactCmd.Flags().IntVar(&pullArtifactArgs.layerIndex, "layer-index", -1, "pull a specific layer of the OCI manifest by its zero-based index (default: pull the first layer)")
 	pullCmd.AddCommand(pullArtifactCmd)
 }
 
@@ -112,7 +120,13 @@ func pullArtifactCmdRun(cmd *cobra.Command, args []string) error {
 
 	logger.Actionf("pulling artifact from %s", url)
 
-	meta, err := ociClient.Pull(ctx, url, pullArtifactArgs.output)
+	var pullOptions []oci.PullOption
+	if pullArtifactArgs.layerIndex >= 0 {
+		logger.Actionf("selecting layer index %d", pullArtifactArgs.layerIndex)
+		pullOptions = append(pullOptions, oci.WithPullLayerIndex(pullArtifactArgs.layerIndex))
+	}
+
+	meta, err := ociClient.Pull(ctx, url, pullArtifactArgs.output, pullOptions...)
 	if err != nil {
 		return err
 	}

--- a/cmd/flux/pull_artifact.go
+++ b/cmd/flux/pull_artifact.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/spf13/cobra"
@@ -36,12 +37,16 @@ var pullArtifactCmd = &cobra.Command{
 	Long: `The pull artifact command downloads and extracts the OCI artifact content to the given path.
 The command can read the credentials from '~/.docker/config.json' but they can also be passed with --creds. It can also login to a supported provider with the --provider flag.
 
-By default the first layer of the OCI manifest is extracted; use --layer-index to select a different layer of an arbitrary OCI artifact.`,
+By default the first layer of the OCI manifest is extracted; use --layer-index to select a different layer of an arbitrary OCI artifact.
+The selected layer is untarred to a directory or copied to a file based on its content; use --layer-type to override this behaviour.`,
 	Example: `  # Pull an OCI artifact created by flux from GHCR
   flux pull artifact oci://ghcr.io/org/manifests/app:v0.0.1 --output ./path/to/local/manifests
 
   # Pull layer index 1 from an arbitrary OCI artifact
   flux pull artifact oci://ghcr.io/org/charts/app:v0.0.1 --output ./path/to/local/extracted --layer-index 1
+
+  # Pull layer index 1 from an arbitrary OCI artifact and copy it to a file as-is
+  flux pull artifact oci://ghcr.io/org/binaries/app:v0.0.1 --output ./path/to/local/file --layer-index 1 --layer-type static
 `,
 	RunE: pullArtifactCmdRun,
 }
@@ -51,6 +56,7 @@ type pullArtifactFlags struct {
 	creds      string
 	insecure   bool
 	layerIndex int
+	layerType  flags.LayerType
 	provider   flags.SourceOCIProvider
 }
 
@@ -69,6 +75,7 @@ func init() {
 	pullArtifactCmd.Flags().Var(&pullArtifactArgs.provider, "provider", sourceOCIRepositoryArgs.provider.Description())
 	pullArtifactCmd.Flags().BoolVar(&pullArtifactArgs.insecure, "insecure-registry", false, "allows artifacts to be pulled without TLS")
 	pullArtifactCmd.Flags().IntVar(&pullArtifactArgs.layerIndex, "layer-index", -1, "pull a specific layer of the OCI manifest by its zero-based index (default: pull the first layer)")
+	pullArtifactCmd.Flags().Var(&pullArtifactArgs.layerType, "layer-type", pullArtifactArgs.layerType.Description())
 	pullCmd.AddCommand(pullArtifactCmd)
 }
 
@@ -82,7 +89,15 @@ func pullArtifactCmdRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("output path cannot be empty")
 	}
 
-	if fs, err := os.Stat(pullArtifactArgs.output); err != nil || !fs.IsDir() {
+	if oci.LayerType(pullArtifactArgs.layerType) == oci.LayerTypeStatic {
+		// a static layer is copied to a single file at the output path
+		if fs, err := os.Stat(pullArtifactArgs.output); err == nil && fs.IsDir() {
+			return fmt.Errorf("invalid output path %q: must be a file path when --layer-type=%s", pullArtifactArgs.output, oci.LayerTypeStatic)
+		}
+		if fs, err := os.Stat(filepath.Dir(pullArtifactArgs.output)); err != nil || !fs.IsDir() {
+			return fmt.Errorf("invalid output path %q: parent directory must exist", pullArtifactArgs.output)
+		}
+	} else if fs, err := os.Stat(pullArtifactArgs.output); err != nil || !fs.IsDir() {
 		return fmt.Errorf("invalid output path %q: %w", pullArtifactArgs.output, err)
 	}
 
@@ -124,6 +139,11 @@ func pullArtifactCmdRun(cmd *cobra.Command, args []string) error {
 	if pullArtifactArgs.layerIndex >= 0 {
 		logger.Actionf("selecting layer index %d", pullArtifactArgs.layerIndex)
 		pullOptions = append(pullOptions, oci.WithPullLayerIndex(pullArtifactArgs.layerIndex))
+	}
+
+	if pullArtifactArgs.layerType != "" {
+		logger.Actionf("extracting layer as %s", pullArtifactArgs.layerType)
+		pullOptions = append(pullOptions, oci.WithPullLayerType(oci.LayerType(pullArtifactArgs.layerType)))
 	}
 
 	meta, err := ociClient.Pull(ctx, url, pullArtifactArgs.output, pullOptions...)

--- a/internal/flags/layer_type.go
+++ b/internal/flags/layer_type.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2026 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/fluxcd/pkg/oci"
+)
+
+var supportedLayerTypes = []oci.LayerType{oci.LayerTypeTarball, oci.LayerTypeStatic}
+
+type LayerType oci.LayerType
+
+func (l *LayerType) String() string {
+	return string(*l)
+}
+
+func (l *LayerType) Set(str string) error {
+	for _, t := range supportedLayerTypes {
+		if oci.LayerType(str) == t {
+			*l = LayerType(t)
+			return nil
+		}
+	}
+	return fmt.Errorf("unsupported layer type '%s', must be one of: %s", str, l.Type())
+}
+
+func (l *LayerType) Type() string {
+	types := make([]string, 0, len(supportedLayerTypes))
+	for _, t := range supportedLayerTypes {
+		types = append(types, string(t))
+	}
+	return strings.Join(types, "|")
+}
+
+func (l *LayerType) Description() string {
+	return fmt.Sprintf("how the selected layer should be extracted: '%s' untars the layer to the output directory, '%s' copies the layer to the output file (default: detect from the layer content)",
+		oci.LayerTypeTarball, oci.LayerTypeStatic)
+}

--- a/internal/flags/layer_type_test.go
+++ b/internal/flags/layer_type_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2026 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"testing"
+)
+
+func TestLayerType_Set(t *testing.T) {
+	tests := []struct {
+		name      string
+		str       string
+		expect    string
+		expectErr bool
+	}{
+		{"tarball", "tarball", "tarball", false},
+		{"static", "static", "static", false},
+		{"unsupported", "unsupported", "", true},
+		{"empty", "", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var l LayerType
+			if err := l.Set(tt.str); (err != nil) != tt.expectErr {
+				t.Errorf("Set() error = %v, expectErr %v", err, tt.expectErr)
+			}
+			if str := l.String(); str != tt.expect {
+				t.Errorf("Set() = %v, expect %v", str, tt.expect)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #4243

## What

Adds `--layer-index <int>` to `flux pull artifact`. When set, the
underlying `oci.Client.Pull` is called with `WithPullLayerIndex(n)` so
the chosen layer is extracted instead of the default first layer. Lets
users pull arbitrary layers from OCI artifacts that were not produced
by flux.

Per review feedback, also adds `--layer-type <tarball|static>` exposing
`WithPullLayerType`. The two are orthogonal: `--layer-index` selects
which layer to pull, `--layer-type` overrides how it is extracted —
`tarball` untars it to the output directory, `static` copies the blob
to the output file. With `--layer-type=static` the `--output` path is
validated as a file path (existing parent directory) instead of an
existing directory.

## Compatibility

Default flow is unchanged — without `--layer-index` the command behaves
exactly as before (extracts the first layer with `layerIndex: 0` in
`oci.Client.Pull`). Without `--layer-type` the extraction mode is
auto-detected from the layer content, as before.

## Precedent

This continues the work from PR #4790 (closed without merge after
21 months of inactivity — no review feedback on the thread, likely
stale-bot closure). That PR no longer applies cleanly because of
unrelated refactors in `pull_artifact.go`, so this is rewritten from
scratch using the same flag name.

## Tests

The new `internal/flags.LayerType` flag type has a table test following
the existing `internal/flags` convention. No existing
`pull_artifact_test.go` in the repo; the CLI wiring itself follows the
existing pull_artifact precedent of no test file. Happy to add coverage
if maintainers prefer.

## Local testing notes

On Apple Silicon the Makefile's `setup-envtest use latest --arch=amd64`
step fails (`bad CPU type in executable`). Ran envtest manually with
`--arch=arm64` and `KUBEBUILDER_ASSETS` pointed at the arm64 dir; the
full `cmd/flux/...` test suite passes. CI on linux/amd64 should be
unaffected.
