### PR TITLE
Add checksum verification for SOPS in e2e workflows

### DIFF
--- a/.github/workflows/e2e-azure.yaml
+++ b/.github/workflows/e2e-azure.yaml
@@ -43,10 +43,12 @@ jobs:
       - name: Setup SOPS
         run: |
           mkdir -p $HOME/.local/bin
-          wget -O $HOME/.local/bin/sops https://github.com/mozilla/sops/releases/download/v$SOPS_VER/sops-v$SOPS_VER.linux
+          wget -O $HOME/.local/bin/sops https://github.com/getsops/sops/releases/download/v$SOPS_VER/sops-v$SOPS_VER.linux
+          echo "$SOPS_CHECKSUM  $HOME/.local/bin/sops" | sha256sum -c -
           chmod +x $HOME/.local/bin/sops
         env:
           SOPS_VER: 3.7.1
+          SOPS_CHECKSUM: "185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74"
       - name: Authenticate to Azure
         uses: Azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v1.4.6
         with:

--- a/.github/workflows/e2e-gcp.yaml
+++ b/.github/workflows/e2e-gcp.yaml
@@ -43,10 +43,12 @@ jobs:
       - name: Setup SOPS
         run: |
           mkdir -p $HOME/.local/bin
-          wget -O $HOME/.local/bin/sops https://github.com/mozilla/sops/releases/download/v$SOPS_VER/sops-v$SOPS_VER.linux
+          wget -O $HOME/.local/bin/sops https://github.com/getsops/sops/releases/download/v$SOPS_VER/sops-v$SOPS_VER.linux
+          echo "$SOPS_CHECKSUM  $HOME/.local/bin/sops" | sha256sum -c -
           chmod +x $HOME/.local/bin/sops
         env:
           SOPS_VER: 3.7.1
+          SOPS_CHECKSUM: "185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74"
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         id: 'auth'


### PR DESCRIPTION
Issue: https://github.com/fluxcd/flux2/issues/5958

To remediate hardening issue in e2e-azure and e2e-gcp CI workflows.
They were both downloading SOPS binary and making it executable without checksum verification.
SOPS would run during integration tests and give full access to runner environment, Azure credentials and GCP credentials.

The mozilla/sops redirects to getsops/sops for downloading the project so it was updated to getsops/sops.