### PR TITLE
Fix envsubst dropping input on long lines

### DIFF
--- a/cmd/flux/envsubst.go
+++ b/cmd/flux/envsubst.go
@@ -47,6 +47,12 @@ type envsubstFlags struct {
 
 var envsubstArgs envsubstFlags
 
+// envsubstMaxLineSize is the maximum length of an input line. It exceeds the
+// maximum size of a Kubernetes object, so that manifests holding an embedded
+// document on a single line, such as a ConfigMap with a JSON payload, are read
+// in full.
+const envsubstMaxLineSize = 2 << 20
+
 func init() {
 	envsubstCmd.Flags().BoolVar(&envsubstArgs.strict, "strict", false,
 		"fail if a variable without a default value is declared in the input but is missing from the environment")
@@ -55,6 +61,7 @@ func init() {
 
 func runEnvsubstCmd(cmd *cobra.Command, args []string) error {
 	stdin := bufio.NewScanner(rootCmd.InOrStdin())
+	stdin.Buffer(nil, envsubstMaxLineSize)
 	stdout := bufio.NewWriter(rootCmd.OutOrStdout())
 	for stdin.Scan() {
 		line, err := envsubst.EvalEnv(stdin.Text(), envsubstArgs.strict)
@@ -70,5 +77,5 @@ func runEnvsubstCmd(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
-	return nil
+	return stdin.Err()
 }

--- a/cmd/flux/envsubst_test.go
+++ b/cmd/flux/envsubst_test.go
@@ -18,7 +18,9 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -47,4 +49,40 @@ func TestEnvsubst_Strinct(t *testing.T) {
 	_, err = executeCommandWithIn("envsubst --strict", bytes.NewReader(input))
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("variable not set (strict mode)"))
+}
+
+func TestEnvsubst_LongLines(t *testing.T) {
+	tests := []struct {
+		name    string
+		lineLen int
+		wantErr string
+	}{
+		{
+			name:    "line longer than the default scanner buffer",
+			lineLen: 100 * 1024,
+		},
+		{
+			name:    "line longer than the maximum",
+			lineLen: envsubstMaxLineSize + 1,
+			wantErr: "token too long",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			input := fmt.Sprintf("data:\n  payload: %s\n  trailer: end\n",
+				strings.Repeat("a", tt.lineLen))
+
+			output, err := executeCommandWithIn("envsubst", strings.NewReader(input))
+			if tt.wantErr != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.wantErr))
+				return
+			}
+
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(Equal(input))
+		})
+	}
 }


### PR DESCRIPTION
envsubst reads stdin with a bufio.Scanner left at its default 64KiB
token limit and never checks Err(), so a longer input line ends the
read loop silently: everything from that line on is dropped and the
command still exits 0. A ConfigMap with an embedded JSON document on
one line is enough to trigger it.

Raise the limit above the maximum size of a Kubernetes object and
return Err(), so oversized input fails instead of being truncated.

Fixes #6017