### PR TITLE
fix(flux2): show cascade deletions on parent KS removal

### DIFF
--- a/internal/build/diff.go
+++ b/internal/build/diff.go
@@ -34,6 +34,7 @@ import (
 	"github.com/lucasb-eyer/go-colorful"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/errors"
 	"sigs.k8s.io/yaml"
 
@@ -219,6 +220,54 @@ func (b *Builder) diff() (string, bool, error) {
 			}
 			for _, object := range staleObjects {
 				output.WriteString(writeString(fmt.Sprintf("► %s deleted\n", ssautil.FmtUnstructured(object)), bunt.OrangeRed))
+			}
+			if b.recursive {
+				seen := make(map[string]bool)
+				for _, o := range staleObjects {
+					seen[ssautil.FmtUnstructured(o)] = true
+				}
+				queue := append([]*unstructured.Unstructured(nil), staleObjects...)
+				for len(queue) > 0 {
+					obj := queue[0]
+					queue = queue[1:]
+					if !isKustomization(obj) {
+						continue
+					}
+					if b.client == nil {
+						continue
+					}
+					liveK := &kustomizev1.Kustomization{}
+					ctx2, cancel2 := context.WithTimeout(context.Background(), b.timeout)
+					err := b.client.Get(ctx2, types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}, liveK)
+					cancel2()
+					if err != nil || liveK.Status.Inventory == nil {
+						continue
+					}
+					for _, entry := range liveK.Status.Inventory.Entries {
+						meta, err := object.ParseObjMetadata(entry.ID)
+						if err != nil {
+							continue
+						}
+						u := &unstructured.Unstructured{}
+						u.SetGroupVersionKind(schema.GroupVersionKind{
+							Group:   meta.GroupKind.Group,
+							Kind:    meta.GroupKind.Kind,
+							Version: entry.Version,
+						})
+						u.SetName(meta.Name)
+						u.SetNamespace(meta.Namespace)
+						key := ssautil.FmtUnstructured(u)
+						if seen[key] {
+							continue
+						}
+						seen[key] = true
+						output.WriteString(writeString(fmt.Sprintf("► %s deleted\n", key), bunt.OrangeRed))
+						createdOrDrifted = true
+						if isKustomization(u) {
+							queue = append(queue, u)
+						}
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Bug: `flux diff --recursive` hides cascade deletions when a parent Kustomization is removed. Only the parent Kustomization is reported as deleted. The child objects that Kustomization managed are silent.

Fix: after stale objects are computed from the inventory diff, when recursive is enabled expand any deleted Kustomization by reading its live `status.inventory` and emitting each entry as deleted. A BFS walks nested Kustomization chains and skips objects already reported.

Verification: rebased onto main at b51b7ce. `go test ./internal/build/... --tags=unit` passes, matching the baseline on main. `go vet` on the changed package is clean and `gofmt -l` reports nothing. The new code path needs a live client, and `internal/build` has no client test harness today, so it is not covered by a unit test. I can pull the expansion out into a helper and add a fake-client test in this PR if you want that before review.

Written in conjunction with my pair programmer Claude.
