### PR TITLE
Add suspend selector to get commands

### DIFF
--- a/cmd/flux/get.go
+++ b/cmd/flux/get.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/fluxcd/pkg/apis/meta"
 
+	"github.com/fluxcd/flux2/v2/internal/flags"
 	"github.com/fluxcd/flux2/v2/internal/utils"
 	"github.com/fluxcd/flux2/v2/pkg/printers"
 )
@@ -63,14 +64,21 @@ var getCmd = &cobra.Command{
 }
 
 type GetFlags struct {
-	allNamespaces  bool
-	noHeader       bool
-	statusSelector string
-	labelSelector  string
-	watch          bool
+	allNamespaces   bool
+	noHeader        bool
+	statusSelector  string
+	suspendSelector flags.SuspendSelector
+	labelSelector   string
+	watch           bool
 }
 
-var getArgs GetFlags
+func newGetFlags() GetFlags {
+	return GetFlags{
+		suspendSelector: flags.SuspendSelectorAny,
+	}
+}
+
+var getArgs = newGetFlags()
 
 func init() {
 	getCmd.PersistentFlags().BoolVarP(&getArgs.allNamespaces, "all-namespaces", "A", false,
@@ -79,6 +87,7 @@ func init() {
 	getCmd.PersistentFlags().BoolVarP(&getArgs.watch, "watch", "w", false, "After listing/getting the requested object, watch for changes.")
 	getCmd.PersistentFlags().StringVar(&getArgs.statusSelector, "status-selector", "",
 		"specify the status condition name and the desired state to filter the get result, e.g. ready=false or ready!=true")
+	getCmd.PersistentFlags().Var(&getArgs.suspendSelector, "suspend-selector", getArgs.suspendSelector.Description())
 	getCmd.PersistentFlags().StringVarP(&getArgs.labelSelector, "label-selector", "l", "",
 		"filter objects by label selector")
 	rootCmd.AddCommand(getCmd)
@@ -89,6 +98,7 @@ type summarisable interface {
 	summariseItem(i int, includeNamespace bool, includeKind bool) []string
 	headers(includeNamespace bool) []string
 	statusSelectorMatches(i int, conditionType, conditionStatus string) bool
+	isSuspended(i int) bool
 }
 
 // --- these help with implementations of summarisable
@@ -260,7 +270,7 @@ func getRowsToPrint(getAll bool, list summarisable) ([][]string, error) {
 	}
 	var rows [][]string
 	for i := 0; i < list.len(); i++ {
-		if filter(i) {
+		if filter(i) && getArgs.suspendSelector.Matches(list.isSuspended(i)) {
 			row := list.summariseItem(i, getArgs.allNamespaces, getAll)
 			rows = append(rows, row)
 		}

--- a/cmd/flux/get_alert.go
+++ b/cmd/flux/get_alert.go
@@ -94,3 +94,7 @@ func (s alertListAdapter) headers(includeNamespace bool) []string {
 func (s alertListAdapter) statusSelectorMatches(i int, conditionType, conditionStatus string) bool {
 	return readyStatusMatches(conditionType, conditionStatus)
 }
+
+func (s alertListAdapter) isSuspended(i int) bool {
+	return s.Items[i].Spec.Suspend
+}

--- a/cmd/flux/get_alertprovider.go
+++ b/cmd/flux/get_alertprovider.go
@@ -90,3 +90,7 @@ func (s alertProviderListAdapter) headers(includeNamespace bool) []string {
 func (s alertProviderListAdapter) statusSelectorMatches(i int, conditionType, conditionStatus string) bool {
 	return readyStatusMatches(conditionType, conditionStatus)
 }
+
+func (s alertProviderListAdapter) isSuspended(i int) bool {
+	return s.Items[i].Spec.Suspend
+}

--- a/cmd/flux/get_artifact_generator.go
+++ b/cmd/flux/get_artifact_generator.go
@@ -91,3 +91,7 @@ func (s artifactGeneratorListAdapter) statusSelectorMatches(i int, conditionType
 	item := s.Items[i]
 	return statusMatches(conditionType, conditionStatus, item.Status.Conditions)
 }
+
+func (s artifactGeneratorListAdapter) isSuspended(i int) bool {
+	return s.Items[i].IsDisabled()
+}

--- a/cmd/flux/get_helmrelease.go
+++ b/cmd/flux/get_helmrelease.go
@@ -138,3 +138,7 @@ func (a helmReleaseListAdapter) statusSelectorMatches(i int, conditionType, cond
 	item := a.Items[i]
 	return statusMatches(conditionType, conditionStatus, item.Status.Conditions)
 }
+
+func (a helmReleaseListAdapter) isSuspended(i int) bool {
+	return a.Items[i].Spec.Suspend
+}

--- a/cmd/flux/get_image_policy.go
+++ b/cmd/flux/get_image_policy.go
@@ -94,3 +94,7 @@ func (s imagePolicyListAdapter) statusSelectorMatches(i int, conditionType, cond
 	item := s.Items[i]
 	return statusMatches(conditionType, conditionStatus, item.Status.Conditions)
 }
+
+func (s imagePolicyListAdapter) isSuspended(i int) bool {
+	return s.Items[i].Spec.Suspend
+}

--- a/cmd/flux/get_image_repository.go
+++ b/cmd/flux/get_image_repository.go
@@ -98,3 +98,7 @@ func (s imageRepositoryListAdapter) statusSelectorMatches(i int, conditionType, 
 	item := s.Items[i]
 	return statusMatches(conditionType, conditionStatus, item.Status.Conditions)
 }
+
+func (s imageRepositoryListAdapter) isSuspended(i int) bool {
+	return s.Items[i].Spec.Suspend
+}

--- a/cmd/flux/get_image_update.go
+++ b/cmd/flux/get_image_update.go
@@ -98,3 +98,7 @@ func (s imageUpdateAutomationListAdapter) statusSelectorMatches(i int, condition
 	item := s.Items[i]
 	return statusMatches(conditionType, conditionStatus, item.Status.Conditions)
 }
+
+func (s imageUpdateAutomationListAdapter) isSuspended(i int) bool {
+	return s.Items[i].Spec.Suspend
+}

--- a/cmd/flux/get_kustomization.go
+++ b/cmd/flux/get_kustomization.go
@@ -124,3 +124,7 @@ func (a kustomizationListAdapter) statusSelectorMatches(i int, conditionType, co
 	item := a.Items[i]
 	return statusMatches(conditionType, conditionStatus, item.Status.Conditions)
 }
+
+func (a kustomizationListAdapter) isSuspended(i int) bool {
+	return a.Items[i].Spec.Suspend
+}

--- a/cmd/flux/get_receiver.go
+++ b/cmd/flux/get_receiver.go
@@ -91,3 +91,7 @@ func (s receiverListAdapter) statusSelectorMatches(i int, conditionType, conditi
 	item := s.Items[i]
 	return statusMatches(conditionType, conditionStatus, item.Status.Conditions)
 }
+
+func (s receiverListAdapter) isSuspended(i int) bool {
+	return s.Items[i].Spec.Suspend
+}

--- a/cmd/flux/get_source_bucket.go
+++ b/cmd/flux/get_source_bucket.go
@@ -101,3 +101,7 @@ func (a bucketListAdapter) statusSelectorMatches(i int, conditionType, condition
 	item := a.Items[i]
 	return statusMatches(conditionType, conditionStatus, item.Status.Conditions)
 }
+
+func (a bucketListAdapter) isSuspended(i int) bool {
+	return a.Items[i].Spec.Suspend
+}

--- a/cmd/flux/get_source_chart.go
+++ b/cmd/flux/get_source_chart.go
@@ -102,3 +102,7 @@ func (a helmChartListAdapter) statusSelectorMatches(i int, conditionType, condit
 	item := a.Items[i]
 	return statusMatches(conditionType, conditionStatus, item.Status.Conditions)
 }
+
+func (a helmChartListAdapter) isSuspended(i int) bool {
+	return a.Items[i].Spec.Suspend
+}

--- a/cmd/flux/get_source_external.go
+++ b/cmd/flux/get_source_external.go
@@ -106,3 +106,7 @@ func (a externalArtifactListAdapter) statusSelectorMatches(i int, conditionType,
 	item := a.Items[i]
 	return statusMatches(conditionType, conditionStatus, item.Status.Conditions)
 }
+
+func (a externalArtifactListAdapter) isSuspended(i int) bool {
+	return false
+}

--- a/cmd/flux/get_source_git.go
+++ b/cmd/flux/get_source_git.go
@@ -101,3 +101,7 @@ func (a gitRepositoryListAdapter) statusSelectorMatches(i int, conditionType, co
 	item := a.Items[i]
 	return statusMatches(conditionType, conditionStatus, item.Status.Conditions)
 }
+
+func (a gitRepositoryListAdapter) isSuspended(i int) bool {
+	return a.Items[i].Spec.Suspend
+}

--- a/cmd/flux/get_source_helm.go
+++ b/cmd/flux/get_source_helm.go
@@ -107,3 +107,7 @@ func (a helmRepositoryListAdapter) statusSelectorMatches(i int, conditionType, c
 	item := a.Items[i]
 	return statusMatches(conditionType, conditionStatus, item.Status.Conditions)
 }
+
+func (a helmRepositoryListAdapter) isSuspended(i int) bool {
+	return a.Items[i].Spec.Suspend
+}

--- a/cmd/flux/get_source_oci.go
+++ b/cmd/flux/get_source_oci.go
@@ -101,3 +101,7 @@ func (a ociRepositoryListAdapter) statusSelectorMatches(i int, conditionType, co
 	item := a.Items[i]
 	return statusMatches(conditionType, conditionStatus, item.Status.Conditions)
 }
+
+func (a ociRepositoryListAdapter) isSuspended(i int) bool {
+	return a.Items[i].Spec.Suspend
+}

--- a/cmd/flux/get_suspend_selector_test.go
+++ b/cmd/flux/get_suspend_selector_test.go
@@ -1,0 +1,415 @@
+//go:build unit
+// +build unit
+
+/*
+Copyright 2026 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	watchtools "k8s.io/client-go/tools/watch"
+
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	autov1 "github.com/fluxcd/image-automation-controller/api/v1"
+	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1"
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
+	notificationv1 "github.com/fluxcd/notification-controller/api/v1"
+	notificationv1b3 "github.com/fluxcd/notification-controller/api/v1beta3"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	swapi "github.com/fluxcd/source-watcher/api/v2/v1beta1"
+)
+
+type suspendedItemReporter interface {
+	isSuspended(i int) bool
+}
+
+func TestGetAdaptersReportSuspension(t *testing.T) {
+	oci := sourcev1.OCIRepository{}
+	oci.Spec.Suspend = true
+	bucket := sourcev1.Bucket{}
+	bucket.Spec.Suspend = true
+	gitRepository := sourcev1.GitRepository{}
+	gitRepository.Spec.Suspend = true
+	helmRepository := sourcev1.HelmRepository{}
+	helmRepository.Spec.Suspend = true
+	helmChart := sourcev1.HelmChart{}
+	helmChart.Spec.Suspend = true
+	helmRelease := helmv2.HelmRelease{}
+	helmRelease.Spec.Suspend = true
+	kustomization := kustomizev1.Kustomization{}
+	kustomization.Spec.Suspend = true
+	receiver := notificationv1.Receiver{}
+	receiver.Spec.Suspend = true
+	alert := notificationv1b3.Alert{}
+	alert.Spec.Suspend = true
+	provider := notificationv1b3.Provider{}
+	provider.Spec.Suspend = true
+	imageRepository := imagev1.ImageRepository{}
+	imageRepository.Spec.Suspend = true
+	imagePolicy := imagev1.ImagePolicy{}
+	imagePolicy.Spec.Suspend = true
+	imageUpdate := autov1.ImageUpdateAutomation{}
+	imageUpdate.Spec.Suspend = true
+	disabledGenerator := swapi.ArtifactGenerator{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				swapi.ReconcileAnnotation: strings.ToUpper(swapi.DisabledValue),
+			},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		list     suspendedItemReporter
+		expected []bool
+	}{
+		{name: "OCIRepository", list: &ociRepositoryListAdapter{&sourcev1.OCIRepositoryList{Items: []sourcev1.OCIRepository{{}, oci}}}, expected: []bool{false, true}},
+		{name: "Bucket", list: &bucketListAdapter{&sourcev1.BucketList{Items: []sourcev1.Bucket{{}, bucket}}}, expected: []bool{false, true}},
+		{name: "GitRepository", list: &gitRepositoryListAdapter{&sourcev1.GitRepositoryList{Items: []sourcev1.GitRepository{{}, gitRepository}}}, expected: []bool{false, true}},
+		{name: "HelmRepository", list: &helmRepositoryListAdapter{&sourcev1.HelmRepositoryList{Items: []sourcev1.HelmRepository{{}, helmRepository}}}, expected: []bool{false, true}},
+		{name: "HelmChart", list: &helmChartListAdapter{&sourcev1.HelmChartList{Items: []sourcev1.HelmChart{{}, helmChart}}}, expected: []bool{false, true}},
+		{name: "ExternalArtifact", list: &externalArtifactListAdapter{&sourcev1.ExternalArtifactList{Items: []sourcev1.ExternalArtifact{{}, {}}}}, expected: []bool{false, false}},
+		{name: "HelmRelease", list: helmReleaseListAdapter{&helmv2.HelmReleaseList{Items: []helmv2.HelmRelease{{}, helmRelease}}}, expected: []bool{false, true}},
+		{name: "Kustomization", list: kustomizationListAdapter{&kustomizev1.KustomizationList{Items: []kustomizev1.Kustomization{{}, kustomization}}}, expected: []bool{false, true}},
+		{name: "Receiver", list: receiverListAdapter{&notificationv1.ReceiverList{Items: []notificationv1.Receiver{{}, receiver}}}, expected: []bool{false, true}},
+		{name: "Alert", list: alertListAdapter{&notificationv1b3.AlertList{Items: []notificationv1b3.Alert{{}, alert}}}, expected: []bool{false, true}},
+		{name: "Provider", list: alertProviderListAdapter{&notificationv1b3.ProviderList{Items: []notificationv1b3.Provider{{}, provider}}}, expected: []bool{false, true}},
+		{name: "ImageRepository", list: imageRepositoryListAdapter{&imagev1.ImageRepositoryList{Items: []imagev1.ImageRepository{{}, imageRepository}}}, expected: []bool{false, true}},
+		{name: "ImagePolicy", list: imagePolicyListAdapter{&imagev1.ImagePolicyList{Items: []imagev1.ImagePolicy{{}, imagePolicy}}}, expected: []bool{false, true}},
+		{name: "ImageUpdateAutomation", list: imageUpdateAutomationListAdapter{&autov1.ImageUpdateAutomationList{Items: []autov1.ImageUpdateAutomation{{}, imageUpdate}}}, expected: []bool{false, true}},
+		{name: "ArtifactGenerator", list: artifactGeneratorListAdapter{&swapi.ArtifactGeneratorList{Items: []swapi.ArtifactGenerator{{}, disabledGenerator}}}, expected: []bool{false, true}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for i, expected := range tt.expected {
+				if got := tt.list.isSuspended(i); got != expected {
+					t.Fatalf("isSuspended(%d) = %v, expected %v", i, got, expected)
+				}
+			}
+		})
+	}
+}
+
+func TestWatchUntilSuspendSelector(t *testing.T) {
+	tests := []struct {
+		name          string
+		apiType       apiType
+		derive        deriveType
+		active        runtime.Object
+		suspended     runtime.Object
+		activeName    string
+		suspendedName string
+	}{
+		{
+			name:    "GitRepository",
+			apiType: gitRepositoryType,
+			derive: func(obj runtime.Object) (summarisable, error) {
+				item, ok := obj.(*sourcev1.GitRepository)
+				if !ok {
+					return nil, fmt.Errorf("unexpected type %T", obj)
+				}
+				return &gitRepositoryListAdapter{&sourcev1.GitRepositoryList{Items: []sourcev1.GitRepository{*item}}}, nil
+			},
+			active: &sourcev1.GitRepository{
+				ObjectMeta: metav1.ObjectMeta{Name: "git-active"},
+			},
+			suspended: &sourcev1.GitRepository{
+				ObjectMeta: metav1.ObjectMeta{Name: "git-suspended"},
+				Spec:       sourcev1.GitRepositorySpec{Suspend: true},
+			},
+			activeName:    "git-active",
+			suspendedName: "git-suspended",
+		},
+		{
+			name:    "ArtifactGenerator",
+			apiType: artifactGeneratorType,
+			derive: func(obj runtime.Object) (summarisable, error) {
+				item, ok := obj.(*swapi.ArtifactGenerator)
+				if !ok {
+					return nil, fmt.Errorf("unexpected type %T", obj)
+				}
+				return artifactGeneratorListAdapter{&swapi.ArtifactGeneratorList{Items: []swapi.ArtifactGenerator{*item}}}, nil
+			},
+			active: &swapi.ArtifactGenerator{
+				ObjectMeta: metav1.ObjectMeta{Name: "generator-active"},
+			},
+			suspended: &swapi.ArtifactGenerator{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "generator-disabled",
+					Annotations: map[string]string{
+						swapi.ReconcileAnnotation: swapi.DisabledValue,
+					},
+				},
+			},
+			activeName:    "generator-active",
+			suspendedName: "generator-disabled",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			get := &getCommand{apiType: tt.apiType, funcMap: make(typeMap)}
+			if err := get.funcMap.registerCommand(tt.apiType.kind, tt.derive); err != nil {
+				t.Fatalf("failed registering watch sink: %v", err)
+			}
+
+			previousArgs := getArgs
+			getArgs = newGetFlags()
+			getArgs.noHeader = true
+			if err := getArgs.suspendSelector.Set("suspended"); err != nil {
+				t.Fatalf("failed setting suspend selector: %v", err)
+			}
+			t.Cleanup(func() {
+				getArgs = previousArgs
+			})
+
+			output := captureWatchOutput(t, get, tt.active, tt.suspended)
+			requireOutputContains(t, output, tt.suspendedName)
+			requireOutputExcludes(t, output, tt.activeName)
+		})
+	}
+}
+
+func captureWatchOutput(t *testing.T, get *getCommand, events ...runtime.Object) string {
+	t.Helper()
+
+	fake := watch.NewFakeWithChanSize(len(events), false)
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed creating stdout pipe: %v", err)
+	}
+	previousStdout := os.Stdout
+	os.Stdout = writer
+	t.Cleanup(func() {
+		os.Stdout = previousStdout
+		_ = reader.Close()
+		_ = writer.Close()
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := watchUntil(context.Background(), fake, get)
+		done <- err
+	}()
+	for _, event := range events {
+		fake.Add(event)
+	}
+	fake.Stop()
+	var watchErr error
+	select {
+	case watchErr = <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for watch to stop")
+	}
+	if !errors.Is(watchErr, watchtools.ErrWatchClosed) {
+		t.Fatalf("watchUntil() error = %v, expected %v", watchErr, watchtools.ErrWatchClosed)
+	}
+
+	if err := writer.Close(); err != nil {
+		t.Fatalf("failed closing stdout writer: %v", err)
+	}
+	os.Stdout = previousStdout
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("failed reading stdout: %v", err)
+	}
+	return string(output)
+}
+
+func TestGetCmdSuspendSelector(t *testing.T) {
+	tmpl := createSuspendSelectorObjects(t)
+	baseCommand := "get sources git -n " + tmpl["fluxns"]
+
+	unfiltered := runGetCommand(t, baseCommand)
+	requireOutputContains(t, unfiltered, "active-ready", "active-failed", "suspended-ready", "suspended-failed")
+	any := runGetCommand(t, baseCommand+" --suspend-selector any")
+	if any != unfiltered {
+		t.Fatalf("expected explicit any output to match default:\nany:\n%s\ndefault:\n%s", any, unfiltered)
+	}
+	requireOutputContains(t, any, "active-ready", "active-failed", "suspended-ready", "suspended-failed")
+
+	suspended := runGetCommand(t, baseCommand+" --suspend-selector suspended")
+	requireOutputContains(t, suspended, "suspended-ready", "suspended-failed")
+	requireOutputExcludes(t, suspended, "active-ready", "active-failed")
+
+	active := runGetCommand(t, baseCommand+" --suspend-selector active")
+	requireOutputContains(t, active, "active-ready", "active-failed")
+	requireOutputExcludes(t, active, "suspended-ready", "suspended-failed")
+
+	intersection := runGetCommand(t, baseCommand+
+		" --label-selector test.fluxcd.io/group=blue"+
+		" --status-selector Ready=True"+
+		" --suspend-selector suspended")
+	requireOutputContains(t, intersection, "suspended-ready")
+	requireOutputExcludes(t, intersection, "active-ready", "active-failed", "suspended-failed")
+
+	noMatch := runGetCommand(t, baseCommand+
+		" --label-selector test.fluxcd.io/group=blue"+
+		" --status-selector Ready=False"+
+		" --suspend-selector suspended")
+	if noMatch == "" {
+		t.Fatal("expected a header-only table for a single-kind selector with no matches")
+	}
+	requireOutputExcludes(t, noMatch, "active-ready", "active-failed", "suspended-ready", "suspended-failed")
+
+	namedMismatch := runGetCommand(t, "get sources git active-ready -n "+tmpl["fluxns"]+" --suspend-selector suspended")
+	if namedMismatch == "" {
+		t.Fatal("expected a header-only table for a named object excluded by the selector")
+	}
+	requireOutputExcludes(t, namedMismatch, "active-ready")
+
+	// executeCommand must restore the default after a preceding explicit value.
+	if reset := runGetCommand(t, baseCommand); reset != unfiltered {
+		t.Fatalf("expected selector to reset to any:\nreset:\n%s\ndefault:\n%s", reset, unfiltered)
+	}
+
+	_, err := executeCommand("get all --suspend-selector unknown --kubeconfig /does/not/exist")
+	if err == nil || !strings.Contains(err.Error(), "unsupported suspend selector 'unknown'") {
+		t.Fatalf("expected invalid selector error before cluster access, got %v", err)
+	}
+}
+
+func TestGetCmdSuspendSelectorSpecialResources(t *testing.T) {
+	tmpl := createSuspendSelectorObjects(t)
+
+	provider := runGetCommand(t, "get alert-providers -n "+tmpl["fluxns"]+" --suspend-selector suspended")
+	requireOutputContains(t, provider, "provider-suspended")
+	requireOutputExcludes(t, provider, "provider-active")
+	providerActive := runGetCommand(t, "get alert-providers -n "+tmpl["fluxns"]+" --suspend-selector active")
+	requireOutputContains(t, providerActive, "provider-active")
+	requireOutputExcludes(t, providerActive, "provider-suspended")
+
+	policy := runGetCommand(t, "get image policy -n "+tmpl["fluxns"]+" --suspend-selector suspended")
+	requireOutputContains(t, policy, "policy-suspended")
+	requireOutputExcludes(t, policy, "policy-active")
+	policyActive := runGetCommand(t, "get image policy -n "+tmpl["fluxns"]+" --suspend-selector active")
+	requireOutputContains(t, policyActive, "policy-active")
+	requireOutputExcludes(t, policyActive, "policy-suspended")
+
+	generators := runGetCommand(t, "get artifact generators -n "+tmpl["fluxns"]+" --suspend-selector suspended")
+	requireOutputContains(t, generators, "generator-disabled")
+	requireOutputExcludes(t, generators, "generator-active")
+	generatorsActive := runGetCommand(t, "get artifact generators -n "+tmpl["fluxns"]+" --suspend-selector active")
+	requireOutputContains(t, generatorsActive, "generator-active")
+	requireOutputExcludes(t, generatorsActive, "generator-disabled")
+
+	external := runGetCommand(t, "get sources external -n "+tmpl["fluxns"]+" --suspend-selector active")
+	requireOutputContains(t, external, "external-active")
+	externalSuspended := runGetCommand(t, "get sources external -n "+tmpl["fluxns"]+" --suspend-selector suspended")
+	requireOutputExcludes(t, externalSuspended, "external-active")
+}
+
+func TestGetAllCmdSuspendSelector(t *testing.T) {
+	tmpl := createSuspendSelectorObjects(t)
+	preservationTests := []struct {
+		command  string
+		expected []string
+	}{
+		{command: "get sources all", expected: []string{"active-ready", "suspended-ready", "external-active"}},
+		{command: "get images all", expected: []string{"policy-active", "policy-suspended"}},
+		{command: "get all", expected: []string{"active-ready", "suspended-ready", "policy-active", "policy-suspended", "provider-active", "provider-suspended"}},
+	}
+	for _, tt := range preservationTests {
+		t.Run(tt.command+" any preserves default", func(t *testing.T) {
+			baseCommand := tt.command + " -n " + tmpl["fluxns"]
+			unfiltered := runGetCommand(t, baseCommand)
+			requireOutputContains(t, unfiltered, tt.expected...)
+			any := runGetCommand(t, baseCommand+" --suspend-selector any")
+			if any != unfiltered {
+				t.Fatalf("expected explicit any output to match default for %q:\nany:\n%s\ndefault:\n%s", tt.command, any, unfiltered)
+			}
+		})
+	}
+
+	sourcesSuspended := runGetCommand(t, "get sources all -n "+tmpl["fluxns"]+" --suspend-selector suspended")
+	requireOutputContains(t, sourcesSuspended, "suspended-ready", "suspended-failed")
+	requireOutputExcludes(t, sourcesSuspended, "active-ready", "active-failed", "external-active")
+
+	sourcesActive := runGetCommand(t, "get sources all -n "+tmpl["fluxns"]+" --suspend-selector active")
+	requireOutputContains(t, sourcesActive, "active-ready", "active-failed", "external-active")
+	requireOutputExcludes(t, sourcesActive, "suspended-ready", "suspended-failed")
+
+	imagesSuspended := runGetCommand(t, "get images all -n "+tmpl["fluxns"]+" --suspend-selector suspended")
+	requireOutputContains(t, imagesSuspended, "policy-suspended")
+	requireOutputExcludes(t, imagesSuspended, "policy-active")
+	imagesActive := runGetCommand(t, "get images all -n "+tmpl["fluxns"]+" --suspend-selector active")
+	requireOutputContains(t, imagesActive, "policy-active")
+	requireOutputExcludes(t, imagesActive, "policy-suspended")
+
+	allSuspended := runGetCommand(t, "get all -n "+tmpl["fluxns"]+" --suspend-selector suspended")
+	requireOutputContains(t, allSuspended, "suspended-ready", "suspended-failed", "policy-suspended", "provider-suspended")
+	requireOutputExcludes(t, allSuspended, "active-ready", "active-failed", "policy-active", "provider-active", "external-active", "generator-disabled")
+	allActive := runGetCommand(t, "get all -n "+tmpl["fluxns"]+" --suspend-selector active")
+	requireOutputContains(t, allActive, "active-ready", "active-failed", "policy-active", "provider-active", "external-active")
+	requireOutputExcludes(t, allActive, "suspended-ready", "suspended-failed", "policy-suspended", "provider-suspended", "generator-active")
+
+	passiveActive := runGetCommand(t, "get sources all -n "+tmpl["passivens"]+" --suspend-selector active")
+	requireOutputContains(t, passiveActive, "passive-only")
+	passiveOnly := runGetCommand(t, "get sources all -n "+tmpl["passivens"]+" --suspend-selector suspended")
+	if passiveOnly != "" {
+		t.Fatalf("expected no aggregate output for a namespace without suspended resources, got:\n%s", passiveOnly)
+	}
+}
+
+func createSuspendSelectorObjects(t *testing.T) map[string]string {
+	t.Helper()
+	tmpl := map[string]string{
+		"fluxns":    allocateNamespace("suspend-selector"),
+		"passivens": allocateNamespace("suspend-selector-passive"),
+	}
+	testEnv.CreateObjectFile("./testdata/get/suspend_objects.yaml", tmpl, t)
+	return tmpl
+}
+
+func runGetCommand(t *testing.T, command string) string {
+	t.Helper()
+	output, err := executeCommand(command)
+	if err != nil {
+		t.Fatalf("%q failed: %v", command, err)
+	}
+	return output
+}
+
+func requireOutputContains(t *testing.T, output string, values ...string) {
+	t.Helper()
+	for _, value := range values {
+		if !strings.Contains(output, value) {
+			t.Errorf("expected output to contain %q:\n%s", value, output)
+		}
+	}
+}
+
+func requireOutputExcludes(t *testing.T, output string, values ...string) {
+	t.Helper()
+	for _, value := range values {
+		if strings.Contains(output, value) {
+			t.Errorf("expected output not to contain %q:\n%s", value, output)
+		}
+	}
+}

--- a/cmd/flux/main_test.go
+++ b/cmd/flux/main_test.go
@@ -443,7 +443,7 @@ func resetCmdArgs() {
 	deleteArgs = deleteFlags{}
 	diffKsArgs = diffKsFlags{}
 	exportArgs = exportFlags{}
-	getArgs = GetFlags{}
+	getArgs = newGetFlags()
 	gitArgs = gitFlags{}
 	githubArgs = githubFlags{}
 	gitlabArgs = gitlabFlags{}

--- a/cmd/flux/testdata/get/suspend_objects.yaml
+++ b/cmd/flux/testdata/get/suspend_objects.yaml
@@ -1,0 +1,186 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .fluxns }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .passivens }}
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  labels:
+    test.fluxcd.io/group: blue
+  name: active-ready
+  namespace: {{ .fluxns }}
+spec:
+  interval: 5m
+  url: https://github.com/example/active-ready
+status:
+  conditions:
+    - lastTransitionTime: "2026-01-01T00:00:00Z"
+      message: ready
+      reason: Succeeded
+      status: "True"
+      type: Ready
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  labels:
+    test.fluxcd.io/group: blue
+  name: active-failed
+  namespace: {{ .fluxns }}
+spec:
+  interval: 5m
+  url: https://github.com/example/active-failed
+status:
+  conditions:
+    - lastTransitionTime: "2026-01-01T00:00:00Z"
+      message: failed
+      reason: Failed
+      status: "False"
+      type: Ready
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  labels:
+    test.fluxcd.io/group: blue
+  name: suspended-ready
+  namespace: {{ .fluxns }}
+spec:
+  interval: 5m
+  suspend: true
+  url: https://github.com/example/suspended-ready
+status:
+  conditions:
+    - lastTransitionTime: "2026-01-01T00:00:00Z"
+      message: ready
+      reason: Succeeded
+      status: "True"
+      type: Ready
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  labels:
+    test.fluxcd.io/group: red
+  name: suspended-failed
+  namespace: {{ .fluxns }}
+spec:
+  interval: 5m
+  suspend: true
+  url: https://github.com/example/suspended-failed
+status:
+  conditions:
+    - lastTransitionTime: "2026-01-01T00:00:00Z"
+      message: failed
+      reason: Failed
+      status: "False"
+      type: Ready
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: ExternalArtifact
+metadata:
+  name: external-active
+  namespace: {{ .fluxns }}
+spec:
+  sourceRef:
+    apiVersion: source.example.com/v1
+    kind: ExampleSource
+    name: external-active
+    namespace: {{ .fluxns }}
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: ExternalArtifact
+metadata:
+  name: passive-only
+  namespace: {{ .passivens }}
+spec:
+  sourceRef:
+    apiVersion: source.example.com/v1
+    kind: ExampleSource
+    name: passive-only
+    namespace: {{ .passivens }}
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Provider
+metadata:
+  name: provider-active
+  namespace: {{ .fluxns }}
+spec:
+  address: https://example.com/active-hook
+  type: generic
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Provider
+metadata:
+  name: provider-suspended
+  namespace: {{ .fluxns }}
+spec:
+  address: https://example.com/hook
+  suspend: true
+  type: generic
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: policy-active
+  namespace: {{ .fluxns }}
+spec:
+  imageRepositoryRef:
+    name: image-repository
+  policy:
+    semver:
+      range: 1.x
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: policy-suspended
+  namespace: {{ .fluxns }}
+spec:
+  imageRepositoryRef:
+    name: image-repository
+  policy:
+    semver:
+      range: 1.x
+  suspend: true
+---
+apiVersion: source.extensions.fluxcd.io/v1beta1
+kind: ArtifactGenerator
+metadata:
+  name: generator-active
+  namespace: {{ .fluxns }}
+spec:
+  artifacts:
+    - copy:
+        - from: "@source/**"
+          to: "@artifact/"
+      name: generator-active
+  sources:
+    - alias: source
+      kind: GitRepository
+      name: active-ready
+---
+apiVersion: source.extensions.fluxcd.io/v1beta1
+kind: ArtifactGenerator
+metadata:
+  annotations:
+    source.extensions.fluxcd.io/reconcile: disabled
+  name: generator-disabled
+  namespace: {{ .fluxns }}
+spec:
+  artifacts:
+    - copy:
+        - from: "@source/**"
+          to: "@artifact/"
+      name: generator-disabled
+  sources:
+    - alias: source
+      kind: GitRepository
+      name: suspended-ready

--- a/internal/flags/suspend_selector.go
+++ b/internal/flags/suspend_selector.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2026 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/fluxcd/flux2/v2/internal/utils"
+)
+
+const (
+	SuspendSelectorAny       SuspendSelector = "any"
+	SuspendSelectorSuspended SuspendSelector = "suspended"
+	SuspendSelectorActive    SuspendSelector = "active"
+)
+
+var supportedSuspendSelectors = []string{
+	string(SuspendSelectorAny),
+	string(SuspendSelectorSuspended),
+	string(SuspendSelectorActive),
+}
+
+type SuspendSelector string
+
+func (s *SuspendSelector) String() string {
+	return string(*s)
+}
+
+func (s *SuspendSelector) Set(str string) error {
+	if strings.TrimSpace(str) == "" {
+		return fmt.Errorf("no suspend selector given, must be one of: %s",
+			strings.Join(supportedSuspendSelectors, ", "))
+	}
+	if !utils.ContainsItemString(supportedSuspendSelectors, str) {
+		return fmt.Errorf("unsupported suspend selector '%s', must be one of: %s",
+			str, strings.Join(supportedSuspendSelectors, ", "))
+	}
+	*s = SuspendSelector(str)
+	return nil
+}
+
+func (s *SuspendSelector) Type() string {
+	return strings.Join(supportedSuspendSelectors, "|")
+}
+
+func (s *SuspendSelector) Description() string {
+	return "filter objects by suspension state"
+}
+
+func (s SuspendSelector) Matches(suspended bool) bool {
+	switch s {
+	case SuspendSelectorAny:
+		return true
+	case SuspendSelectorSuspended:
+		return suspended
+	case SuspendSelectorActive:
+		return !suspended
+	default:
+		return false
+	}
+}

--- a/internal/flags/suspend_selector_test.go
+++ b/internal/flags/suspend_selector_test.go
@@ -1,0 +1,84 @@
+//go:build !e2e
+// +build !e2e
+
+/*
+Copyright 2026 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import "testing"
+
+func TestSuspendSelector_Set(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		expected  SuspendSelector
+		expectErr bool
+	}{
+		{name: "any", value: "any", expected: SuspendSelectorAny},
+		{name: "suspended", value: "suspended", expected: SuspendSelectorSuspended},
+		{name: "active", value: "active", expected: SuspendSelectorActive},
+		{name: "empty", value: "", expectErr: true},
+		{name: "uppercase", value: "Any", expectErr: true},
+		{name: "boolean", value: "true", expectErr: true},
+		{name: "whitespace", value: " any ", expectErr: true},
+		{name: "unsupported", value: "unknown", expectErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var selector SuspendSelector
+			err := selector.Set(tt.value)
+			if (err != nil) != tt.expectErr {
+				t.Fatalf("Set() error = %v, expectErr %v", err, tt.expectErr)
+			}
+			if selector != tt.expected {
+				t.Fatalf("Set() = %q, expected %q", selector, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSuspendSelector_Matches(t *testing.T) {
+	tests := []struct {
+		name      string
+		selector  SuspendSelector
+		suspended bool
+		expected  bool
+	}{
+		{name: "any matches active", selector: SuspendSelectorAny, expected: true},
+		{name: "any matches suspended", selector: SuspendSelectorAny, suspended: true, expected: true},
+		{name: "active matches active", selector: SuspendSelectorActive, expected: true},
+		{name: "active rejects suspended", selector: SuspendSelectorActive, suspended: true},
+		{name: "suspended rejects active", selector: SuspendSelectorSuspended},
+		{name: "suspended matches suspended", selector: SuspendSelectorSuspended, suspended: true, expected: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.selector.Matches(tt.suspended); got != tt.expected {
+				t.Fatalf("Matches() = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSuspendSelector_Type(t *testing.T) {
+	var selector SuspendSelector
+	if got, expected := selector.Type(), "any|suspended|active"; got != expected {
+		t.Fatalf("Type() = %q, expected %q", got, expected)
+	}
+}


### PR DESCRIPTION
Closes #3886

## What

- Add `--suspend-selector=any|suspended|active` to `flux get`, defaulting to `any` for backward-compatible output.
- Apply the selector consistently to named resources, leaf commands, aggregate commands, and watch events, in conjunction with label and status selectors.
- Read the native suspend field for Flux resources, the reconcile-disabled annotation for `ArtifactGenerator`, and classify `ExternalArtifact` as active because it has no suspension state.
- Add exhaustive adapter, command, aggregate, default-reset, invalid-input, and watch coverage.

This is a draft so maintainers can confirm the public flag name and the treatment of resource types without a native suspend field before it is marked ready.

## Tests

- `make tidy fmt vet && make test`

## Local testing

- Built baseline `1ed703a3` and signed candidate `ef1fb5fd` twice from commit-authenticated Git archives; each build pair was byte-identical and used SHA-bearing versions.
- Exercised both binaries against a real Kubernetes 1.36.2 envtest API.
- Verified baseline default output equals candidate default and explicit `any` output.
- Verified active/suspended leaf and aggregate partitions, label/status intersection, special resource semantics, invalid-value rejection before cluster access, and passive-only namespaces.
- Verified a real API watch suppresses enabled `ArtifactGenerator` events and emits disabled transitions.

Assisted-by: codex/gpt-5
