### PR TITLE
Show recursive cascade deletions

### DIFF
--- a/cmd/flux/diff_kustomization_cascade_test.go
+++ b/cmd/flux/diff_kustomization_cascade_test.go
@@ -1,0 +1,43 @@
+//go:build unit
+// +build unit
+
+/*
+Copyright 2026 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+func TestDiffKustomizationRecursiveCascadeDelete(t *testing.T) {
+	fluxNS := allocateNamespace("flux-system")
+	setupTestNamespace(fluxNS, t)
+
+	tmpl := map[string]string{
+		"fluxns": fluxNS,
+	}
+	testEnv.CreateObjectFile("./testdata/diff-kustomization/cascade-delete.yaml", tmpl, t)
+
+	cmd := cmdTestCase{
+		args: "diff kustomization cascade-root " +
+			"--path ./testdata/build-kustomization/cascade-empty " +
+			"--recursive --progress-bar=false -n " + fluxNS,
+		assert: assertGoldenTemplateFile(
+			"./testdata/diff-kustomization/diff-with-recursive-cascade-delete.golden",
+			tmpl,
+		),
+	}
+	cmd.runTestCmd(t)
+}

--- a/cmd/flux/testdata/build-kustomization/cascade-empty/kustomization.yaml
+++ b/cmd/flux/testdata/build-kustomization/cascade-empty/kustomization.yaml
@@ -1,0 +1,3 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/cmd/flux/testdata/diff-kustomization/cascade-delete.yaml
+++ b/cmd/flux/testdata/diff-kustomization/cascade-delete.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cascade-root
+  namespace: {{ .fluxns }}
+spec:
+  interval: 5m
+  prune: true
+  path: ./
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+status:
+  inventory:
+    entries:
+      - id: {{ .fluxns }}_cascade-child_kustomize.toolkit.fluxcd.io_Kustomization
+        v: v1
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cascade-child
+  namespace: {{ .fluxns }}
+spec:
+  interval: 5m
+  prune: true
+  path: ./child
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+status:
+  inventory:
+    entries:
+      - id: default_cascade-config_v1_ConfigMap
+        v: v1
+      - id: {{ .fluxns }}_cascade-grandchild_kustomize.toolkit.fluxcd.io_Kustomization
+        v: v1
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cascade-grandchild
+  namespace: {{ .fluxns }}
+spec:
+  interval: 5m
+  prune: true
+  path: ./grandchild
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+status:
+  inventory:
+    entries:
+      - id: default_cascade-secret_v1_Secret
+        v: v1

--- a/cmd/flux/testdata/diff-kustomization/diff-with-recursive-cascade-delete.golden
+++ b/cmd/flux/testdata/diff-kustomization/diff-with-recursive-cascade-delete.golden
@@ -1,0 +1,6 @@
+► Kustomization/{{ .fluxns }}/cascade-child deleted
+📁 Kustomization/{{ .fluxns }}/cascade-child deleted resources
+► ConfigMap/default/cascade-config deleted
+► Kustomization/{{ .fluxns }}/cascade-grandchild deleted
+📁 Kustomization/{{ .fluxns }}/cascade-grandchild deleted resources
+► Secret/default/cascade-secret deleted

--- a/internal/build/diff.go
+++ b/internal/build/diff.go
@@ -32,8 +32,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/homeport/dyff/pkg/dyff"
 	"github.com/lucasb-eyer/go-colorful"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/errors"
 	"sigs.k8s.io/yaml"
 
@@ -217,8 +219,17 @@ func (b *Builder) diff() (string, bool, error) {
 			if len(staleObjects) > 0 {
 				createdOrDrifted = true
 			}
+			visited := make(map[types.NamespacedName]struct{})
 			for _, object := range staleObjects {
 				output.WriteString(writeString(fmt.Sprintf("► %s deleted\n", ssautil.FmtUnstructured(object)), bunt.OrangeRed))
+				if b.recursive && isKustomization(object) {
+					cascadeOutput, err := b.deletedKustomizationDiff(ctx, object, visited)
+					if err != nil {
+						diffErrs = append(diffErrs, err)
+						continue
+					}
+					output.WriteString(cascadeOutput)
+				}
 			}
 		}
 	}
@@ -261,6 +272,56 @@ func (b *Builder) kustomizationDiff(kustomization *kustomizev1.Kustomization) (s
 	}
 
 	return subBuilder.diff()
+}
+
+// deletedKustomizationDiff reports resources that would be pruned when a stale
+// Kustomization is removed during a recursive diff.
+func (b *Builder) deletedKustomizationDiff(ctx context.Context, object *unstructured.Unstructured, visited map[types.NamespacedName]struct{}) (string, error) {
+	key := types.NamespacedName{
+		Namespace: object.GetNamespace(),
+		Name:      object.GetName(),
+	}
+	if _, ok := visited[key]; ok {
+		return "", nil
+	}
+	visited[key] = struct{}{}
+
+	kustomization := &kustomizev1.Kustomization{}
+	if err := b.client.Get(ctx, key, kustomization); err != nil {
+		if apierrors.IsNotFound(err) {
+			return writeString(fmt.Sprintf("⚠️ %s cascade inventory unavailable: object not found\n", ssautil.FmtUnstructured(object)), bunt.Orange), nil
+		}
+		return "", fmt.Errorf("failed to get %s for cascade diff: %w", ssautil.FmtUnstructured(object), err)
+	}
+	if kustomization.Status.Inventory == nil {
+		return "", nil
+	}
+
+	deletedObjects, err := diffInventory(kustomization.Status.Inventory, newInventory())
+	if err != nil {
+		return "", fmt.Errorf("failed to inspect inventory of %s: %w", ssautil.FmtUnstructured(object), err)
+	}
+	if len(deletedObjects) == 0 {
+		return "", nil
+	}
+
+	output := strings.Builder{}
+	output.WriteString(bunt.Sprint(fmt.Sprintf("📁 %s deleted resources\n", ssautil.FmtUnstructured(object))))
+	for _, deletedObject := range deletedObjects {
+		output.WriteString(writeString(fmt.Sprintf("► %s deleted\n", ssautil.FmtUnstructured(deletedObject)), bunt.OrangeRed))
+
+		// A Kustomization targeting another cluster can expose its direct
+		// inventory, but nested Kustomizations cannot be fetched with this client.
+		if kustomization.Spec.KubeConfig == nil && isKustomization(deletedObject) {
+			nestedOutput, err := b.deletedKustomizationDiff(ctx, deletedObject, visited)
+			if err != nil {
+				return "", err
+			}
+			output.WriteString(nestedOutput)
+		}
+	}
+
+	return output.String(), nil
 }
 
 func writeYamls(liveObject, mergedObject *unstructured.Unstructured) (string, string, string, error) {


### PR DESCRIPTION
Fixes #6042.

When `flux diff kustomization --recursive` finds a stale Kustomization, inspect its live `status.inventory` and report the resources that would be pruned with it.

Nested Kustomizations are traversed recursively with cycle protection. Non-recursive diff behavior is unchanged.

Previously, recursive diff only descended into Kustomizations present in the new build. When a parent Kustomization was removed from source, the inventory diff reported only the parent as deleted, hiding the resources that would be pruned with it.

This makes the effective deletion scope visible before reconciliation, which is particularly useful when `flux diff --recursive` is used as a pre-merge GitOps safety check.

A unit regression test covers a two-level hierarchy where removing a child Kustomization also removes:

* a ConfigMap;
* a nested Kustomization;
* a Secret owned by the nested Kustomization.

For Kustomizations targeting a remote cluster, the directly available inventory is reported, but nested Kustomizations are not fetched through the local cluster client.

AI assistance was used while preparing this change.

Assisted-by: ChatGPT/GPT-5.6 Sol
