### PR TITLE
Fix typos in user-facing CLI messages and comments

### DIFF
--- a/cmd/flux/bootstrap_git.go
+++ b/cmd/flux/bootstrap_git.go
@@ -372,7 +372,7 @@ func bootstrapGitCmdRun(cmd *cobra.Command, args []string) error {
 	return bootstrap.Run(ctx, b, manifestsBase, installOptions, secretOpts, syncOpts, rootArgs.pollInterval, rootArgs.timeout)
 }
 
-// getAuthOpts retruns a AuthOptions based on the scheme
+// getAuthOpts returns an AuthOptions based on the scheme
 // of the given URL and the configured flags. If the protocol equals
 // "ssh" but no private key is configured, authentication using the local
 // SSH-agent is attempted.

--- a/cmd/flux/build_kustomization.go
+++ b/cmd/flux/build_kustomization.go
@@ -51,7 +51,7 @@ flux build kustomization my-app --path ./path/to/local/manifests \
 	--kustomization-file ./path/to/local/my-app.yaml \
 	--dry-run
 
-# Exclude files by providing a comma separated list of entries that follow the .gitignore pattern fromat.
+# Exclude files by providing a comma separated list of entries that follow the .gitignore pattern format.
 flux build kustomization my-app --path ./path/to/local/manifests \
 	--kustomization-file ./path/to/local/my-app.yaml \
 	--ignore-paths "/to_ignore/**/*.yaml,ignore.yaml"

--- a/cmd/flux/create_receiver.go
+++ b/cmd/flux/create_receiver.go
@@ -93,7 +93,7 @@ func createReceiverCmdRun(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(resources) == 0 {
-		return fmt.Errorf("atleast one resource is required")
+		return fmt.Errorf("at least one resource is required")
 	}
 
 	sourceLabels, err := parseLabels()

--- a/cmd/flux/diff_kustomization.go
+++ b/cmd/flux/diff_kustomization.go
@@ -41,7 +41,7 @@ flux diff kustomization my-app --path ./path/to/local/manifests
 flux diff kustomization my-app --path ./path/to/local/manifests \
 	--kustomization-file ./path/to/local/my-app.yaml
 
-# Exclude files by providing a comma separated list of entries that follow the .gitignore pattern fromat.
+# Exclude files by providing a comma separated list of entries that follow the .gitignore pattern format.
 flux diff kustomization my-app --path ./path/to/local/manifests \
 	--kustomization-file ./path/to/local/my-app.yaml \
 	--ignore-paths "/to_ignore/**/*.yaml,ignore.yaml"

--- a/cmd/flux/readiness.go
+++ b/cmd/flux/readiness.go
@@ -44,7 +44,7 @@ const (
 )
 
 // isObjectReady determines if an object is ready using the kstatus.Compute()
-// result. statusType helps differenciate between static and dynamic objects to
+// result. statusType helps differentiate between static and dynamic objects to
 // accurately check the object's readiness. A dynamic object may have some extra
 // considerations depending on the object.
 func isObjectReady(obj client.Object, statusType objectStatusType) (bool, error) {

--- a/cmd/flux/trace.go
+++ b/cmd/flux/trace.go
@@ -156,7 +156,7 @@ func getObjectStatic(ctx context.Context, kubeClient client.Client, args []strin
 
 	gv, err := schema.ParseGroupVersion(traceArgs.apiVersion)
 	if err != nil {
-		return nil, fmt.Errorf("invaild apiVersion: %w", err)
+		return nil, fmt.Errorf("invalid apiVersion: %w", err)
 	}
 
 	obj := &unstructured.Unstructured{}

--- a/install/flux.sh
+++ b/install/flux.sh
@@ -69,7 +69,7 @@ verify_downloader() {
     return 0
 }
 
-# Create tempory directory and cleanup when done
+# Create temporary directory and cleanup when done
 setup_tmp() {
     TMP_DIR=$(mktemp -d -t flux-install.XXXXXXXXXX)
     TMP_METADATA="${TMP_DIR}/flux.json"


### PR DESCRIPTION
Corrects a handful of spelling mistakes, four of which are visible to users:

- `flux create receiver` error: "atleast one resource is required" -> "at least one resource is required"
- `flux trace` error: "invaild apiVersion" -> "invalid apiVersion"
- `flux build kustomization` / `flux diff kustomization` help text: ".gitignore pattern fromat" -> "format"

Plus three non-user-facing ones: "retruns a AuthOptions" -> "returns an AuthOptions" in `bootstrap_git.go`, "differenciate" -> "differentiate" in `readiness.go`, and "tempory" -> "temporary" in `install/flux.sh`.

No behaviour changes. I checked that nothing else in the tree matches the old strings, so no tests assert on them. `go build ./cmd/...` passes and `gofmt` is clean.

Per CONTRIBUTING.md, this was AI-assisted and the commit carries the `Assisted-by: claude-code/claude-opus-5` trailer.