### PR TITLE
Guard against Kustomization tree cycles

### DIFF
--- a/cmd/flux/testdata/tree/kustomizations.yaml
+++ b/cmd/flux/testdata/tree/kustomizations.yaml
@@ -86,3 +86,38 @@ status:
       status: "True"
       type: Ready
 ---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cycle-a
+  namespace: {{ .fluxns }}
+spec:
+  interval: 5m
+  path: ./cycle-a
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+status:
+  inventory:
+    entries:
+      - id: {{ .fluxns }}_cycle-b_kustomize.toolkit.fluxcd.io_Kustomization
+        v: v1
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cycle-b
+  namespace: {{ .fluxns }}
+spec:
+  interval: 5m
+  path: ./cycle-b
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+status:
+  inventory:
+    entries:
+      - id: {{ .fluxns }}_cycle-a_kustomize.toolkit.fluxcd.io_Kustomization
+        v: v1

--- a/cmd/flux/testdata/tree/tree-cycle.golden
+++ b/cmd/flux/testdata/tree/tree-cycle.golden
@@ -1,0 +1,3 @@
+Kustomization/{{ .fluxns }}/cycle-a
+└── Kustomization/{{ .fluxns }}/cycle-b
+

--- a/cmd/flux/tree_kustomization.go
+++ b/cmd/flux/tree_kustomization.go
@@ -101,7 +101,7 @@ func treeKsCmdRun(cmd *cobra.Command, args []string) error {
 		GroupKind: schema.GroupKind{Group: kustomizev1.GroupVersion.Group, Kind: kustomizev1.KustomizationKind},
 	})
 
-	err = treeKustomization(ctx, kTree, k, kubeClient, treeKsArgs.compact)
+	err = treeKustomization(ctx, kTree, k, kubeClient, treeKsArgs.compact, map[client.ObjectKey]struct{}{})
 	if err != nil {
 		return err
 	}
@@ -126,7 +126,11 @@ func treeKsCmdRun(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func treeKustomization(ctx context.Context, tree tree.ObjMetadataTree, item *kustomizev1.Kustomization, kubeClient client.Client, compact bool) error {
+func treeKustomization(ctx context.Context, tree tree.ObjMetadataTree, item *kustomizev1.Kustomization, kubeClient client.Client, compact bool, ancestors map[client.ObjectKey]struct{}) error {
+	itemKey := client.ObjectKeyFromObject(item)
+	ancestors[itemKey] = struct{}{}
+	defer delete(ancestors, itemKey)
+
 	if item.Status.Inventory == nil || len(item.Status.Inventory.Entries) == 0 {
 		return nil
 	}
@@ -143,11 +147,24 @@ func treeKustomization(ctx context.Context, tree tree.ObjMetadataTree, item *kus
 			continue
 		}
 
-		if objMetadata.GroupKind.Group == kustomizev1.GroupVersion.Group &&
-			objMetadata.GroupKind.Kind == kustomizev1.KustomizationKind &&
+		isKustomization := objMetadata.GroupKind.Group == kustomizev1.GroupVersion.Group &&
+			objMetadata.GroupKind.Kind == kustomizev1.KustomizationKind
+
+		if isKustomization &&
 			objMetadata.Namespace == item.Namespace &&
 			objMetadata.Name == item.Name {
 			continue
+		}
+
+		canRecurse := isKustomization && item.Spec.KubeConfig == nil
+		if canRecurse {
+			key := client.ObjectKey{
+				Namespace: objMetadata.Namespace,
+				Name:      objMetadata.Name,
+			}
+			if _, ok := ancestors[key]; ok {
+				continue
+			}
 		}
 
 		ks := tree.Add(objMetadata)
@@ -171,10 +188,7 @@ func treeKustomization(ctx context.Context, tree tree.ObjMetadataTree, item *kus
 			}
 		}
 
-		if objMetadata.GroupKind.Group == kustomizev1.GroupVersion.Group &&
-			objMetadata.GroupKind.Kind == kustomizev1.KustomizationKind &&
-			// skip kustomization if it targets a remote clusters
-			item.Spec.KubeConfig == nil {
+		if canRecurse {
 			k := &kustomizev1.Kustomization{}
 			err = kubeClient.Get(ctx, client.ObjectKey{
 				Namespace: objMetadata.Namespace,
@@ -183,7 +197,7 @@ func treeKustomization(ctx context.Context, tree tree.ObjMetadataTree, item *kus
 			if err != nil {
 				return fmt.Errorf("failed to find object: %w", err)
 			}
-			err := treeKustomization(ctx, ks, k, kubeClient, compact)
+			err := treeKustomization(ctx, ks, k, kubeClient, compact, ancestors)
 			if err != nil {
 				return err
 			}

--- a/cmd/flux/tree_kustomization_test.go
+++ b/cmd/flux/tree_kustomization_test.go
@@ -48,9 +48,23 @@ func TestTree(t *testing.T) {
 			"testdata/tree/kustomizations.yaml",
 			"testdata/tree/tree-empty.golden",
 		},
+		{
+			"tree kustomization cycle",
+			"tree kustomization cycle-a --timeout=1s",
+			"testdata/tree/kustomizations.yaml",
+			"testdata/tree/tree-cycle.golden",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			previousTimeout := rootArgs.timeout
+			timeoutFlag := rootCmd.PersistentFlags().Lookup("timeout")
+			previousTimeoutChanged := timeoutFlag.Changed
+			t.Cleanup(func() {
+				rootArgs.timeout = previousTimeout
+				timeoutFlag.Changed = previousTimeoutChanged
+			})
+
 			tmpl := map[string]string{
 				"fluxns": allocateNamespace("flux-system"),
 			}


### PR DESCRIPTION
Closes #5998

## What

Guard `flux tree kustomization` recursion with the current traversal
path. Cyclic inventory paths now stop at an ancestor instead of querying
the API server until the command times out.

Path-local tracking keeps shared non-cyclic subtrees traversable under
independent branches.

## Tests

- `make tidy fmt vet && make test`

## Local testing

- Built `flux` from `e8594afcd6c29c9a573464892d0c645c1e2cdf65`.
- Against a disposable Kubernetes 1.36.2 envtest API server, seeded a
  two-object Kustomization inventory cycle. The base binary exited 1 at
  the two-second timeout; the candidate exited 0 and printed `cycle-a`
  followed by `cycle-b` once each.

Assisted-by: codex/gpt-5
