### PR TITLE
Fix proxy bypass in bootstrap --ca-file

### DIFF
--- a/pkg/bootstrap/provider/factory.go
+++ b/pkg/bootstrap/provider/factory.go
@@ -41,7 +41,7 @@ func BuildGitProvider(config Config) (gitprovider.Client, error) {
 			opts = append(opts, gitprovider.WithDomain(config.Hostname))
 		}
 		if config.CaBundle != nil {
-			opts = append(opts, gitprovider.WithCustomCAPostChainTransportHook(config.CaBundle))
+			opts = append(opts, withCustomCATransportHook(config.CaBundle))
 		}
 		if client, err = github.NewClient(opts...); err != nil {
 			return nil, err
@@ -52,7 +52,7 @@ func BuildGitProvider(config Config) (gitprovider.Client, error) {
 			opts = append(opts, gitprovider.WithDomain(config.Hostname))
 		}
 		if config.CaBundle != nil {
-			opts = append(opts, gitprovider.WithCustomCAPostChainTransportHook(config.CaBundle))
+			opts = append(opts, withCustomCATransportHook(config.CaBundle))
 		}
 		if client, err = gitea.NewClient(config.Token, opts...); err != nil {
 			return nil, err
@@ -65,7 +65,7 @@ func BuildGitProvider(config Config) (gitprovider.Client, error) {
 			opts = append(opts, gitprovider.WithDomain(config.Hostname))
 		}
 		if config.CaBundle != nil {
-			opts = append(opts, gitprovider.WithCustomCAPostChainTransportHook(config.CaBundle))
+			opts = append(opts, withCustomCATransportHook(config.CaBundle))
 		}
 		if client, err = gitlab.NewClient(config.Token, "", opts...); err != nil {
 			return nil, err
@@ -76,7 +76,7 @@ func BuildGitProvider(config Config) (gitprovider.Client, error) {
 			opts = append(opts, gitprovider.WithDomain(config.Hostname))
 		}
 		if config.CaBundle != nil {
-			opts = append(opts, gitprovider.WithCustomCAPostChainTransportHook(config.CaBundle))
+			opts = append(opts, withCustomCATransportHook(config.CaBundle))
 		}
 		if client, err = stash.NewStashClient(config.Username, config.Token, opts...); err != nil {
 			return nil, err

--- a/pkg/bootstrap/provider/transport.go
+++ b/pkg/bootstrap/provider/transport.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2026 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net/http"
+
+	"github.com/fluxcd/go-git-providers/gitprovider"
+)
+
+func withCustomCATransportHook(caBundle []byte) gitprovider.ClientOption {
+	return gitprovider.WithPostChainTransportHook(func(_ http.RoundTripper) http.RoundTripper {
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+
+		rootCAs, _ := x509.SystemCertPool()
+		if rootCAs == nil {
+			rootCAs = x509.NewCertPool()
+		}
+		rootCAs.AppendCertsFromPEM(caBundle)
+
+		if transport.TLSClientConfig == nil {
+			transport.TLSClientConfig = &tls.Config{}
+		}
+		transport.TLSClientConfig.RootCAs = rootCAs
+
+		return transport
+	})
+}

--- a/pkg/bootstrap/provider/transport_test.go
+++ b/pkg/bootstrap/provider/transport_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2026 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/fluxcd/go-git-providers/gitprovider"
+)
+
+func TestWithCustomCATransportHookPreservesProxy(t *testing.T) {
+	opts, err := gitprovider.MakeClientOptions(withCustomCATransportHook(testCAPEM))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client, err := gitprovider.BuildClientFromTransportChain(opts.GetTransportChain())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("got transport type %T, want *http.Transport", client.Transport)
+	}
+	if transport.Proxy == nil {
+		t.Fatal("expected proxy configuration to be preserved")
+	}
+	if transport.TLSClientConfig == nil || transport.TLSClientConfig.RootCAs == nil {
+		t.Fatal("expected custom CA bundle to be configured")
+	}
+}
+
+var testCAPEM = []byte(`-----BEGIN CERTIFICATE-----
+MIIBkTCB+wIJALRiMLAh4HMHMA0GCSqGSIb3DQEBCwUAMBExDzANBgNVBAMMBnRl
+c3RjYTAeFw0yNDA0MDQwMDAwMDBaFw0zNDA0MDIwMDAwMDBaMBExDzANBgNVBAMM
+BnRlc3RjYTBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQC7o96+IG5sKBe0QKbsBigc
+GsR8cKQuDfhCFqzWn7zr4aqHsLQiKEJsClMDGnNHEFGDFpXuIFxnGOTPYFOYIuDH
+AgMBAAGjUzBRMB0GA1UdDgQWBBQgTxe0MCRKYB0ILQM0L7V/lMjxNjAfBgNVHSME
+GDAWgBQgTxe0MCRKYB0ILQM0L7V/lMjxNjAPBgNVHRMBAf8EBTADAQH/MA0GCSqG
+SIb3DQEBCwUAA0EAh/8fnFa6VW1cB8QJWIM4KpCmpY9R1YMaqGCbDjM0FZmE+dqA
+NsaKMCSE1YOIMBN6mBUX3iTmy/sCTIYMBbFPgQ==
+-----END CERTIFICATE-----
+`)


### PR DESCRIPTION
Fixes #3405

## Problem
When bootstrapping with --ca-file against a Git provider reachable only through an HTTP(S) proxy (e.g. flux bootstrap gitlab --token-auth --ca-file=/etc/...), the CLI fails with a DNS/connect timeout instead of routing through the configured proxy, even though HTTP_PROXY/HTTPS_PROXY are exported and bootstrapping works fine without --ca-file.

## Root cause
The Git provider API client (GitHub/GitLab/Gitea/Stash) was built via gitprovider.WithCustomCAPostChainTransportHook from github.com/fluxcd/go-git-providers. That hook constructs a bare &http.Transport{} with only TLSClientConfig set, and never copies Proxy: http.ProxyFromEnvironment from http.DefaultTransport. As soon as --ca-file is passed, the resulting HTTP client silently stops honoring proxy environment variables and attempts a direct connection, which fails in networks that require a proxy to reach the Internet. This only affects the provider API client (repository existence check/creation); the actual git clone/push path already clones http.DefaultTransport correctly and is unaffected.

## Fix
Added provider.withCustomCATransportHook in pkg/bootstrap/provider/transport.go, which clones http.DefaultTransport (preserving its Proxy func and other defaults) before layering in the custom CA bundle, and used it in place of gitprovider.WithCustomCAPostChainTransportHook for all four supported Git providers in pkg/bootstrap/provider/factory.go.

## Testing
- Added pkg/bootstrap/provider/transport_test.go, asserting the built transport preserves a proxy function and has the custom CA bundle configured.
- go build, go vet, and go test pass for pkg/bootstrap/....