### PR TITLE
refactor(api): migrate MakeDependsOn to shared apis/meta func

### DIFF
--- a/cmd/flux/create_helmrelease.go
+++ b/cmd/flux/create_helmrelease.go
@@ -218,7 +218,7 @@ func createHelmReleaseCmdRun(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(helmReleaseArgs.dependsOn) > 0 {
-		ls := utils.MakeDependsOn(helmReleaseArgs.dependsOn)
+		ls := meta.MakeDependsOn(helmReleaseArgs.dependsOn)
 		hrDependsOn := make([]helmv2.DependencyReference, 0, len(ls))
 		for _, d := range ls {
 			hrDependsOn = append(hrDependsOn, helmv2.DependencyReference{

--- a/cmd/flux/create_kustomization.go
+++ b/cmd/flux/create_kustomization.go
@@ -172,7 +172,7 @@ func createKsCmdRun(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(kustomizationArgs.dependsOn) > 0 {
-		ls := utils.MakeDependsOn(kustomizationArgs.dependsOn)
+		ls := meta.MakeDependsOn(kustomizationArgs.dependsOn)
 		ksDependsOn := make([]kustomizev1.DependencyReference, 0, len(ls))
 		for _, d := range ls {
 			ksDependsOn = append(ksDependsOn, kustomizev1.DependencyReference{

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/fluxcd/kustomize-controller/api v1.8.5
 	github.com/fluxcd/notification-controller/api v1.8.4
 	github.com/fluxcd/pkg/apis/event v0.26.0
-	github.com/fluxcd/pkg/apis/meta v1.27.0
+	github.com/fluxcd/pkg/apis/meta v1.28.0
 	github.com/fluxcd/pkg/auth v0.45.0
 	github.com/fluxcd/pkg/chartutil v1.24.0
 	github.com/fluxcd/pkg/envsubst v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -194,8 +194,8 @@ github.com/fluxcd/pkg/apis/event v0.26.0 h1:QzBRz9Qy91jzJmLlOhd4ecp6OWDpMVFvm311
 github.com/fluxcd/pkg/apis/event v0.26.0/go.mod h1:0yy7FMJABzq8PP5/VEi1Gro6ssPaPlH9xuPIoF+Rm6M=
 github.com/fluxcd/pkg/apis/kustomize v1.18.0 h1:FCNjViCLyKYj6lddpnjXybKBTC2eK6eXK9YOaNwLVTM=
 github.com/fluxcd/pkg/apis/kustomize v1.18.0/go.mod h1:mvtMtM4NNLipdCna6DYPC6Bd42xeaF15N+tNO+F6kxY=
-github.com/fluxcd/pkg/apis/meta v1.27.0 h1:EspByEk5j8w3rs1cGbEh9AjSmpDwQIz7DFG/zzqf6uI=
-github.com/fluxcd/pkg/apis/meta v1.27.0/go.mod h1:2t6JyrRfvIBhx6EBnXfFh/6sCCJ1db9WGaqko0JmNOE=
+github.com/fluxcd/pkg/apis/meta v1.28.0 h1:eJjMlLnfObnh23cyUB6xiIwDbgJaRU2MgfzzuilLFxI=
+github.com/fluxcd/pkg/apis/meta v1.28.0/go.mod h1:3DmYMnyH3XdY8/g2gXfsVIGEd/zpcB2PEkuurv2vgHU=
 github.com/fluxcd/pkg/auth v0.45.0 h1:3p/CMdFJ1c8LevdLd2cikackaTW1Tw8JB2xg4YqpP8A=
 github.com/fluxcd/pkg/auth v0.45.0/go.mod h1:/ijjR9G/l6URmEo/zWzpJ3XIMIXWP1Ad7AXTCqmWioY=
 github.com/fluxcd/pkg/cache v0.14.0 h1:wEwJA8NhYj+nH9P6ifcsglDZARWlcbxbmwngGOzfU4c=

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -47,7 +47,6 @@ import (
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
 	notificationv1 "github.com/fluxcd/notification-controller/api/v1"
 	notificationv1b3 "github.com/fluxcd/notification-controller/api/v1beta3"
-	"github.com/fluxcd/pkg/apis/meta"
 	runclient "github.com/fluxcd/pkg/runtime/client"
 	"github.com/fluxcd/pkg/version"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
@@ -229,26 +228,6 @@ func ParseObjectKindNameNamespace(input string) (kind, name, namespace string) {
 	}
 
 	return kind, name, namespace
-}
-
-func MakeDependsOn(deps []string) []meta.NamespacedObjectReference {
-	refs := []meta.NamespacedObjectReference{}
-	for _, dep := range deps {
-		parts := strings.Split(dep, "/")
-		depNamespace := ""
-		depName := ""
-		if len(parts) > 1 {
-			depNamespace = parts[0]
-			depName = parts[1]
-		} else {
-			depName = parts[0]
-		}
-		refs = append(refs, meta.NamespacedObjectReference{
-			Namespace: depNamespace,
-			Name:      depName,
-		})
-	}
-	return refs
 }
 
 func ValidateComponents(components []string) error {

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -21,10 +21,7 @@ package utils
 
 import (
 	"path/filepath"
-	"reflect"
 	"testing"
-
-	"github.com/fluxcd/pkg/apis/meta"
 )
 
 func TestCompatibleVersion(t *testing.T) {
@@ -76,28 +73,6 @@ func TestParseObjectKindNameNamespace(t *testing.T) {
 				t.Errorf("namespace = %s, want %s", gotNamespace, tt.wantNamespace)
 			}
 		})
-	}
-}
-
-func TestMakeDependsOn(t *testing.T) {
-	input := []string{
-		"someNSA/someNameA",
-		"someNSB/someNameB",
-		"someNameC",
-		"someNSD/",
-		"",
-	}
-	want := []meta.NamespacedObjectReference{
-		{Namespace: "someNSA", Name: "someNameA"},
-		{Namespace: "someNSB", Name: "someNameB"},
-		{Namespace: "", Name: "someNameC"},
-		{Namespace: "someNSD", Name: ""},
-		{Namespace: "", Name: ""},
-	}
-
-	got := MakeDependsOn(input)
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("MakeDependsOn() = %v, want %v", got, want)
 	}
 }
 


### PR DESCRIPTION
### Summary

This PR replaces the local `MakeDependsOn` helper in `internal/utils` with the shared `meta.MakeDependsOn` from `apis/meta`, and updates the Flux CLI callers to consume the new `meta.DependencyReference` type.

### Changes

- Removed `MakeDependsOn` helper from `internal/utils/utils.go`
- Removed `TestMakeDependsOn` from `internal/utils/utils_test.go`. Coverage now lives in `apis/meta`
- Updated `create_helmrelease.go` and `create_kustomization.go` to use `meta.MakeDependsOn`

### Motivation

Centralizing on a shared helper ensures consistent dependency parsing behavior across the Flux CLI and controllers, and enables downstream CEL-based readiness expression support.

### Notes

- Backward behavior preserved.
- Based on the work of @Iam-Karan-Suresh (xref: fluxcd/pkg#1129), thank you very much! 🚀