### PR TITLE
Support specifing sparseCheckout in flux bootstrap

### DIFF
--- a/cmd/flux/bootstrap.go
+++ b/cmd/flux/bootstrap.go
@@ -47,6 +47,7 @@ type bootstrapFlags struct {
 
 	branch            string
 	recurseSubmodules bool
+	sparseCheckout    []string
 	manifestsPath     string
 
 	defaultComponents  []string
@@ -109,6 +110,8 @@ func init() {
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapArgs.branch, "branch", bootstrapDefaultBranch, "Git branch")
 	bootstrapCmd.PersistentFlags().BoolVar(&bootstrapArgs.recurseSubmodules, "recurse-submodules", false,
 		"when enabled, configures the GitRepository source to initialize and include Git submodules in the artifact it produces")
+	bootstrapCmd.PersistentFlags().StringSliceVar(&bootstrapArgs.sparseCheckout, "sparse-checkout", nil,
+		"list of directories to be included in the GitRepository sparse checkout, the configured --path must be one of them, accepts comma-separated values")
 
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapArgs.manifestsPath, "manifests", "", "path to the manifest directory")
 

--- a/cmd/flux/bootstrap_bitbucket_server.go
+++ b/cmd/flux/bootstrap_bitbucket_server.go
@@ -253,6 +253,7 @@ func bootstrapBServerCmdRun(cmd *cobra.Command, args []string) error {
 		TargetPath:        bServerArgs.path.ToSlash(),
 		ManifestFile:      sync.MakeDefaultOptions().ManifestFile,
 		RecurseSubmodules: bootstrapArgs.recurseSubmodules,
+		SparseCheckout:    bootstrapArgs.sparseCheckout,
 	}
 
 	entityList, err := bootstrap.LoadEntityListFromPath(bootstrapArgs.gpgKeyRingPath)

--- a/cmd/flux/bootstrap_git.go
+++ b/cmd/flux/bootstrap_git.go
@@ -311,6 +311,7 @@ func bootstrapGitCmdRun(cmd *cobra.Command, args []string) error {
 		TargetPath:        gitArgs.path.ToSlash(),
 		ManifestFile:      sync.MakeDefaultOptions().ManifestFile,
 		RecurseSubmodules: bootstrapArgs.recurseSubmodules,
+		SparseCheckout:    bootstrapArgs.sparseCheckout,
 	}
 	if gitProvider != "" {
 		syncOpts.Provider = gitProvider

--- a/cmd/flux/bootstrap_gitea.go
+++ b/cmd/flux/bootstrap_gitea.go
@@ -232,6 +232,7 @@ func bootstrapGiteaCmdRun(cmd *cobra.Command, args []string) error {
 		TargetPath:        giteaArgs.path.ToSlash(),
 		ManifestFile:      sync.MakeDefaultOptions().ManifestFile,
 		RecurseSubmodules: bootstrapArgs.recurseSubmodules,
+		SparseCheckout:    bootstrapArgs.sparseCheckout,
 	}
 
 	entityList, err := bootstrap.LoadEntityListFromPath(bootstrapArgs.gpgKeyRingPath)

--- a/cmd/flux/bootstrap_github.go
+++ b/cmd/flux/bootstrap_github.go
@@ -239,6 +239,7 @@ func bootstrapGitHubCmdRun(cmd *cobra.Command, args []string) error {
 		TargetPath:        githubArgs.path.ToSlash(),
 		ManifestFile:      sync.MakeDefaultOptions().ManifestFile,
 		RecurseSubmodules: bootstrapArgs.recurseSubmodules,
+		SparseCheckout:    bootstrapArgs.sparseCheckout,
 	}
 
 	entityList, err := bootstrap.LoadEntityListFromPath(bootstrapArgs.gpgKeyRingPath)

--- a/cmd/flux/bootstrap_gitlab.go
+++ b/cmd/flux/bootstrap_gitlab.go
@@ -287,6 +287,7 @@ func bootstrapGitLabCmdRun(cmd *cobra.Command, args []string) error {
 		TargetPath:        gitlabArgs.path.ToSlash(),
 		ManifestFile:      sync.MakeDefaultOptions().ManifestFile,
 		RecurseSubmodules: bootstrapArgs.recurseSubmodules,
+		SparseCheckout:    bootstrapArgs.sparseCheckout,
 	}
 
 	entityList, err := bootstrap.LoadEntityListFromPath(bootstrapArgs.gpgKeyRingPath)

--- a/pkg/manifestgen/sync/options.go
+++ b/pkg/manifestgen/sync/options.go
@@ -34,6 +34,7 @@ type Options struct {
 	ManifestFile      string
 	RecurseSubmodules bool
 	Provider          string
+	SparseCheckout    []string
 }
 
 func MakeDefaultOptions() Options {

--- a/pkg/manifestgen/sync/sync.go
+++ b/pkg/manifestgen/sync/sync.go
@@ -69,6 +69,7 @@ func Generate(options Options) (*manifestgen.Manifest, error) {
 			},
 			RecurseSubmodules: options.RecurseSubmodules,
 			Provider:          options.Provider,
+			SparseCheckout:    options.SparseCheckout,
 		},
 	}
 


### PR DESCRIPTION
fix: #5917 

## Summary

Add `--sparse-checkout` flag to `flux bootstrap` (all providers: github, gitlab, gitea, git, bitbucket-server) that sets `spec.sparseCheckout` on the generated `flux-system` GitRepository.

This allows users who store Kubernetes manifests in a large monorepo to limit which directories are checked out by Flux, reducing clone size and improving performance.

## Changes

- Added `--sparse-checkout` flag to the `bootstrap` persistent flags (comma-separated list of directories)
- Passed `SparseCheckout` field through to `sync.Options` and then to the generated `GitRepository` spec
- Applied consistently to all bootstrap providers: `github`, `gitlab`, `gitea`, `git`, `bitbucket-server`

### Example usage

```sh
flux bootstrap github \
  --owner=my-org \
  --repository=fleet \
  --path=clusters/prod \
  --sparse-checkout=clusters/prod,apps
```

> **Note:** The directory specified via `--path` must be included in the `--sparse-checkout` list, as documented in the flag help text.

## Testing

Verified end-to-end behavior using my personal GitHub repository. Bootstrapped Flux with the `--sparse-checkout` flag and confirmed that the generated `flux-system` GitRepository manifest contains the expected `spec.sparseCheckout` entries.