### PR TITLE
fix: restrict `allow-webhooks` netpol to receiver port

### DIFF
--- a/manifests/policies/allow-webhooks.yaml
+++ b/manifests/policies/allow-webhooks.yaml
@@ -8,6 +8,9 @@ spec:
   ingress:
     - from:
         - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 9292
   podSelector:
     matchLabels:
       app: notification-controller


### PR DESCRIPTION
Update the `allow-webhooks` network policy to allow only the webhook receiver endpoint which notification-controller exposes on port 9292.