### PR TITLE
Add support for 2.9 in `migrate -f`

### DIFF
--- a/cmd/flux/migrate.go
+++ b/cmd/flux/migrate.go
@@ -65,6 +65,10 @@ type APIVersions struct {
 // https://fluxcd.io/flux/releases/#supported-releases
 var latestAPIVersions = []APIVersions{
 	{
+		FluxVersion:    "2.9",
+		LatestVersions: flux27LatestAPIVersions,
+	},
+	{
 		FluxVersion:    "2.8",
 		LatestVersions: flux27LatestAPIVersions,
 	},


### PR DESCRIPTION
Filing also a follow-up PR in the skill for minor releases.