### PR TITLE
test: use a unique temp kubeconfig path in the CLI test env

### DIFF
--- a/cmd/flux/main_test.go
+++ b/cmd/flux/main_test.go
@@ -24,12 +24,10 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"text/template"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/mattn/go-shellwords"
@@ -184,8 +182,17 @@ func NewTestEnvKubeManager(testClusterMode TestClusterMode) (*testEnvKubeManager
 			return nil, err
 		}
 
-		tmpFilename := filepath.Join("/tmp", "kubeconfig-"+time.Nanosecond.String())
-		os.WriteFile(tmpFilename, kubeConfig, 0o600)
+		tmpFile, err := os.CreateTemp("", "kubeconfig-")
+		if err != nil {
+			return nil, err
+		}
+		tmpFilename := tmpFile.Name()
+		if _, err := tmpFile.Write(kubeConfig); err != nil {
+			return nil, err
+		}
+		if err := tmpFile.Close(); err != nil {
+			return nil, err
+		}
 		k8sClient, err := client.NewWithWatch(cfg, client.Options{
 			Scheme: utils.NewScheme(),
 		})


### PR DESCRIPTION
In `cmd/flux/main_test.go`, `NewTestEnvKubeManager` builds its temp kubeconfig path from `time.Nanosecond.String()`:

```go
tmpKubeConfigPath := filepath.Join("/tmp", "kubeconfig-"+time.Nanosecond.String())
```

`time.Nanosecond` is the `time.Duration` constant (value `1`), and `Duration.String()` renders it as the literal `"1ns"` — it is **not** a timestamp. So the path is hard-coded to `/tmp/kubeconfig-1ns` on every run instead of being unique, which risks collisions and stale-file reuse across concurrent or repeated envtest runs (`TestMain` sets this up for the whole unit suite).

This uses `os.CreateTemp("", "kubeconfig-")` to get a guaranteed-unique path in the OS temp dir, and checks the write/close errors that were previously ignored. (`NewTestEnvKubeManager` is called from `TestMain`, so there is no `*testing.T` for `t.TempDir()`.)

Test-harness only; no CLI behaviour changed. Verified with `go test --tags=unit ./cmd/flux/` (envtest) — passes; `gofmt`/`go vet` clean.

Assisted-by: Claude Code (Anthropic, Opus 4.8)