### PR TITLE
Fix `--in-memory-build` restricting disk access

### DIFF
--- a/cmd/flux/build_kustomization.go
+++ b/cmd/flux/build_kustomization.go
@@ -86,7 +86,7 @@ func init() {
 		"When enabled, the post build substitutions will fail if a var without a default value is declared in files but is missing from the input vars.")
 	buildKsCmd.Flags().BoolVarP(&buildKsArgs.recursive, "recursive", "r", false, "Recursively build Kustomizations")
 	buildKsCmd.Flags().StringToStringVar(&buildKsArgs.localSources, "local-sources", nil, "Comma-separated list of repositories in format: Kind/namespace/name=path")
-	buildKsCmd.Flags().BoolVar(&buildKsArgs.inMemoryBuild, "in-memory-build", false,
+	buildKsCmd.Flags().BoolVar(&buildKsArgs.inMemoryBuild, "in-memory-build", true,
 		"Use in-memory filesystem during build.")
 	buildCmd.AddCommand(buildKsCmd)
 }

--- a/cmd/flux/diff_kustomization.go
+++ b/cmd/flux/diff_kustomization.go
@@ -77,7 +77,7 @@ func init() {
 		"When enabled, the post build substitutions will fail if a var without a default value is declared in files but is missing from the input vars.")
 	diffKsCmd.Flags().BoolVarP(&diffKsArgs.recursive, "recursive", "r", false, "Recursively diff Kustomizations")
 	diffKsCmd.Flags().StringToStringVar(&diffKsArgs.localSources, "local-sources", nil, "Comma-separated list of repositories in format: Kind/namespace/name=path")
-	diffKsCmd.Flags().BoolVar(&diffKsArgs.inMemoryBuild, "in-memory-build", false,
+	diffKsCmd.Flags().BoolVar(&diffKsArgs.inMemoryBuild, "in-memory-build", true,
 		"Use in-memory filesystem during build.")
 	diffKsCmd.Flags().BoolVar(&diffKsArgs.ignoreNotFound, "ignore-not-found", false,
 		"Ignore Kustomization not found errors on the cluster when diffing.")

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -106,16 +106,7 @@ func (inMemoryFsBackend) Generate(gen *kustomize.Generator, dirPath string) (fil
 		return nil, "", action, fmt.Errorf("failed to eval symlinks: %w", err)
 	}
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		return nil, "", action, fmt.Errorf("failed to get working directory: %w", err)
-	}
-
-	diskFS, err := buildfs.MakeFsOnDiskSecure(cwd)
-	if err != nil {
-		return nil, "", action, fmt.Errorf("failed to create secure filesystem: %w", err)
-	}
-	fs := buildfs.MakeFsInMemory(diskFS)
+	fs := buildfs.MakeFsInMemory(filesys.MakeFsOnDisk())
 
 	if err := fs.WriteFile(filepath.Join(absDirPath, filepath.Base(kfilePath)), manifest); err != nil {
 		return nil, "", action, err

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -786,7 +786,7 @@ resources:
 func Test_inMemoryFsBackend_Generate_outsideCwd(t *testing.T) {
 	// Two sibling temp dirs: one for the source tree, one as cwd.
 	// The kustomization references a file that exists on disk but is
-	// outside cwd, so the secure filesystem must reject it.
+	// outside cwd. The in-memory backend must allow this.
 	//
 	// parentDir/
 	//   outside/configmap.yaml      (exists but outside cwd)
@@ -818,7 +818,6 @@ resources:
 		t.Fatal(err)
 	}
 
-	// Set cwd to cwdDir so the secure root excludes outsideDir.
 	chdirTemp(t, cwdDir)
 
 	ks := unstructured.Unstructured{Object: map[string]interface{}{
@@ -834,10 +833,17 @@ resources:
 		t.Fatalf("Generate: %v", err)
 	}
 
-	// Build must fail because the resource is outside the secure root.
-	_, err = kustomize.Build(fs, dir)
-	if err == nil {
-		t.Fatal("expected error when referencing resource outside cwd, got nil")
+	m, err := kustomize.Build(fs, dir)
+	if err != nil {
+		t.Fatalf("Build should succeed for resources outside cwd: %v", err)
+	}
+
+	resources := m.Resources()
+	if len(resources) == 0 {
+		t.Fatal("expected at least one resource")
+	}
+	if resources[0].GetName() != "outside-cm" {
+		t.Errorf("expected ConfigMap name outside-cm, got %s", resources[0].GetName())
 	}
 }
 


### PR DESCRIPTION
Addresses https://github.com/fluxcd/flux2/issues/5968

The PR that introduced the bug https://github.com/fluxcd/flux2/pull/5794 implemented a new `--in-memory-build` option; it wraps a 'filesystem' instance, specifically the `buildfs.MakeFsOnDiskSecure`. This restricts access to files in PWD.

The fix is pretty straightforward; use the unrestricted `MakeFsOnDisk` option. I've also updated one of the tests accordingly, as it wasn't testing the desired behavior.

---

Side-note: as far as I can see, the `MakeFsOnDiskSecure` logic is only implemented for the `flux bootstrap` command, which is likely why this issue didn't occur previously 🤔 