### PR TITLE
Fix stale version comment on pinned Azure/login

### DIFF
--- a/.github/workflows/e2e-azure.yaml
+++ b/.github/workflows/e2e-azure.yaml
@@ -50,7 +50,7 @@ jobs:
           SOPS_VER: 3.7.1
           SOPS_CHECKSUM: "185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74"
       - name: Authenticate to Azure
-        uses: Azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v1.4.6
+        uses: Azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
         with:
           creds: '{"clientId":"${{ secrets.ARM_CLIENT_ID }}","clientSecret":"${{ secrets.ARM_CLIENT_SECRET }}","subscriptionId":"${{ secrets.ARM_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.ARM_TENANT_ID }}"}'
       - name: Set dynamic variables in .env


### PR DESCRIPTION
### Summary

`.github/workflows/e2e-azure.yaml` pins `Azure/login` to `7ddb5af1ef8758cf1353cf3b42f940aee27ba21c` with the comment `# v1.4.6`. That commit is **v3.0.2**. Only the comment changes here; the SHA is untouched, so there is no behavioural difference.

### Why it is worth fixing

Nothing validates the version comment on a SHA pin, so it silently drifts when the SHA is bumped and the comment is not. This one is two majors behind the commit it labels, which matters more than usual for `Azure/login`: v1 and v2 are Node 16/20-era and v3 changed the auth surface, so the comment implies a very different action from the one actually running.

### Verification

```bash
# what tags does the pinned commit carry?
gh api repos/Azure/login/tags --paginate \
  --jq '.[] | select(.commit.sha=="7ddb5af1ef8758cf1353cf3b42f940aee27ba21c") | .name'
# -> v3.0.2, v3

# where does the claimed tag actually point?
gh api repos/Azure/login/git/ref/tags/v1.4.6 --jq '.object.sha'
# -> 92a5484dfaf04ca78a94597f4f19fea633851fa2   (a different commit)
```

The pinned commit is dated 2026-08-26, so the pin itself is current — it is only the label that is stale.

Every pinned action across `.github/workflows/` was checked (53 pins). This was the only mismatch.
