### PR TITLE
Add digests flag to plugin search, which displays SHA values for all os/arch per binary

### DIFF
--- a/cmd/flux/main_test.go
+++ b/cmd/flux/main_test.go
@@ -455,6 +455,7 @@ func resetCmdArgs() {
 	imageUpdateArgs = imageUpdateFlags{}
 	installArgs = newInstallFlags()
 	kustomizationArgs = NewKustomizationFlags()
+	pluginSearchArgs = pluginSearchFlags{}
 	receiverArgs = receiverFlags{}
 	resumeArgs = ResumeFlags{}
 	rhrArgs = reconcileHelmReleaseFlags{}

--- a/cmd/flux/plugin.go
+++ b/cmd/flux/plugin.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 

--- a/cmd/flux/plugin.go
+++ b/cmd/flux/plugin.go
@@ -112,7 +112,7 @@ func newCatalogClient() *plugin.CatalogClient {
 }
 
 func newPluginSpinner(message string) *spinner.Spinner {
-	s := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
+	s := spinner.New(spinner.CharSets[14], 100*time.Millisecond, spinner.WithWriterFile(os.Stderr))
 	s.Suffix = " " + message
 	return s
 }

--- a/cmd/flux/plugin_search.go
+++ b/cmd/flux/plugin_search.go
@@ -95,13 +95,14 @@ func pluginSearchCmdRun(cmd *cobra.Command, args []string) error {
 	var rows [][]string
 	if digests {
 		header = []string{"NAME", "VERSION", "OS/ARCH", "DIGEST"}
-		rows, err = pluginDigestRows(catalogClient, entries, version)
+		var warnings []error
+		rows, warnings = pluginDigestRows(catalogClient, entries, version)
+		for _, w := range warnings {
+			logger.Warningf("%s", w)
+		}
 	} else {
 		header = []string{"NAME", "DESCRIPTION", "INSTALLED"}
 		rows = pluginCatalogRows(entries)
-	}
-	if err != nil {
-		return err
 	}
 
 	if len(rows) == 0 {
@@ -135,8 +136,9 @@ func pluginCatalogRows(entries []plugintypes.CatalogEntry) [][]string {
 }
 
 // pluginDigestRows fetches the manifest of every entry and returns one row per
-// os/arch for the binary of the requested version.
-func pluginDigestRows(catalogClient *plugin.CatalogClient, entries []plugintypes.CatalogEntry, version string) ([][]string, error) {
+// os/arch for the binary of the requested version. Any errors encountered when
+// fetching plugin information are recorded and plugins are skipped in output.
+func pluginDigestRows(catalogClient *plugin.CatalogClient, entries []plugintypes.CatalogEntry, version string) ([][]string, []error) {
 	if len(entries) == 0 {
 		return nil, nil
 	}
@@ -146,14 +148,17 @@ func pluginDigestRows(catalogClient *plugin.CatalogClient, entries []plugintypes
 	defer sp.Stop()
 
 	var rows [][]string
+	var warnings []error
 	for _, entry := range entries {
 		manifest, err := catalogClient.FetchManifest(entry.Name)
 		if err != nil {
-			return nil, err
+			warnings = append(warnings, err)
+			continue
 		}
 
 		pv, err := plugin.ResolveVersion(manifest, version)
 		if err != nil {
+			warnings = append(warnings, err)
 			continue
 		}
 
@@ -167,5 +172,5 @@ func pluginDigestRows(catalogClient *plugin.CatalogClient, entries []plugintypes
 		}
 	}
 
-	return rows, nil
+	return rows, warnings
 }

--- a/cmd/flux/plugin_search.go
+++ b/cmd/flux/plugin_search.go
@@ -17,49 +17,112 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/fluxcd/flux2/v2/internal/plugin"
+	plugintypes "github.com/fluxcd/flux2/v2/pkg/plugin"
 	"github.com/fluxcd/flux2/v2/pkg/printers"
 )
 
 var pluginSearchCmd = &cobra.Command{
-	Use:   "search [query]",
+	Use:   "search [query[@<version>]]",
 	Short: "Search the plugin catalog",
-	Long:  `The plugin search command lists available plugins from the Flux plugin catalog.`,
-	Args:  cobra.MaximumNArgs(1),
-	RunE:  pluginSearchCmdRun,
+	Long: `The plugin search command lists available plugins from the Flux plugin catalog.
+
+Examples:
+  # List all plugins in the catalog
+  flux plugin search
+
+  # List the digests for all plugins
+  flux plugin search --digests
+
+  # List the digests of a specific version (implies --digests)
+  flux plugin search operator@0.45.0`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: pluginSearchCmdRun,
 }
 
+type pluginSearchFlags struct {
+	digests bool
+}
+
+var pluginSearchArgs pluginSearchFlags
+
 func init() {
+	pluginSearchCmd.Flags().BoolVar(&pluginSearchArgs.digests, "digests", false,
+		"list the digest of every platform binary")
 	pluginCmd.AddCommand(pluginSearchCmd)
 }
 
 func pluginSearchCmdRun(cmd *cobra.Command, args []string) error {
+	var arg, query, version string
+	if len(args) == 1 {
+		arg = args[0]
+		query, version = parseNameVersion(arg)
+		query = strings.ToLower(query)
+	}
+
+	if isDigestRef(version) {
+		return fmt.Errorf("searching by digest is not supported, use 'flux plugin install %s' to pin a plugin to a digest", arg)
+	}
+	if version != "" && query == "" {
+		return fmt.Errorf("a query is required in front of '@%s', e.g. 'flux plugin search operator@%[1]s'", version)
+	}
+
+	// Print digest information for a given version
+	digests := pluginSearchArgs.digests || version != ""
+
 	catalogClient := newCatalogClient()
 	catalog, err := catalogClient.FetchCatalog()
 	if err != nil {
 		return err
 	}
 
-	var query string
-	if len(args) == 1 {
-		query = strings.ToLower(args[0])
+	var entries []plugintypes.CatalogEntry
+	for _, entry := range catalog.Plugins {
+		if query != "" &&
+			!strings.Contains(strings.ToLower(entry.Name), query) &&
+			!strings.Contains(strings.ToLower(entry.Description), query) {
+			continue
+		}
+		entries = append(entries, entry)
 	}
 
-	pluginDir := pluginHandler.PluginDir()
-	header := []string{"NAME", "DESCRIPTION", "INSTALLED"}
+	var header []string
 	var rows [][]string
-	for _, entry := range catalog.Plugins {
-		if query != "" {
-			if !strings.Contains(strings.ToLower(entry.Name), query) &&
-				!strings.Contains(strings.ToLower(entry.Description), query) {
-				continue
-			}
-		}
+	if digests {
+		header = []string{"NAME", "VERSION", "OS/ARCH", "DIGEST"}
+		rows, err = pluginDigestRows(catalogClient, entries, version)
+	} else {
+		header = []string{"NAME", "DESCRIPTION", "INSTALLED"}
+		rows = pluginCatalogRows(entries)
+	}
+	if err != nil {
+		return err
+	}
 
+	if len(rows) == 0 {
+		if arg != "" {
+			cmd.Printf("No plugins matching %q found in catalog\n", arg)
+		} else {
+			cmd.Println("No plugins found in catalog")
+		}
+		return nil
+	}
+
+	return printers.TablePrinter(header).Print(cmd.OutOrStdout(), rows)
+}
+
+// pluginCatalogRows returns one row per catalog entry, annotated with the
+// installed version when a receipt exists.
+func pluginCatalogRows(entries []plugintypes.CatalogEntry) [][]string {
+	pluginDir := pluginHandler.PluginDir()
+
+	var rows [][]string
+	for _, entry := range entries {
 		installed := ""
 		if receipt := plugin.ReadReceipt(pluginDir, entry.Name); receipt != nil {
 			installed = receipt.Version
@@ -68,14 +131,41 @@ func pluginSearchCmdRun(cmd *cobra.Command, args []string) error {
 		rows = append(rows, []string{entry.Name, entry.Description, installed})
 	}
 
-	if len(rows) == 0 {
-		if query != "" {
-			cmd.Printf("No plugins matching %q found in catalog\n", query)
-		} else {
-			cmd.Println("No plugins found in catalog")
-		}
-		return nil
+	return rows
+}
+
+// pluginDigestRows fetches the manifest of every entry and returns one row per
+// os/arch for the binary of the requested version.
+func pluginDigestRows(catalogClient *plugin.CatalogClient, entries []plugintypes.CatalogEntry, version string) ([][]string, error) {
+	if len(entries) == 0 {
+		return nil, nil
 	}
 
-	return printers.TablePrinter(header).Print(cmd.OutOrStdout(), rows)
+	sp := newPluginSpinner("fetching plugin digests")
+	sp.Start()
+	defer sp.Stop()
+
+	var rows [][]string
+	for _, entry := range entries {
+		manifest, err := catalogClient.FetchManifest(entry.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		pv, err := plugin.ResolveVersion(manifest, version)
+		if err != nil {
+			continue
+		}
+
+		for _, plat := range pv.Platforms {
+			rows = append(rows, []string{
+				entry.Name,
+				pv.Version,
+				fmt.Sprintf("%s/%s", plat.OS, plat.Arch),
+				plat.Checksum,
+			})
+		}
+	}
+
+	return rows, nil
 }

--- a/cmd/flux/plugin_search.go
+++ b/cmd/flux/plugin_search.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -91,30 +92,35 @@ func pluginSearchCmdRun(cmd *cobra.Command, args []string) error {
 		entries = append(entries, entry)
 	}
 
-	var header []string
-	var rows [][]string
 	if digests {
-		header = []string{"NAME", "VERSION", "OS/ARCH", "DIGEST"}
-		var warnings []error
-		rows, warnings = pluginDigestRows(catalogClient, entries, version)
+		trees, warnings := pluginDigestTrees(catalogClient, entries, version)
 		for _, w := range warnings {
 			logger.Warningf("%s", w)
 		}
-	} else {
-		header = []string{"NAME", "DESCRIPTION", "INSTALLED"}
-		rows = pluginCatalogRows(entries)
-	}
-
-	if len(rows) == 0 {
-		if arg != "" {
-			cmd.Printf("No plugins matching %q found in catalog\n", arg)
-		} else {
-			cmd.Println("No plugins found in catalog")
+		if len(trees) == 0 {
+			printPluginSearchNoMatch(cmd, arg)
+			return nil
 		}
+		printPluginDigestTrees(cmd.OutOrStdout(), trees)
 		return nil
 	}
 
+	rows := pluginCatalogRows(entries)
+	if len(rows) == 0 {
+		printPluginSearchNoMatch(cmd, arg)
+		return nil
+	}
+
+	header := []string{"NAME", "DESCRIPTION", "INSTALLED"}
 	return printers.TablePrinter(header).Print(cmd.OutOrStdout(), rows)
+}
+
+func printPluginSearchNoMatch(cmd *cobra.Command, arg string) {
+	if arg != "" {
+		cmd.Printf("No plugins matching %q found in catalog\n", arg)
+	} else {
+		cmd.Println("No plugins found in catalog")
+	}
 }
 
 // pluginCatalogRows returns one row per catalog entry, annotated with the
@@ -135,10 +141,19 @@ func pluginCatalogRows(entries []plugintypes.CatalogEntry) [][]string {
 	return rows
 }
 
-// pluginDigestRows fetches the manifest of every entry and returns one row per
-// os/arch for the binary of the requested version. Any errors encountered when
-// fetching plugin information are recorded and plugins are skipped in output.
-func pluginDigestRows(catalogClient *plugin.CatalogClient, entries []plugintypes.CatalogEntry, version string) ([][]string, []error) {
+// pluginDigestTree holds the platform digests of a single plugin version.
+type pluginDigestTree struct {
+	name        string
+	version     string
+	description string
+	platforms   []plugintypes.Platform
+}
+
+// pluginDigestTrees fetches the manifest of every entry and returns one tree
+// per plugin with the platform digests of the requested version. Any errors
+// encountered when fetching plugin information are recorded and plugins are
+// skipped in output.
+func pluginDigestTrees(catalogClient *plugin.CatalogClient, entries []plugintypes.CatalogEntry, version string) ([]pluginDigestTree, []error) {
 	if len(entries) == 0 {
 		return nil, nil
 	}
@@ -147,7 +162,7 @@ func pluginDigestRows(catalogClient *plugin.CatalogClient, entries []plugintypes
 	sp.Start()
 	defer sp.Stop()
 
-	var rows [][]string
+	var trees []pluginDigestTree
 	var warnings []error
 	for _, entry := range entries {
 		manifest, err := catalogClient.FetchManifest(entry.Name)
@@ -162,15 +177,35 @@ func pluginDigestRows(catalogClient *plugin.CatalogClient, entries []plugintypes
 			continue
 		}
 
-		for _, plat := range pv.Platforms {
-			rows = append(rows, []string{
-				entry.Name,
-				pv.Version,
-				fmt.Sprintf("%s/%s", plat.OS, plat.Arch),
-				plat.Checksum,
-			})
-		}
+		trees = append(trees, pluginDigestTree{
+			name:        entry.Name,
+			version:     pv.Version,
+			description: entry.Description,
+			platforms:   pv.Platforms,
+		})
 	}
 
-	return rows, warnings
+	return trees, warnings
+}
+
+// printPluginDigestTrees renders one tree per plugin, with the plugin header
+// as the root and one branch per os/arch, digests aligned per plugin.
+func printPluginDigestTrees(w io.Writer, trees []pluginDigestTree) {
+	for _, t := range trees {
+		fmt.Fprintf(w, "%s  %s  %s\n", t.name, t.version, t.description)
+
+		width := 0
+		for _, plat := range t.platforms {
+			if l := len(plat.OS) + len(plat.Arch) + 1; l > width {
+				width = l
+			}
+		}
+		for i, plat := range t.platforms {
+			branch := "├──"
+			if i == len(t.platforms)-1 {
+				branch = "└──"
+			}
+			fmt.Fprintf(w, "%s %-*s  %s\n", branch, width, plat.OS+"/"+plat.Arch, plat.Checksum)
+		}
+	}
 }

--- a/cmd/flux/plugin_search.go
+++ b/cmd/flux/plugin_search.go
@@ -73,7 +73,7 @@ func pluginSearchCmdRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("a query is required in front of '@%s', e.g. 'flux plugin search operator@%[1]s'", version)
 	}
 
-	// Print digest information for a given version
+	// A version query implies --digests
 	digests := pluginSearchArgs.digests || version != ""
 
 	catalogClient := newCatalogClient()

--- a/cmd/flux/plugin_search.go
+++ b/cmd/flux/plugin_search.go
@@ -92,35 +92,32 @@ func pluginSearchCmdRun(cmd *cobra.Command, args []string) error {
 		entries = append(entries, entry)
 	}
 
+	if len(entries) == 0 {
+		if arg != "" {
+			cmd.Printf("No plugins matching %q found in catalog\n", arg)
+		} else {
+			cmd.Println("No plugins found in catalog")
+		}
+		return nil
+	}
+
 	if digests {
 		trees, warnings := pluginDigestTrees(catalogClient, entries, version)
 		for _, w := range warnings {
 			logger.Warningf("%s", w)
 		}
 		if len(trees) == 0 {
-			printPluginSearchNoMatch(cmd, arg)
-			return nil
+			if len(entries) == 1 {
+				return fmt.Errorf("failed to fetch digests for plugin %s", entries[0].Name)
+			}
+			return fmt.Errorf("failed to fetch digests for all %d matching plugins", len(entries))
 		}
 		printPluginDigestTrees(cmd.OutOrStdout(), trees)
 		return nil
 	}
 
-	rows := pluginCatalogRows(entries)
-	if len(rows) == 0 {
-		printPluginSearchNoMatch(cmd, arg)
-		return nil
-	}
-
 	header := []string{"NAME", "DESCRIPTION", "INSTALLED"}
-	return printers.TablePrinter(header).Print(cmd.OutOrStdout(), rows)
-}
-
-func printPluginSearchNoMatch(cmd *cobra.Command, arg string) {
-	if arg != "" {
-		cmd.Printf("No plugins matching %q found in catalog\n", arg)
-	} else {
-		cmd.Println("No plugins found in catalog")
-	}
+	return printers.TablePrinter(header).Print(cmd.OutOrStdout(), pluginCatalogRows(entries))
 }
 
 // pluginCatalogRows returns one row per catalog entry, annotated with the
@@ -154,10 +151,6 @@ type pluginDigestTree struct {
 // encountered when fetching plugin information are recorded and plugins are
 // skipped in output.
 func pluginDigestTrees(catalogClient *plugin.CatalogClient, entries []plugintypes.CatalogEntry, version string) ([]pluginDigestTree, []error) {
-	if len(entries) == 0 {
-		return nil, nil
-	}
-
 	sp := newPluginSpinner("fetching plugin digests")
 	sp.Start()
 	defer sp.Stop()

--- a/cmd/flux/plugin_test.go
+++ b/cmd/flux/plugin_test.go
@@ -433,9 +433,12 @@ func TestPluginSearch(t *testing.T) {
 			notWant: []string{"0.12.0", testSomeToolDigestDarwinLatest},
 		},
 		{
-			name:    "reports an unknown version as no match",
-			args:    "plugin search some-tool@9.9.9 --digests",
-			want:    []string{`No plugins matching "some-tool@9.9.9"`},
+			name: "warns about an unknown version and reports no match",
+			args: "plugin search some-tool@9.9.9 --digests",
+			want: []string{
+				`version "9.9.9" not found`,
+				`No plugins matching "some-tool@9.9.9"`,
+			},
 			notWant: []string{"sha256:"},
 		},
 	}

--- a/cmd/flux/plugin_test.go
+++ b/cmd/flux/plugin_test.go
@@ -18,6 +18,8 @@ package main
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
@@ -282,5 +284,212 @@ func TestPluginDiscoverSkipsBuiltins(t *testing.T) {
 	}
 	if plugins[0].Name != "myplugin" {
 		t.Errorf("expected 'myplugin', got %q", plugins[0].Name)
+	}
+}
+
+const (
+	testCatalogYAML = `apiVersion: cli.fluxcd.io/v1beta1
+kind: PluginCatalog
+plugins:
+  - name: some-tool
+    description: Some tool
+  - name: my-plugin
+    description: My plugin`
+
+	testSomeToolDigestDarwinLatest = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	testSomeToolDigestLinuxLatest  = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	testSomeToolDigestDarwinOld    = "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+	testSomeToolDigestLinuxOld     = "sha256:4444444444444444444444444444444444444444444444444444444444444444"
+
+	testSomeToolYAML = `apiVersion: cli.fluxcd.io/v1beta1
+kind: Plugin
+name: some-tool
+description: Some tool
+bin: flux-some-tool
+versions:
+  - version: 0.12.0
+    platforms:
+      - os: darwin
+        arch: arm64
+        url: https://example.com/flux-some-tool_0.12.0_darwin_arm64.tar.gz
+        checksum: ` + testSomeToolDigestDarwinLatest + `
+      - os: linux
+        arch: amd64
+        url: https://example.com/flux-some-tool_0.12.0_linux_amd64.tar.gz
+        checksum: ` + testSomeToolDigestLinuxLatest + `
+  - version: 0.11.0
+    platforms:
+      - os: darwin
+        arch: arm64
+        url: https://example.com/flux-some-tool_0.11.0_darwin_arm64.tar.gz
+        checksum: ` + testSomeToolDigestDarwinOld + `
+      - os: linux
+        arch: amd64
+        url: https://example.com/flux-some-tool_0.11.0_linux_amd64.tar.gz
+        checksum: ` + testSomeToolDigestLinuxOld
+
+	testMyPluginDigest = "sha256:5555555555555555555555555555555555555555555555555555555555555555"
+
+	testMyPluginYAML = `apiVersion: cli.fluxcd.io/v1beta1
+kind: Plugin
+name: my-plugin
+description: My plugin
+bin: flux-my-plugin
+versions:
+  - version: 0.1.2
+    platforms:
+      - os: linux
+        arch: amd64
+        url: https://example.com/flux-my-plugin_0.1.2_linux_amd64.tar.gz
+        checksum: ` + testMyPluginDigest
+)
+
+// serveTestCatalog starts a server for the default plugin catalog fixtures and
+// points pluginHandler at it through FLUXCD_PLUGIN_CATALOG.
+func serveTestCatalog(t *testing.T) {
+	t.Helper()
+
+	files := map[string]string{
+		"catalog.yaml":   testCatalogYAML,
+		"some-tool.yaml": testSomeToolYAML,
+		"my-plugin.yaml": testMyPluginYAML,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, ok := files[strings.TrimPrefix(r.URL.Path, "/")]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		fmt.Fprint(w, body)
+	}))
+	t.Cleanup(server.Close)
+
+	origHandler := pluginHandler
+	t.Cleanup(func() { pluginHandler = origHandler })
+
+	pluginDir := t.TempDir()
+	pluginHandler = &plugin.Handler{
+		ReadDir: os.ReadDir,
+		Stat:    os.Stat,
+		GetEnv: func(key string) string {
+			switch key {
+			case "FLUXCD_PLUGIN_CATALOG":
+				return server.URL + "/"
+			case "FLUXCD_PLUGINS":
+				return pluginDir
+			}
+			return ""
+		},
+		HomeDir: func() (string, error) { return t.TempDir(), nil },
+	}
+}
+
+func TestPluginSearch(t *testing.T) {
+	serveTestCatalog(t)
+
+	tests := []struct {
+		name    string
+		args    string
+		want    []string
+		notWant []string
+	}{
+		{
+			name:    "lists the whole catalog",
+			args:    "plugin search",
+			want:    []string{"NAME", "DESCRIPTION", "INSTALLED", "some-tool", "Some tool", "my-plugin", "My plugin"},
+			notWant: []string{"sha256:"},
+		},
+		{
+			name:    "narrows down to the query",
+			args:    "plugin search some-tool",
+			want:    []string{"some-tool", "Some tool"},
+			notWant: []string{"my-plugin", "sha256:"},
+		},
+		{
+			name: "lists the digests of every plugin",
+			args: "plugin search --digests",
+			want: []string{"NAME", "VERSION", "OS/ARCH", "DIGEST",
+				testSomeToolDigestDarwinLatest, testSomeToolDigestLinuxLatest, testMyPluginDigest},
+		},
+		{
+			name: "lists every platform of the latest version",
+			args: "plugin search some-tool --digests",
+			want: []string{"0.12.0",
+				"darwin/arm64", testSomeToolDigestDarwinLatest,
+				"linux/amd64", testSomeToolDigestLinuxLatest},
+			notWant: []string{"0.11.0", testMyPluginDigest},
+		},
+		{
+			name:    "lists the platforms of a specific version",
+			args:    "plugin search some-tool@0.11.0 --digests",
+			want:    []string{"0.11.0", testSomeToolDigestDarwinOld, testSomeToolDigestLinuxOld},
+			notWant: []string{"0.12.0", testSomeToolDigestDarwinLatest},
+		},
+		{
+			name:    "a version implies --digests",
+			args:    "plugin search some-tool@0.11.0",
+			want:    []string{"0.11.0", testSomeToolDigestDarwinOld, testSomeToolDigestLinuxOld},
+			notWant: []string{"0.12.0", testSomeToolDigestDarwinLatest},
+		},
+		{
+			name:    "reports an unknown version as no match",
+			args:    "plugin search some-tool@9.9.9 --digests",
+			want:    []string{`No plugins matching "some-tool@9.9.9"`},
+			notWant: []string{"sha256:"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output, err := executeCommand(tt.args)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			for _, want := range tt.want {
+				if !strings.Contains(output, want) {
+					t.Errorf("expected %q in output, got: %s", want, output)
+				}
+			}
+			for _, notWant := range tt.notWant {
+				if strings.Contains(output, notWant) {
+					t.Errorf("expected %q to be absent from output, got: %s", notWant, output)
+				}
+			}
+		})
+	}
+}
+
+func TestPluginSearchErrors(t *testing.T) {
+	serveTestCatalog(t)
+
+	tests := []struct {
+		name    string
+		args    string
+		wantErr string
+	}{
+		{
+			name:    "version without a query",
+			args:    "plugin search @0.11.0",
+			wantErr: "a query is required",
+		},
+		{
+			name:    "digest instead of a version",
+			args:    "plugin search some-tool@sha256:abc123 --digests",
+			wantErr: "not supported",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := executeCommand(tt.args)
+			if err == nil {
+				t.Fatalf("expected an error containing %q, got none", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("expected an error containing %q, got: %v", tt.wantErr, err)
+			}
+		})
 	}
 }

--- a/cmd/flux/plugin_test.go
+++ b/cmd/flux/plugin_test.go
@@ -294,7 +294,9 @@ plugins:
   - name: some-tool
     description: Some tool
   - name: my-plugin
-    description: My plugin`
+    description: My plugin
+  - name: broken-tool
+    description: Broken tool`
 
 	testSomeToolDigestDarwinLatest = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
 	testSomeToolDigestLinuxLatest  = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
@@ -397,25 +399,26 @@ func TestPluginSearch(t *testing.T) {
 		{
 			name:    "lists the whole catalog",
 			args:    "plugin search",
-			want:    []string{"NAME", "DESCRIPTION", "INSTALLED", "some-tool", "Some tool", "my-plugin", "My plugin"},
+			want:    []string{"NAME", "DESCRIPTION", "INSTALLED", "some-tool", "Some tool", "my-plugin", "My plugin", "broken-tool", "Broken tool"},
 			notWant: []string{"sha256:"},
 		},
 		{
 			name:    "narrows down to the query",
 			args:    "plugin search some-tool",
 			want:    []string{"some-tool", "Some tool"},
-			notWant: []string{"my-plugin", "sha256:"},
+			notWant: []string{"my-plugin", "broken-tool", "sha256:"},
 		},
 		{
-			name: "lists the digests of every plugin as trees",
+			name: "lists the digests of every plugin as trees, warning about broken ones",
 			args: "plugin search --digests",
 			want: []string{
 				"some-tool  0.12.0  Some tool",
 				"my-plugin  0.1.2  My plugin",
 				testSomeToolDigestDarwinLatest, testSomeToolDigestLinuxLatest,
 				"└── linux/amd64  " + testMyPluginDigest,
+				`plugin "broken-tool" not found in catalog`,
 			},
-			notWant: []string{"NAME", "OS/ARCH", "DIGEST"},
+			notWant: []string{"NAME", "OS/ARCH", "DIGEST", "Broken tool"},
 		},
 		{
 			name: "lists every platform of the latest version",

--- a/cmd/flux/plugin_test.go
+++ b/cmd/flux/plugin_test.go
@@ -440,12 +440,9 @@ func TestPluginSearch(t *testing.T) {
 			notWant: []string{"0.12.0", testSomeToolDigestDarwinLatest},
 		},
 		{
-			name: "warns about an unknown version and reports no match",
-			args: "plugin search some-tool@9.9.9 --digests",
-			want: []string{
-				`version "9.9.9" not found`,
-				`No plugins matching "some-tool@9.9.9"`,
-			},
+			name:    "reports no match for an unknown query with digests",
+			args:    "plugin search does-not-exist --digests",
+			want:    []string{`No plugins matching "does-not-exist" found in catalog`},
 			notWant: []string{"sha256:"},
 		},
 	}
@@ -475,9 +472,10 @@ func TestPluginSearchErrors(t *testing.T) {
 	serveTestCatalog(t)
 
 	tests := []struct {
-		name    string
-		args    string
-		wantErr string
+		name       string
+		args       string
+		wantErr    string
+		wantOutput []string
 	}{
 		{
 			name:    "version without a query",
@@ -489,16 +487,27 @@ func TestPluginSearchErrors(t *testing.T) {
 			args:    "plugin search some-tool@sha256:abc123 --digests",
 			wantErr: "not supported",
 		},
+		{
+			name:       "unknown version fails after warning",
+			args:       "plugin search some-tool@9.9.9",
+			wantErr:    "failed to fetch digests for plugin some-tool",
+			wantOutput: []string{`version "9.9.9" not found`},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := executeCommand(tt.args)
+			output, err := executeCommand(tt.args)
 			if err == nil {
 				t.Fatalf("expected an error containing %q, got none", tt.wantErr)
 			}
 			if !strings.Contains(err.Error(), tt.wantErr) {
 				t.Errorf("expected an error containing %q, got: %v", tt.wantErr, err)
+			}
+			for _, want := range tt.wantOutput {
+				if !strings.Contains(output, want) {
+					t.Errorf("expected %q in output, got: %s", want, output)
+				}
 			}
 		})
 	}

--- a/cmd/flux/plugin_test.go
+++ b/cmd/flux/plugin_test.go
@@ -407,17 +407,24 @@ func TestPluginSearch(t *testing.T) {
 			notWant: []string{"my-plugin", "sha256:"},
 		},
 		{
-			name: "lists the digests of every plugin",
+			name: "lists the digests of every plugin as trees",
 			args: "plugin search --digests",
-			want: []string{"NAME", "VERSION", "OS/ARCH", "DIGEST",
-				testSomeToolDigestDarwinLatest, testSomeToolDigestLinuxLatest, testMyPluginDigest},
+			want: []string{
+				"some-tool  0.12.0  Some tool",
+				"my-plugin  0.1.2  My plugin",
+				testSomeToolDigestDarwinLatest, testSomeToolDigestLinuxLatest,
+				"└── linux/amd64  " + testMyPluginDigest,
+			},
+			notWant: []string{"NAME", "OS/ARCH", "DIGEST"},
 		},
 		{
 			name: "lists every platform of the latest version",
 			args: "plugin search some-tool --digests",
-			want: []string{"0.12.0",
-				"darwin/arm64", testSomeToolDigestDarwinLatest,
-				"linux/amd64", testSomeToolDigestLinuxLatest},
+			want: []string{
+				"some-tool  0.12.0  Some tool",
+				"├── darwin/arm64  " + testSomeToolDigestDarwinLatest,
+				"└── linux/amd64   " + testSomeToolDigestLinuxLatest,
+			},
 			notWant: []string{"0.11.0", testMyPluginDigest},
 		},
 		{


### PR DESCRIPTION

### Changes

+ Added `--digests` flag to `flux plugin search`

```
› ./bin/flux plugin search --digests      
operator  0.57.0  Flux Operator CLI
├── darwin/amd64   sha256:dea268f9ae341c81e77bd5dda25f0c94a543c6acf629cd79e2de30f9e999a94b
├── darwin/arm64   sha256:4dc9b3026f3b2d9fc7f13d9f6f5805036cff7d0af94d684abc928431c914138a
├── linux/amd64    sha256:abd705d2772912c482379103163df9537b4828326d29be114ec1da1cbf7a81b3
├── linux/arm64    sha256:ac2ac47b55dc42459ab8de71ddb1e8687597e80320dbba43ace5d9904f219d1d
├── windows/amd64  sha256:d0161b5aabc2016a12bbcd2763d8da0a59668e0e163df73ffafc57bfaa3010ff
└── windows/arm64  sha256:0b9fe5e1f600426f0f1896d7c8aeee4ca1ba47f87f3e2c1ea9800fd847f21b50
schema  0.11.0  Kubernetes schema extraction and manifests validation
├── darwin/amd64   sha256:0ec55397e49a2ac76a34ae04f99cdfd26ec814fd1475fa2d821611be16294548
├── darwin/arm64   sha256:7ef017fa6d123e7fa9805668fcea2d7baca2a61e1a6f08bb21a48ae57f055b96
├── linux/amd64    sha256:f208a99e829c5bb1df1ae290438161a7bc3ce1d2caad949a8a9c09bfb2a496ac
├── linux/arm64    sha256:602325d27b036abd74c166c857705a578338bf2d1eada81928ac3192e3a140ae
├── windows/amd64  sha256:9ae033656824163e82068393164a102b044d98a7567054cb448a6f05b56ce2ca
└── windows/arm64  sha256:87313c25de041f169f680cc9054f49f0a9209259ec8902446f3fcd622dc73dc8
mirror  0.8.0  Helm charts, OCI artifacts and container images mirroring
├── darwin/amd64   sha256:52f028aa0d60a335219fe9b06f18288d2a082163ce0661af4d66d7133c7edbf0
├── darwin/arm64   sha256:4e4a974f6acaa15e808381d7fa19ca03ce2b0556675da99b51f51599d3839836
├── linux/amd64    sha256:4862e9c4a2c9ac6bfe4976766ec425b015f2e6730adebcf95184d1d94beb5b35
├── linux/arm64    sha256:71222a7bcfe0715da9481845b34b60df68034c1be386d59c3c3cef8c76fca6f3
├── windows/amd64  sha256:cdd399ce097b4ae8f0a92f126d73672be7c9fb80c4728e960e966a26c981d2ff
└── windows/arm64  sha256:c0339e7c64f56c348117fdd0d04d0b6ce5f618dabff1c1d35cde16a3fc058d03
```

+ Added an optional `[@version]` field to `flux plugin search [query]`

```
› ./bin/flux plugin search operator@0.45.0
operator  0.45.0  Flux Operator CLI
├── darwin/amd64   sha256:8f8f6d04adb6a2451be1e5585753cf111536cf4a95b3f4716680d6b14f6bb667
├── darwin/arm64   sha256:cd85d5d84d2646a0bf991713fd2ee83e5c27a629094be447d4acd67fe5c54dea
├── linux/amd64    sha256:96198da9690965df56488a2a4a8b39cf56e2dc217a622446d5f00b1425f89fe8
├── linux/arm64    sha256:9c20eeca130f4a3374951dedfe12b89d7b093b521560f37f09bea39748a62142
├── windows/amd64  sha256:9712026094a5c99efbbd8feabbf7bc30b737e9f93e0f534f14129b4ac1ed796b
└── windows/arm64  sha256:9481a7a8d8111c8e9ff8de99bd10ef653aeeb7c2271e778b2c3e75c19b876f9a
```

Example output from https://github.com/fluxcd/flux2/pull/6016/commits/6b6f078614a6e89eeff376551c6708d88fbe25d6

### Implementation Decisions

I would like to call out these decisions and invite feedback on the direction here!

#### Tree View

`flux plugin search` uses the columns NAME, DESCRIPTION, and INSTALLED. To pin by hash, we need at least two (additional) pieces of information: OS/ARCH and DIGEST.

To efficiently display that information and prevent duplicate values, a tree-based view is used for digests.

#### Implied --digests

`flux plugin search operator` uses the standard output format.

`flux plugin search operator --digests` uses the "pinning relevant" output format. 

`flux plugin search name@1.2.3` implies `--digests` and therefore presents the "pinning relevant" information, since the user wants more information about a specific version. 

Are we okay with this, or should we require the explicit use of --digests?

#### Potentially Large Output

For each new plugin added to the catalogue, `flux plugin search --digests` will produce 6 rows of output, more if we decide to support more architectures or operating systems.

I think this is fine, since `--digests` has to be set explicitly, and filtering down using the plugin name is possible.

#### Sequential Fetching

To display the SHA values, the manifest for each plugin has to be fetched. To keep the implementation simple, I opted for a simple loop instead of parallel fetching.

I think this is reasonable right now, but it might be slow if the number of plugins grows substantially.


fixes #6008 