### PR TITLE
Remove unused fields from installFlags

### DIFF
--- a/cmd/flux/install.go
+++ b/cmd/flux/install.go
@@ -75,12 +75,10 @@ type installFlags struct {
 	registry           string
 	registryCredential string
 	imagePullSecret    string
-	branch             string
 	watchAllNamespaces bool
 	networkPolicy      bool
 	manifestsPath      string
 	logLevel           flags.LogLevel
-	tokenAuth          bool
 	clusterDomain      string
 	tolerationKeys     []string
 	force              bool


### PR DESCRIPTION
`installFlags.branch` and `installFlags.tokenAuth` are never registered as flags and never read. staticcheck reports both as unused (U1000).

No flag is exposed for either, and neither appears in the docs, so removing them does not change the CLI surface.

Verified: `go build`, `go vet` and `gofmt` clean; staticcheck no longer reports U1000 for `install.go`. `go test ./cmd/flux/... --tags=unit` produces an identical set of failures before and after the change (`TestDiffArtifact`, which fails the same way on unmodified `main` in this environment), and `./internal/...` passes.

Assisted by claude-code/claude-opus-5; disclosed in the commit trailer per CONTRIBUTING.md.
