### PR TITLE
Reject extra args in get commands

### DIFF
--- a/cmd/flux/get.go
+++ b/cmd/flux/get.go
@@ -136,6 +136,10 @@ type getCommand struct {
 }
 
 func (get getCommand) run(cmd *cobra.Command, args []string) error {
+	if len(args) > 1 {
+		return fmt.Errorf("expected at most one resource name, got %d", len(args))
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
 	defer cancel()
 

--- a/cmd/flux/get_test.go
+++ b/cmd/flux/get_test.go
@@ -84,6 +84,11 @@ func Test_GetCmdErrors(t *testing.T) {
 			args:   "get helmrelease -n " + tmpl["fluxns"],
 			assert: assertError(fmt.Sprintf("no HelmRelease objects found in \"%s\" namespace", tmpl["fluxns"])),
 		},
+		{
+			name:   "rejects extra positional args",
+			args:   "get sources git repo-a repo-b -n " + tmpl["fluxns"],
+			assert: assertError("expected at most one resource name, got 2"),
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Tiny CLI papercut fix.

`flux get ...` only accepts one resource name, but right now extra args get silently ignored. Kinda sneaky.

Repro:

```sh
flux get sources git podinfo podinfo-shard1 -n flux-system
```

Before:

- succeeds
- prints the result for `podinfo`
- ignores `podinfo-shard1`

After:

- fails fast with `expected at most one resource name, got 2`

Checks:

- `make tidy fmt vet && make test`
