### PR TITLE
Validate Helm source URL schemes

### DIFF
--- a/cmd/flux/create_source_helm.go
+++ b/cmd/flux/create_source_helm.go
@@ -114,8 +114,15 @@ func createSourceHelmCmdRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if _, err := url.Parse(sourceHelmArgs.url); err != nil {
+	helmURL, err := url.Parse(sourceHelmArgs.url)
+	if err != nil {
 		return fmt.Errorf("url parse failed: %w", err)
+	}
+	if helmURL.Scheme != "http" && helmURL.Scheme != "https" && helmURL.Scheme != sourcev1.HelmRepositoryTypeOCI {
+		return fmt.Errorf("url scheme '%s' not supported, can be: http, https and oci", helmURL.Scheme)
+	}
+	if helmURL.Host == "" {
+		return fmt.Errorf("url host is required")
 	}
 
 	helmRepository := &sourcev1.HelmRepository{
@@ -132,11 +139,7 @@ func createSourceHelmCmdRun(cmd *cobra.Command, args []string) error {
 		},
 	}
 
-	url, err := url.Parse(sourceHelmArgs.url)
-	if err != nil {
-		return fmt.Errorf("failed to parse URL: %w", err)
-	}
-	if url.Scheme == sourcev1.HelmRepositoryTypeOCI {
+	if helmURL.Scheme == sourcev1.HelmRepositoryTypeOCI {
 		helmRepository.Spec.Type = sourcev1.HelmRepositoryTypeOCI
 		helmRepository.Spec.Provider = sourceHelmArgs.ociProvider
 	}

--- a/cmd/flux/create_source_helm_test.go
+++ b/cmd/flux/create_source_helm_test.go
@@ -37,6 +37,12 @@ func TestCreateSourceHelm(t *testing.T) {
 			assertFunc: "assertError",
 		},
 		{
+			name:       "unsupported URL scheme",
+			args:       "create source helm podinfo --url=git://example.com/charts --export",
+			resultFile: "url scheme 'git' not supported, can be: http, https and oci",
+			assertFunc: "assertError",
+		},
+		{
 			name:       "OCI repo",
 			args:       "create source helm podinfo --url=oci://ghcr.io/stefanprodan/charts/podinfo --interval 5m --export",
 			resultFile: "./testdata/create_source_helm/oci.golden",


### PR DESCRIPTION
Reject unsupported URL schemes in `flux create source helm` before the command generates or applies a HelmRepository.

Repro before this patch:

```sh
flux create source helm podinfo --url=git://example.com/charts --export
```

That printed a HelmRepository with `spec.url: git://...`, but the CRD only accepts `http`, `https`, and `oci` URLs. Bit of a papercut, easy to hit when using `--export`.

Now the command fails early with a clear error and keeps the existing `https` and `oci` export paths working.

Tests:

```sh
make tidy fmt vet
make test TEST_ARGS='-run TestCreateSourceHelm -count=1'
```
