### PR TITLE
fix: preserve invalid metadata.labels in `flux build ks`

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -659,17 +659,10 @@ func kustomizationsEqual(k1 *kustomizev1.Kustomization, k2 *kustomizev1.Kustomiz
 }
 
 func (b *Builder) setOwnerLabels(res *resource.Resource) error {
-	labels := res.GetLabels()
-
-	labels[controllerGroup+"/name"] = b.kustomization.GetName()
-	labels[controllerGroup+"/namespace"] = b.kustomization.GetNamespace()
-
-	err := res.SetLabels(labels)
-	if err != nil {
+	if err := res.PipeE(yaml.SetLabel(controllerGroup+"/name", b.kustomization.GetName())); err != nil {
 		return err
 	}
-
-	return nil
+	return res.PipeE(yaml.SetLabel(controllerGroup+"/namespace", b.kustomization.GetNamespace()))
 }
 
 func maskSopsData(res *resource.Resource) error {

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -840,3 +840,38 @@ resources:
 		t.Fatal("expected error when referencing resource outside cwd, got nil")
 	}
 }
+
+func Test_Build_preserveAllLabels(t *testing.T) {
+	b, err := NewBuilder("test-ks", "testdata/invalid-labels/resources",
+		WithDryRun(true),
+		WithNamespace("flux-system"),
+		WithKustomizationFile("testdata/invalid-labels/kustomization.yaml"),
+	)
+	if err != nil {
+		t.Fatalf("unable to create builder: %v", err)
+	}
+
+	objects, err := b.Build()
+	if err != nil {
+		t.Fatalf("build failed: %v", err)
+	}
+
+	if len(objects) == 0 {
+		t.Fatal("expected at least one object, got none")
+	}
+
+	rawLabels, _, _ := unstructured.NestedMap(objects[0].Object, "metadata", "labels")
+
+	if got, ok := rawLabels["invalid"]; !ok || got != int64(0) {
+		t.Errorf("expected label invalid=0, got %#v", got)
+	}
+	if got, ok := rawLabels["valid"]; !ok || got != "yes" {
+		t.Errorf("expected label valid=\"yes\", got %v", got)
+	}
+	if got := rawLabels[controllerGroup+"/name"]; got != "test-ks" {
+		t.Errorf("expected owner name label \"test-ks\", got %v", got)
+	}
+	if got := rawLabels[controllerGroup+"/namespace"]; got != "flux-system" {
+		t.Errorf("expected owner namespace label \"flux-system\", got %v", got)
+	}
+}

--- a/internal/build/testdata/invalid-labels/kustomization.yaml
+++ b/internal/build/testdata/invalid-labels/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: test-ks
+  namespace: flux-system
+spec:
+  path: "./resources"

--- a/internal/build/testdata/invalid-labels/resources/invalid-resource.yaml
+++ b/internal/build/testdata/invalid-labels/resources/invalid-resource.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: invalid-resource
+  labels:
+    invalid: 0
+    valid: yes

--- a/internal/build/testdata/invalid-labels/resources/kustomization.yaml
+++ b/internal/build/testdata/invalid-labels/resources/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - invalid-resource.yaml


### PR DESCRIPTION
## Current situation

Building a kustomization using the cli `flux build ks` and which manifests have invalid metadata.labels results in silently converting the invalid labels to strings.

Example:

flux build ks platform --recursive --dry-run --kustomization-file test-kustomize.yaml --path "manifests" --local-sources "GitRepository/flux-system/test-repo=."

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  labels:
    invalid: 0
    hello: world
  name: test
```

This will end up as: (Notice the quoted invalid label)
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  labels:
    invalid: "0"
    hello: world
    kustomize.toolkit.fluxcd.io/name: test
    kustomize.toolkit.fluxcd.io/namespace: flux-system
  name: test
```

This should not happen. The expectation would be that the invalid label is preserved.
Running the same through a kustomize build preserves the invalid label.

## Proposal
Its crucial that invalid labels are passed through, otherwise it would be impossible to properly validate manifests for example on ci. Also I suspect its not actually a wanted behavior?

## kustomize-controller
Now at runtime applying invalid manifests via the kustomize-controller is different again. What happens there is that the same manifest is applied as:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  labels:
    kustomize.toolkit.fluxcd.io/name: test
    kustomize.toolkit.fluxcd.io/namespace: flux-system
  name: test
```

What happens there is that both labels the invalid and the valid label are silently removed. There its again a similar problem, the labels are retrieved as a string map and reason is https://github.com/kubernetes/apimachinery/blob/a7225b106d19985c2a47654c106cb419007af6d2/pkg/apis/meta/v1/unstructured/helpers.go#L210 which returns nil if a label is invalid removing all labels.

My expectation at runtime is actually the same, the apply should actually fail, currently it silently adds the resource with the wrong labels. The user experience should be the same as for instance adding the same resource with an invalid label using kubectl.

Now this could potentially break existing pipelines which have such invalid resources in their sources. One could argue thats fine since they are invalid. There is also an argument of putting the fix behind a feature flag.

See https://github.com/fluxcd/pkg/pull/1208