### PR TITLE
fix(goreleaser): make Homebrew formula pass brew audit

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -81,13 +81,13 @@ brews:
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     directory: Formula
     homepage: "https://fluxcd.io/"
-    description: "Flux CLI"
+    description: "CLI for GitOps continuous delivery"
     install: |
       bin.install "flux"
 
       generate_completions_from_executable(bin/"flux", "completion")
     test: |
-      system "#{bin}/flux --version"
+      system bin/"flux", "--version"
 dockers:
 - image_templates:
     - 'fluxcd/flux-cli:{{ .Tag }}-amd64'


### PR DESCRIPTION
Fixes two common `brew audit --strict` failures in the generated Homebrew formula:

- Description no longer starts with the formula name.
- Test `system` call uses separate arguments instead of a shell string.

This ensures future releases of Flux publish a compliant formula to fluxcd/homebrew-tap.

Related to fluxcd/homebrew-tap#17.