### PR TITLE
Include source-watcher to oci flux-manifests

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -130,7 +130,7 @@ jobs:
         run: |
           mkdir -p ./ghcr.io/flux-system
           flux install --registry=ghcr.io/fluxcd \
-          --components-extra=image-reflector-controller,image-automation-controller \
+          --components-extra=image-reflector-controller,image-automation-controller,source-watcher \
           --export > ./ghcr.io/flux-system/gotk-components.yaml
 
           cd ./ghcr.io && flux push artifact \
@@ -142,7 +142,7 @@ jobs:
         run: |
           mkdir -p ./docker.io/flux-system
           flux install --registry=docker.io/fluxcd \
-          --components-extra=image-reflector-controller,image-automation-controller \
+          --components-extra=image-reflector-controller,image-automation-controller,source-watcher \
           --export > ./docker.io/flux-system/gotk-components.yaml
 
           cd ./docker.io && flux push artifact \

--- a/cmd/flux/install.go
+++ b/cmd/flux/install.go
@@ -53,11 +53,14 @@ If a previous version is installed, then an in-place upgrade will be performed.`
   # Install all components including the image automation ones
   flux install --components-extra="image-reflector-controller,image-automation-controller"
 
+  # Install all components including source-watcher
+  flux install --components-extra="source-watcher"
+
   # Install Flux onto tainted Kubernetes nodes
   flux install --toleration-keys=node.kubernetes.io/dedicated-to-flux
 
   # Dry-run install
-  flux install --export | kubectl apply --dry-run=client -f- 
+  flux install --export | kubectl apply --dry-run=client -f-
 
   # Write install manifests to file
   flux install --export > flux-system.yaml`,


### PR DESCRIPTION
The source-watcher controller is currently not included in the oci://ghcr.io/fluxcd/flux-manifests which is part of a release bundle.

Closes: #5991
xref:  #5881